### PR TITLE
Graceful shutdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "rust-analyzer.checkOnSave.allTargets": false,
-  "rust-analyzer.cargo.buildScripts.enable": true,
-  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.check.allTargets": true,
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": "file:///home/dave/dev/bpfd/.github/workflows/build.yml"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,6 @@ dependencies = [
  "clap",
  "env_logger",
  "flate2",
- "futures",
  "log",
  "nix",
  "oci-distribution",

--- a/bpfd-api/src/config.rs
+++ b/bpfd-api/src/config.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::util::directories::*;
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Config {
     #[serde(default)]
     pub tls: TlsConfig,
@@ -32,7 +32,7 @@ impl FromStr for Config {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct TlsConfig {
     #[serde(default = "default_ca_cert")]
     pub ca_cert: String,
@@ -78,7 +78,7 @@ fn default_client_key() -> String {
     CFGPATH_BPFD_CLIENT_CERTS_KEY.to_string()
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Copy, Clone)]
 pub struct InterfaceConfig {
     pub xdp_mode: XdpMode,
 }
@@ -111,13 +111,13 @@ impl ToString for XdpMode {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Grpc {
     #[serde(default)]
     pub endpoint: Endpoint,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Endpoint {
     #[serde(default = "default_address")]
     pub address: String,

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -39,4 +39,3 @@ tokio-stream = { version = "0.1.12", features = ["net"] }
 sha2 = "0.10.6"
 base16ct = { version = "0.2.0", features = ["alloc"] }
 tempfile = "3.4.0"
-futures = "0.3.27"

--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -27,48 +27,60 @@ type Responder<T> = oneshot::Sender<T>;
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Command {
     /// Load an XDP program
-    LoadXDP {
-        location: Location,
-        section_name: String,
-        id: Option<Uuid>,
-        global_data: HashMap<String, Vec<u8>>,
-        iface: String,
-        priority: i32,
-        proceed_on: XdpProceedOn,
-        username: String,
-        responder: Responder<Result<Uuid, BpfdError>>,
-    },
+    LoadXDP(LoadXDPArgs),
     /// Load a TC Program
-    LoadTC {
-        location: Location,
-        section_name: String,
-        id: Option<Uuid>,
-        global_data: HashMap<String, Vec<u8>>,
-        iface: String,
-        priority: i32,
-        direction: Direction,
-        proceed_on: TcProceedOn,
-        username: String,
-        responder: Responder<Result<Uuid, BpfdError>>,
-    },
+    LoadTC(LoadTCArgs),
     // Load a Tracepoint Program
-    LoadTracepoint {
-        location: Location,
-        id: Option<Uuid>,
-        section_name: String,
-        global_data: HashMap<String, Vec<u8>>,
-        tracepoint: String,
-        username: String,
-        responder: Responder<Result<Uuid, BpfdError>>,
-    },
-    Unload {
-        id: Uuid,
-        username: String,
-        responder: Responder<Result<(), BpfdError>>,
-    },
+    LoadTracepoint(LoadTracepointArgs),
+    Unload(UnloadArgs),
     List {
         responder: Responder<Result<Vec<ProgramInfo>, BpfdError>>,
     },
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadXDPArgs {
+    pub(crate) location: Location,
+    pub(crate) section_name: String,
+    pub(crate) id: Option<Uuid>,
+    pub(crate) global_data: HashMap<String, Vec<u8>>,
+    pub(crate) iface: String,
+    pub(crate) priority: i32,
+    pub(crate) proceed_on: XdpProceedOn,
+    pub(crate) username: String,
+    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadTCArgs {
+    pub(crate) location: Location,
+    pub(crate) section_name: String,
+    pub(crate) id: Option<Uuid>,
+    pub(crate) global_data: HashMap<String, Vec<u8>>,
+    pub(crate) iface: String,
+    pub(crate) priority: i32,
+    pub(crate) direction: Direction,
+    pub(crate) proceed_on: TcProceedOn,
+    pub(crate) username: String,
+    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadTracepointArgs {
+    pub(crate) location: Location,
+    pub(crate) id: Option<Uuid>,
+    pub(crate) section_name: String,
+    pub(crate) global_data: HashMap<String, Vec<u8>>,
+    pub(crate) tracepoint: String,
+    pub(crate) username: String,
+    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct UnloadArgs {
+    pub(crate) id: Uuid,
+    pub(crate) username: String,
+    pub(crate) responder: Responder<Result<(), BpfdError>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/bpfd/src/serve.rs
+++ b/bpfd/src/serve.rs
@@ -4,10 +4,10 @@
 use std::{fs::remove_file, net::SocketAddr, path::Path};
 
 use anyhow::Context;
-use bpfd_api::{config::Config, util::directories::RTDIR_FS_MAPS, v1::loader_server::LoaderServer};
-use futures::{channel::oneshot, FutureExt};
-use log::{debug, info};
+use bpfd_api::{config::Config, v1::loader_server::LoaderServer};
+use log::{debug, error, info};
 use tokio::{
+    join,
     net::UnixListener,
     select,
     signal::unix::{signal, SignalKind},
@@ -18,27 +18,19 @@ use tonic::transport::{Server, ServerTlsConfig};
 
 pub use crate::certs::get_tls_config;
 use crate::{
-    bpf::BpfManager,
-    command::{
-        Command, Metadata, Program, ProgramData, TcProgram, TcProgramInfo, TracepointProgram,
-        TracepointProgramInfo, XdpProgram, XdpProgramInfo,
-    },
-    errors::BpfdError,
-    rpc::{intercept, BpfdLoader},
-    static_program::get_static_programs,
-    utils::{get_ifindex, set_dir_permissions, set_file_permissions},
+    bpf::BpfManager, errors::BpfdError, rpc::BpfdLoader, static_program::get_static_programs,
+    utils::set_file_permissions,
 };
 
-const MAPS_MODE: u32 = 0o0660;
 const SOCK_MODE: u32 = 0o0770;
 
 pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<()> {
-    let (tx, mut rx) = mpsc::channel(32);
-    let mut shutdown_senders = Vec::new();
-    let mut task_handles = Vec::new();
+    let (tx, rx) = mpsc::channel(32);
     let endpoint = &config.grpc.endpoint;
 
-    // Listen on Unix socket
+    let loader = BpfdLoader::new(tx.clone());
+    let service = LoaderServer::new(loader);
+
     let unix = endpoint.unix.clone();
     if Path::new(&unix).exists() {
         // Attempt to remove the socket, since bind fails if it exists
@@ -49,33 +41,26 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
     let uds_stream = UnixListenerStream::new(uds);
     set_file_permissions(&unix, SOCK_MODE).await;
 
-    let loader = BpfdLoader::new(tx.clone());
-
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    shutdown_senders.push(shutdown_tx);
-
     let serve = Server::builder()
-        .add_service(LoaderServer::new(loader))
-        .serve_with_incoming_shutdown(uds_stream, shutdown_rx.map(drop));
+        .add_service(service.clone())
+        .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
 
-    task_handles.push(tokio::spawn(async move {
+    let unix_listener = async move {
         info!("Listening on {}", unix);
         if let Err(e) = serve.await {
-            panic!("Error = {e:?}");
+            error!("unix socket error: {e:?}");
         }
-    }));
+        info!("Shutdown Unix Handler {}", unix);
+    };
 
-    // Listen on TCP socket
-    let addr = SocketAddr::new(
-        endpoint
-            .address
-            .parse()
-            .unwrap_or_else(|_| panic!("failed to parse listening address '{}'", endpoint.address)),
-        endpoint.port,
-    );
-
-    let loader = BpfdLoader::new(tx);
-
+    let ip = endpoint.address.parse().map_err(|_| {
+        BpfdError::Error(format!(
+            "failed to parse listening address '{}'",
+            endpoint.address
+        ))
+    })?;
+    let port = endpoint.port;
+    let addr = SocketAddr::new(ip, port);
     let (ca_cert, identity) = get_tls_config(&config.tls)
         .await
         .context("CA Cert File does not exist")?;
@@ -84,35 +69,20 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
         .identity(identity)
         .client_ca_root(ca_cert);
 
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    shutdown_senders.push(shutdown_tx);
-
     let serve = Server::builder()
         .tls_config(tls_config)?
-        .add_service(LoaderServer::with_interceptor(loader, intercept))
-        .serve_with_shutdown(addr, shutdown_rx.map(drop));
+        .add_service(service.clone())
+        .serve_with_shutdown(addr, shutdown_handler());
 
-    task_handles.push(tokio::spawn(async move {
+    let tcp_listener = async move {
         info!("Listening on {addr}");
         if let Err(e) = serve.await {
-            panic!("Error = {e:?}");
+            error!("tcp error: {e:?}");
         }
-    }));
+        info!("Shutdown TCP Handler {}", addr);
+    };
 
-    task_handles.push(tokio::spawn(async move {
-        let mut sigint = signal(SignalKind::interrupt()).unwrap();
-        let mut sigterm = signal(SignalKind::terminate()).unwrap();
-        select! {
-            _ = sigint.recv() => {debug!("Received SIGINT")},
-            _ = sigterm.recv() => {debug!("Received SIGTERM")},
-        }
-
-        for handle in shutdown_senders {
-            handle.send(()).unwrap_or_default();
-        }
-    }));
-
-    let mut bpf_manager = BpfManager::new(&config);
+    let mut bpf_manager = BpfManager::new(config, rx);
     bpf_manager.rebuild_state().await?;
 
     let static_programs = get_static_programs(static_program_path).await?;
@@ -124,162 +94,15 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
             info!("Loaded static program with UUID {}", uuid)
         }
     };
-
-    // Start receiving messages
-    while let Some(cmd) = rx.recv().await {
-        match cmd {
-            Command::LoadXDP {
-                location,
-                section_name,
-                id,
-                global_data,
-                iface,
-                priority,
-                proceed_on,
-                username,
-                responder,
-            } => {
-                let res = if let Ok(if_index) = get_ifindex(&iface) {
-                    let prog_data =
-                        ProgramData::new(location, section_name.clone(), global_data, username)
-                            .await?;
-
-                    let prog_result = Ok(Program::Xdp(XdpProgram {
-                        data: prog_data.clone(),
-                        info: XdpProgramInfo {
-                            if_index,
-                            current_position: None,
-                            metadata: Metadata {
-                                priority,
-                                // This could have been overridden by image tags
-                                name: prog_data.section_name,
-                                attached: false,
-                            },
-                            proceed_on,
-                            if_name: iface,
-                        },
-                    }));
-
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    Err(BpfdError::InvalidInterface)
-                };
-
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
-                }
-
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::LoadTC {
-                location,
-                section_name,
-                id,
-                global_data,
-                iface,
-                priority,
-                direction,
-                proceed_on,
-                username,
-                responder,
-            } => {
-                let res = if let Ok(if_index) = get_ifindex(&iface) {
-                    let prog_data =
-                        ProgramData::new(location, section_name, global_data, username).await?;
-
-                    let prog_result = Ok(Program::Tc(TcProgram {
-                        data: prog_data.clone(),
-                        direction,
-                        info: TcProgramInfo {
-                            if_index,
-                            current_position: None,
-                            metadata: Metadata {
-                                priority,
-                                // This could have been overridden by image tags
-                                name: prog_data.section_name,
-                                attached: false,
-                            },
-                            proceed_on,
-                            if_name: iface,
-                        },
-                    }));
-
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    Err(BpfdError::InvalidInterface)
-                };
-
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{}", uuid.clone());
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
-                }
-
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::LoadTracepoint {
-                location,
-                section_name,
-                id,
-                global_data,
-                tracepoint,
-                username,
-                responder,
-            } => {
-                let res = {
-                    let prog_data =
-                        ProgramData::new(location, section_name, global_data, username).await?;
-
-                    let prog_result = Ok(Program::Tracepoint(TracepointProgram {
-                        data: prog_data,
-                        info: TracepointProgramInfo { tracepoint },
-                    }));
-
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
-                    }
-                };
-
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
-                }
-
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::Unload {
-                id,
-                username,
-                responder,
-            } => {
-                let res = bpf_manager.remove_program(id, username).await;
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::List { responder } => {
-                let progs = bpf_manager.list_programs();
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(progs);
-            }
-        }
-    }
-
-    for handle in task_handles {
-        handle.await?;
-    }
-
+    join!(unix_listener, tcp_listener, bpf_manager.process_commands());
     Ok(())
+}
+
+pub(crate) async fn shutdown_handler() {
+    let mut sigint = signal(SignalKind::interrupt()).unwrap();
+    let mut sigterm = signal(SignalKind::terminate()).unwrap();
+    select! {
+        _ = sigint.recv() => {debug!("Received SIGINT")},
+        _ = sigterm.recv() => {debug!("Received SIGTERM")},
+    }
 }


### PR DESCRIPTION
This carries the last iteration of #405 which removes the use of `futures` by using a function.
I'd originally intended that we should use a tokio::sync::watch channel that was populated by a single signal handler - but rustc said nope because `rx.changed()` requires `rx` to have a static lifetime 😕 anyway, maybe we can fix that in future 😆 

While working on this, I took the opportunity to refactor the command handling a little:

1. Each `Command` that has > 1 arg has a `CommandArgs` struct, which tidies up the code a lot
1. Command processing has been moved from `serve` to `BpfManager::process_commands` as this is both easier to read, and easier to test
1. Since the processing of these commands has also got rather large, they've been factored out into their own functions `load_xdp_command`