### PR TITLE
bpf: adds cleanup for tc programs when qdisc is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "log",
  "object",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -377,6 +378,7 @@ dependencies = [
  "base16ct",
  "bpfd-api",
  "bpfd-csi",
+ "bytes",
  "caps",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.21.4", default-features = false }
 bpfd-api = { version = "0.2.0", path = "./bpfd-api" }
 bpfd-csi = { version = "1.8.0", path = "./csi" }
+bytes = { version = "1.5.0", default-features = false }
 caps = { version = "0.5.4", default-features = false }
 chrono = { version = "0.4.31", default-features = false }
 clap = { version = "4", default-features = false }

--- a/bpf/tc_qdisc.bpf.c
+++ b/bpf/tc_qdisc.bpf.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of bpfd */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <linux/types.h>
+
+#define DEBUG 1
+#ifdef  DEBUG
+/* Only use this for debug output. Notice output from bpf_trace_printk()
+ * end-up in /sys/kernel/debug/tracing/trace_pipe
+ */
+#define bpf_debug(fmt, ...)						\
+		({							\
+			char ____fmt[] = fmt;				\
+			bpf_trace_printk(____fmt, sizeof(____fmt),	\
+				     ##__VA_ARGS__);			\
+		})
+#else
+#define bpf_debug(fmt, ...) { } while (0)
+#endif
+
+// qdisc_destroy format
+// from: /sys/kernel/debug/tracing/events/qdisc/qdisc_destroy/format
+// name: qdisc_destroy
+// ID: 1426
+// format:
+//         field:unsigned short common_type;       offset:0;       size:2; signed:0;
+//         field:unsigned char common_flags;       offset:2;       size:1; signed:0;
+//         field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
+//         field:int common_pid;   offset:4;       size:4; signed:1;
+//
+//         field:__data_loc char[] dev;    offset:8;       size:4; signed:1;
+//         field:__data_loc char[] kind;   offset:12;      size:4; signed:1;
+//         field:u32 parent;       offset:16;      size:4; signed:0;
+//         field:u32 handle;       offset:20;      size:4; signed:0;
+typedef struct {
+    __u64 __unused__;
+    __u32 data_loc_dev;
+    __u32 data_loc_kind;
+    __u32 parent;
+    __u32 handle;
+} qdisc_destroy_args_t;
+
+#define DEV_NAME_MAX_LEN 64
+#define KIND_NAME_MAX_LEN 64
+
+// We should use __u32 __length = args->data_loc##field > 16
+// instead of sizeof(dst), but a verifier message is emitted:
+// 2023/09/21 22:14:08 loading objects: field TpClsactQdiscDestroy: program tp_clsact_qdisc_destroy: load program:
+// permission denied: invalid indirect access to stack R1 off=-128 size=65535 (36 line(s) omitted)
+#define TP_DATA_LOC_READ(dst, field)                                        \
+        do {                                                                \
+            __u32 __offset = args->data_loc_##field & 0xFFFF;      \
+            bpf_probe_read((void *)dst, sizeof(dst), (char *)args + __offset); \
+        } while (0);
+
+struct qdisc_event{
+    char dev[DEV_NAME_MAX_LEN];
+    char kind[KIND_NAME_MAX_LEN];
+} ;
+
+// Force emitting struct qdisc_event into the ELF.
+const struct qdisc_event *unused __attribute__((unused));
+
+// create perf event map to send qdisc_destroy events to user space.
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(int));
+    __uint(value_size, sizeof(int));
+} perf_event_qdisc SEC(".maps");
+
+
+SEC("tracepoint/clsact_qdisc_destroy")
+int tp_clsact_qdisc_destroy(void *ctx) {
+    qdisc_destroy_args_t *args = (qdisc_destroy_args_t *)ctx;
+    struct qdisc_event event = {};
+
+    TP_DATA_LOC_READ(event.dev, dev);
+    TP_DATA_LOC_READ(event.kind, kind);
+
+    // Sending event to user space
+    long ret = bpf_perf_event_output(ctx, &perf_event_qdisc, BPF_F_CURRENT_CPU, &event, sizeof(struct qdisc_event));
+    if (ret != 0) {
+        bpf_debug("bpf_perf_event_output failed: %ld", ret);
+    }
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -13,10 +13,11 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }
-aya = { workspace = true }
+aya = { workspace = true, features = ["async_tokio"] }
 base16ct = { workspace = true, features = ["alloc"] }
 bpfd-api = { workspace = true }
 bpfd-csi = { workspace = true }
+bytes = { workspace = true }
 caps = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "std"] }

--- a/bpfd/src/main.rs
+++ b/bpfd/src/main.rs
@@ -15,6 +15,7 @@ mod dispatcher_config;
 mod errors;
 mod multiprog;
 mod oci_utils;
+mod qdisc;
 mod rpc;
 mod serve;
 mod static_program;

--- a/bpfd/src/qdisc.rs
+++ b/bpfd/src/qdisc.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Copyright Authors of bpfd
+
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
+
+use aya::{
+    include_bytes_aligned, maps::perf::AsyncPerfEventArray, programs::TracePoint,
+    util::online_cpus, Bpf,
+};
+use bytes::BytesMut;
+use log::{debug, trace};
+// use tokio::sync::Mutex;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Mutex;
+
+use crate::serve::shutdown_handler;
+
+// Assuming DEV_NAME_MAX_LEN and KIND_NAME_MAX_LEN are defined as constants
+const DEV_NAME_MAX_LEN: usize = 64;
+const KIND_NAME_MAX_LEN: usize = 64;
+
+static QDISC_BYTES: &[u8] = include_bytes_aligned!("../../.output/tc_qdisc.bpf.o");
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) struct QdiscEvent {
+    pub dev: [u8; DEV_NAME_MAX_LEN],
+    pub kind: [u8; KIND_NAME_MAX_LEN],
+}
+
+pub(crate) struct OnQdiscDestroyEvent {}
+
+impl OnQdiscDestroyEvent {
+    #[allow(unreachable_code)]
+    pub async fn run(qdisc_destroy_event: Arc<Mutex<Sender<QdiscEvent>>>) {
+        debug!("QdiscDestroyObserver::start()");
+
+        let mut bpf: Bpf = Bpf::load(QDISC_BYTES).unwrap();
+
+        let program: &mut TracePoint = bpf
+            .program_mut("tp_clsact_qdisc_destroy")
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        program.load().unwrap();
+        debug!("QdiscDestroyObserver::start() program loaded");
+
+        program.attach("qdisc", "qdisc_destroy").unwrap();
+        debug!("QdiscDestroyObserver::start() program attached ");
+
+        let mut perf_array: AsyncPerfEventArray<aya::maps::MapData> =
+            AsyncPerfEventArray::try_from(bpf.take_map("perf_event_qdisc").unwrap()).unwrap();
+        let cpus = online_cpus().unwrap();
+        let num_cpus = cpus.len();
+
+        for cpu_id in cpus {
+            // open a separate perf buffer for each cpu
+            let mut buf = perf_array.open(cpu_id, None).unwrap();
+
+            trace!("QdiscDestroyObserver::start() perf_array opened");
+            let qdisc_destroy_event_clone = qdisc_destroy_event.clone();
+
+            // process each perf buffer in a separate task
+            tokio::task::spawn(async move {
+                let mut buffers = (0..num_cpus)
+                    .map(|_| BytesMut::with_capacity(1024))
+                    .collect::<Vec<_>>();
+
+                loop {
+                    // wait for events
+                    trace!("QdiscDestroyObserver::start() wait for events");
+                    let events = buf.read_events(&mut buffers).await?;
+
+                    trace!("QdiscDestroyObserver::start() read events");
+                    for buf in buffers.iter_mut().take(events.read) {
+                        // TODO reuse the same buffer instead of allocating a new one.
+                        // The *const QdiscEvent does not implement Send.
+                        // let ptr = buf.as_ptr() as *const QdiscEvent;
+                        // let qdisc_event = unsafe { read_unaligned(ptr) };
+
+                        // Copying data from the raw buffer to a safe structure
+                        let qdisc_event_data = buf[0..std::mem::size_of::<QdiscEvent>()].to_vec();
+                        let qdisc_event: QdiscEvent =
+                            unsafe { std::ptr::read(qdisc_event_data.as_ptr() as *const _) };
+
+                        qdisc_destroy_event_clone
+                            .lock()
+                            .await
+                            .send(qdisc_event)
+                            .await
+                            .unwrap();
+                    }
+                }
+
+                Ok::<_, anyhow::Error>(())
+            });
+        }
+
+        shutdown_handler().await;
+    }
+}


### PR DESCRIPTION
This PR introduces a new logic to monitor qdisc destroy events in the Linux Traffic Control subsystem. Upon detection of these events, the code performs a thorough cleanup operation for all TC programs attached to the affected network interface. This ensures that stale or orphaned TC programs do not persist in the bpfd.

Related: #468

[![asciicast](https://asciinema.org/a/611968.svg)](https://asciinema.org/a/611968)