### PR TITLE
bpf-metrics-exporter: Add metrics exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bpf-metrics-exporter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aya",
+ "chrono",
+ "clap",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "bpfman"
 version = "0.3.1"
 dependencies = [
@@ -373,7 +389,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "url",
  "users",
@@ -386,12 +402,12 @@ dependencies = [
  "aya",
  "clap",
  "log",
- "prost",
+ "prost 0.12.2",
  "serde",
  "thiserror",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.10.2",
  "url",
 ]
 
@@ -399,9 +415,9 @@ dependencies = [
 name = "bpfman-csi"
 version = "1.8.0"
 dependencies = [
- "prost",
+ "prost 0.12.2",
  "prost-types",
- "tonic",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -1137,6 +1153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1497,15 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1969,6 +2000,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "thiserror",
+ "tokio",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968ba3f2ca03e90e5187f5e4f46c791ef7f2c163ae87789c8ce5f5ca3b7b7de5"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2392,7 @@ checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
+ "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -2327,12 +2442,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.2",
 ]
 
 [[package]]
@@ -2343,13 +2468,13 @@ checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.12.2",
  "prost-types",
  "regex",
  "syn 2.0.39",
@@ -2359,12 +2484,25 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -2376,7 +2514,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
- "prost",
+ "prost 0.12.2",
 ]
 
 [[package]]
@@ -3256,6 +3394,34 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.5",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -3272,7 +3438,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3511,6 +3677,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "users"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "bpf-metrics-exporter",
     "bpfman",
     "bpfman-api",
     "csi",
@@ -37,6 +38,10 @@ log = { version = "0.4", default-features = false }
 netlink-packet-route = { version = "0.17.1", default-features = false }
 nix = { version = "0.27", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
+opentelemetry = { version = "0.21.0", default-features = false }
+opentelemetry-otlp = { version = "0.14.0", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.13.0" }
+opentelemetry_sdk = { version = "0.21.1", default-features = false }
 predicates = { version = "3.0.4", default-features = false }
 prost = { version = "0.12.2", default-features = false }
 prost-types = { version = "0.12.1", default-features = false }
@@ -55,6 +60,7 @@ tempfile = { version = "3.8.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.34.0", default-features = false }
 tokio-stream = { version = "0.1.12", default-features = false }
+tokio-util = { version = "0.7.10", default-features = false }
 toml = { version = "0.7", default-features = false }
 tonic = { version = "0.10.2", default-features = false }
 tonic-build = { version = "0.10.2", default-features = false }

--- a/bpf-metrics-exporter/Cargo.toml
+++ b/bpf-metrics-exporter/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+edition = "2021"
+name = "bpf-metrics-exporter"
+version = "0.1.0"
+
+[dependencies]
+anyhow = { workspace = true }
+aya = { workspace = true }
+chrono = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+] }
+opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic", "metrics"] }
+opentelemetry-semantic-conventions = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["metrics", "rt-tokio"] }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }

--- a/bpf-metrics-exporter/README.md
+++ b/bpf-metrics-exporter/README.md
@@ -1,0 +1,52 @@
+# bpf-metrics-exporter
+
+Exports metrics from the kernel's BPF subsystem to OpenTelmetry.
+These can later be enriched with other metrics from the system, for example,
+to correlate process IDs -> containers -> k8s pods.
+
+## Usage
+
+```bash
+./bpf-metrics-exporter --otlp-grpc localhost:4317
+```
+
+## Metrics
+
+The following metrics are exported:
+
+- `bpf_program_size_jitted_bytes`: The size of the BPF program in bytes.
+- `bpf_program_size_translated_bytes`: The size of the BPF program in bytes.
+- `bpf_program_mem_bytes`: The amount of memory used by the BPF program in bytes.
+- `bpf_program_verified_instructions_total`: The number of instructions in the BPF program.
+
+
+The following will be added pending: https://github.com/open-telemetry/opentelemetry-rust/issues/1242
+
+- `bpf_programs_total`: The number of BPF programs loaded into the kernel.
+
+Labels:
+
+- `id`: The ID of the BPF program
+- `name`: The name of the BPF program
+- `type`: The type of the BPF program
+- `tag`: The tag of the BPF program
+- `gpl_compatible`: Whether the BPF program is GPL compatible
+- `load_time`: The time the BPF program was loaded
+
+## Try it out
+
+You'll need a Grafana stack set up.
+You can quickly deploy one using:
+
+```bash
+podman play kube metrics-stack.yaml
+```
+
+Then, you can deploy the exporter:
+
+```
+sudo ./target/debug/bpf-metrics-exporter
+```
+
+You can log into grafana at http://localhost:3000/ with the credentials `admin:admin`. Once there, you can explore the metrics in the prometheus
+datasource.

--- a/bpf-metrics-exporter/metrics-stack.yaml
+++ b/bpf-metrics-exporter/metrics-stack.yaml
@@ -1,0 +1,160 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    app: grafana-stack
+data:
+  prometheus.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://localhost:9009/prometheus
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mimir-config
+  labels:
+    app: grafana-stack
+data:
+  mimir-local-config.yaml: |
+    # Do not use this configuration in production.
+    # It is for demonstration purposes only.
+    multitenancy_enabled: false
+
+    blocks_storage:
+      backend: filesystem
+      bucket_store:
+        sync_dir: /tmp/mimir/tsdb-sync
+      filesystem:
+        dir: /tmp/mimir/data/tsdb
+      tsdb:
+        dir: /tmp/mimir/tsdb
+
+    compactor:
+      data_dir: /tmp/mimir/compactor
+      sharding_ring:
+        kvstore:
+          store: memberlist
+
+    distributor:
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: memberlist
+
+    ingester:
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: memberlist
+        replication_factor: 1
+
+    ruler_storage:
+      backend: filesystem
+      filesystem:
+        dir: /tmp/mimir/rules
+
+    server:
+      http_listen_port: 9009
+      log_level: error
+
+    store_gateway:
+      sharding_ring:
+        replication_factor: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  labels:
+    app: grafana-stack
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+
+    exporters:
+      prometheusremotewrite:
+        endpoint: http://127.0.0.1:9009/api/v1/push
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [prometheusremotewrite]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-stack
+  labels:
+    app: grafana-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana-stack
+  template:
+    metadata:
+      labels:
+        app: grafana-stack
+    spec:
+      containers:
+        - name: otel-collector
+          image: docker.io/otel/opentelemetry-collector-contrib:0.89.0
+          ports:
+            - containerPort: 4317
+              hostPort: 4317
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/otelcol-contrib
+              name: otel-collector-config
+              readOnly: true
+        - name: grafana
+          image: docker.io/grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+              hostPort: 3000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana-data
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: grafana-datasources
+              readOnly: true
+        - name: mimir
+          image: docker.io/grafana/mimir:latest
+          args:
+            - --config.file=/mnt/config/mimir-local-config.yaml
+          ports:
+            - containerPort: 9009
+              hostPort: 9009
+              protocol: TCP
+            - containerPort: 9095
+              hostPort: 9095
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/mimir
+              name: mimir-data
+            - mountPath: /mnt/config
+              name: mimir-config
+              readOnly: true
+      volumes:
+        - name: grafana-data
+          emptyDir: {}
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
+        - name: mimir-data
+          emptyDir: {}
+        - name: mimir-config
+          configMap:
+            name: mimir-config
+        - name: otel-collector-config
+          configMap:
+            name: otel-collector-config

--- a/bpf-metrics-exporter/src/main.rs
+++ b/bpf-metrics-exporter/src/main.rs
@@ -1,0 +1,134 @@
+use aya::loaded_programs;
+use chrono::{prelude::DateTime, Utc};
+use clap::Parser;
+use opentelemetry::{
+    metrics::{MeterProvider as _, Unit},
+    KeyValue,
+};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{metrics::MeterProvider as SdkMeterProvider, runtime, Resource};
+use tokio::signal::ctrl_c;
+
+fn init_meter_provider(grpc_endpoint: &str) -> SdkMeterProvider {
+    opentelemetry_otlp::new_pipeline()
+        .metrics(runtime::Tokio)
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(grpc_endpoint),
+        )
+        .with_resource(Resource::new(vec![KeyValue::new(
+            opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+            "bpf-metrics-exporter",
+        )]))
+        .with_period(std::time::Duration::from_secs(5))
+        .build()
+        .expect("unable to create a new provider")
+}
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(long, default_value = "http://localhost:4317")]
+    otel_grpc: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    // Initialize the MeterProvider with the OTLP exporter.
+    let meter_provider = init_meter_provider(&cli.otel_grpc);
+
+    // Create a meter from the above MeterProvider.
+    let meter = meter_provider.meter("bpf-metrics");
+
+    let bpf_program_size_jitted_bytes = meter
+        .u64_observable_counter("bpf_program_size_jitted_bytes")
+        .with_description("BPF program size in bytes")
+        .with_unit(Unit::new("bytes"))
+        .init();
+
+    let bpf_program_size_translated_bytes = meter
+        .u64_observable_counter("bpf_program_size_translated_bytes")
+        .with_description("BPF program size in bytes")
+        .with_unit(Unit::new("bytes"))
+        .init();
+
+    let bpf_program_mem_bytes = meter
+        .u64_observable_counter("bpf_program_mem_bytes")
+        .with_description("BPF program memory usage in bytes")
+        .with_unit(Unit::new("bytes"))
+        .init();
+
+    let bpf_program_verified_instructions_total = meter
+        .u64_observable_counter("bpf_program_verified_instructions_total")
+        .with_description("BPF program verified instructions")
+        .with_unit(Unit::new("instructions"))
+        .init();
+
+    meter
+        .register_callback(
+            &[
+                bpf_program_size_jitted_bytes.as_any(),
+                bpf_program_size_translated_bytes.as_any(),
+                bpf_program_mem_bytes.as_any(),
+                bpf_program_verified_instructions_total.as_any(),
+            ],
+            move |observer| {
+                for program in loaded_programs().flatten() {
+                    let name = program.name_as_str().unwrap_or_default().to_string();
+                    let ty = program.program_type().to_string();
+                    let tag = program.tag().to_string();
+                    let gpl_compatible = program.gpl_compatible();
+                    let load_time = DateTime::<Utc>::from(program.loaded_at());
+
+                    let jitted_bytes = program.size_jitted();
+                    let translated_bytes = program.size_translated();
+                    let mem_bytes = program.memory_locked().unwrap_or_default();
+                    let verified_instructions = program.verified_instruction_count();
+
+                    let labels = [
+                        KeyValue::new("name", name),
+                        KeyValue::new("type", ty),
+                        KeyValue::new("tag", tag),
+                        KeyValue::new("gpl_compatible", gpl_compatible),
+                        KeyValue::new(
+                            "load_time",
+                            load_time.format("%Y-%m-%d %H:%M:%S").to_string(),
+                        ),
+                    ];
+
+                    observer.observe_u64(
+                        &bpf_program_size_jitted_bytes,
+                        jitted_bytes.into(),
+                        &labels,
+                    );
+
+                    observer.observe_u64(
+                        &bpf_program_size_translated_bytes,
+                        translated_bytes.into(),
+                        &labels,
+                    );
+
+                    observer.observe_u64(&bpf_program_mem_bytes, mem_bytes.into(), &labels);
+
+                    observer.observe_u64(
+                        &bpf_program_verified_instructions_total,
+                        verified_instructions.into(),
+                        &labels,
+                    );
+                }
+            },
+        )
+        .expect("failed to register callback");
+
+    println!("Listening for Ctrl-C...");
+    ctrl_c().await.expect("failed to listen for event");
+    println!("Ctrl-C received, shutting down...");
+
+    // Explicitly shutdown the provider to flush any remaining metrics data.
+    // There is no guarantee that this will be successful, so ignore the error.
+    let _ = meter_provider.shutdown();
+
+    Ok(())
+}


### PR DESCRIPTION
This commit adds a sample bpf-metrics-exporter.
This currently just reads programs that are loaded into the kernel and exports the metrics (at a 5s interval) to an OTEL-gRPC endpoint.

There is some documentation and a sample metrics stack attached for visualising this information.

fixes #578 