### PR TITLE
bpfman: add support for socket activation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
         run: sleep 5
 
       - name: Verify the bpfman systemd service is active
-        run: systemctl is-active bpfman
+        run: systemctl is-active bpfman.socket
 
       - name: Verify the CLI can reach bpfman
         run: sudo bpfman list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
+ "libsystemd 0.7.0",
  "log",
  "netlink-packet-route",
  "nix 0.27.1",
@@ -1694,6 +1695,24 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.4",
+ "nom",
+ "once_cell",
+ "serde",
+ "sha2",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "libsystemd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c592dc396b464005f78a5853555b9f240bc5378bf5221acc4e129910b2678869"
+dependencies = [
+ "hmac",
+ "libc",
+ "log",
+ "nix 0.27.1",
  "nom",
  "once_cell",
  "serde",
@@ -3347,7 +3366,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "356b5cb52ce54916cbfaee19b07d305c7ea8ce5435a088c58743d4a0211f3eff"
 dependencies = [
- "libsystemd",
+ "libsystemd 0.6.0",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hex = { version = "0.4.3", default-features = false }
 integration-test-macros = { path = "./tests/integration-test-macros" }
 inventory = { version = "0.3", default-features = false }
 lazy_static = { version = "1", default-features = false }
+libsystemd = { version = "0.7.0", default-features = false }
 log = { version = "0.4", default-features = false }
 netlink-packet-route = { version = "0.17.1", default-features = false }
 nix = { version = "0.27", default-features = false }

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
+libsystemd = { workspace = true }
 log = { workspace = true }
 netlink-packet-route = { workspace = true }
 nix = { workspace = true, features = [

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -891,12 +891,12 @@ impl BpfManager {
         Ok(())
     }
 
-    pub(crate) async fn process_commands(&mut self) {
+    pub(crate) async fn process_commands(&mut self, use_activity_timer: bool) {
         loop {
             // Start receiving messages
             select! {
                 biased;
-                _ = shutdown_handler() => {
+                _ = shutdown_handler(use_activity_timer) => {
                     info!("Signal received to stop command processing");
                     self._database.flush().expect("Unable to flush database to disk before shutting down BpfManager");
                     break;

--- a/bpfman/src/oci_utils/image_manager.rs
+++ b/bpfman/src/oci_utils/image_manager.rs
@@ -147,12 +147,12 @@ impl ImageManager {
         })
     }
 
-    pub(crate) async fn run(&mut self) {
+    pub(crate) async fn run(&mut self, use_activity_timer: bool) {
         loop {
             // Start receiving messages
             select! {
                 biased;
-                _ = shutdown_handler() => {
+                _ = shutdown_handler(use_activity_timer) => {
                     info!("image_manager: Signal received to stop command processing");
                     self.database.flush().expect("Unable to flush database to disk before shutting down ImageManager");
                     break;

--- a/bpfman/src/serve.rs
+++ b/bpfman/src/serve.rs
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use std::{fs::remove_file, path::Path};
+use std::{
+    fs::remove_file,
+    os::unix::prelude::{FromRawFd, IntoRawFd},
+    path::Path,
+};
 
+use anyhow::anyhow;
 use bpfman_api::{
     config::Config,
     util::directories::{RTPATH_BPFMAN_SOCKET, STDIR_DB},
     v1::bpfman_server::BpfmanServer,
 };
+use libsystemd::activation::IsType;
 use log::{debug, info};
 use sled::Config as DbConfig;
 use tokio::{
@@ -43,10 +49,8 @@ pub async fn serve(
 
     let mut listeners: Vec<_> = Vec::new();
 
-    match serve_unix(path.clone(), service.clone()).await {
-        Ok(handle) => listeners.push(handle),
-        Err(e) => eprintln!("Error = {e:?}"),
-    }
+    let (handle, use_activity_timer) = serve_unix(path.clone(), service.clone()).await?;
+    listeners.push(handle);
 
     let allow_unsigned = config.signing.as_ref().map_or(true, |s| s.allow_unsigned);
     let (itx, irx) = mpsc::channel(32);
@@ -58,7 +62,7 @@ pub async fn serve(
 
     let mut image_manager = ImageManager::new(database.clone(), allow_unsigned, irx).await?;
     let image_manager_handle = tokio::spawn(async move {
-        image_manager.run().await;
+        image_manager.run(use_activity_timer).await;
     });
 
     let mut bpf_manager = BpfManager::new(config.clone(), rx, itx, database);
@@ -80,12 +84,13 @@ pub async fn serve(
 
     if csi_support {
         let storage_manager = StorageManager::new(tx);
-        let storage_manager_handle = tokio::spawn(async move { storage_manager.run().await });
+        let storage_manager_handle =
+            tokio::spawn(async move { storage_manager.run(use_activity_timer).await });
         let (_, res_image, res_storage, _) = join!(
             join_listeners(listeners),
             image_manager_handle,
             storage_manager_handle,
-            bpf_manager.process_commands()
+            bpf_manager.process_commands(use_activity_timer)
         );
         if let Some(e) = res_storage.err() {
             return Err(e.into());
@@ -97,7 +102,7 @@ pub async fn serve(
         let (_, res_image, _) = join!(
             join_listeners(listeners),
             image_manager_handle,
-            bpf_manager.process_commands()
+            bpf_manager.process_commands(use_activity_timer)
         );
         if let Some(e) = res_image.err() {
             return Err(e.into());
@@ -107,12 +112,25 @@ pub async fn serve(
     Ok(())
 }
 
-pub(crate) async fn shutdown_handler() {
+pub(crate) async fn shutdown_handler(use_activity_timer: bool) {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
     let mut sigint = signal(SignalKind::interrupt()).unwrap();
     let mut sigterm = signal(SignalKind::terminate()).unwrap();
-    select! {
-        _ = sigint.recv() => {debug!("Received SIGINT")},
-        _ = sigterm.recv() => {debug!("Received SIGTERM")},
+
+    if use_activity_timer {
+        let mut timer = Box::pin(tokio::time::sleep(TIMEOUT));
+
+        select! {
+            _ = sigint.recv() => {debug!("Received SIGINT")},
+            _ = sigterm.recv() => {debug!("Received SIGTERM")},
+            _ = &mut timer => {debug!("Inactivity timer expired")},
+        }
+    } else {
+        select! {
+            _ = sigint.recv() => {debug!("Received SIGINT")},
+            _ = sigterm.recv() => {debug!("Received SIGTERM")},
+        }
     }
 }
 
@@ -128,7 +146,52 @@ async fn join_listeners(listeners: Vec<JoinHandle<()>>) {
 async fn serve_unix(
     path: String,
     service: BpfmanServer<BpfmanLoader>,
-) -> anyhow::Result<JoinHandle<()>> {
+) -> anyhow::Result<(JoinHandle<()>, bool)> {
+    let use_activity_timer;
+    let uds_stream = if let Ok(stream) = systemd_unix_stream(path.clone()) {
+        use_activity_timer = true;
+        stream
+    } else {
+        use_activity_timer = false;
+        std_unix_stream(path.clone()).await?
+    };
+
+    let serve = Server::builder()
+        .add_service(service)
+        .serve_with_incoming_shutdown(uds_stream, shutdown_handler(use_activity_timer));
+
+    Ok((
+        tokio::spawn(async move {
+            info!("Listening on {path}");
+            if let Err(e) = serve.await {
+                eprintln!("Error = {e:?}");
+            }
+            info!("Shutdown Unix Handler {}", path);
+        }),
+        use_activity_timer,
+    ))
+}
+
+fn systemd_unix_stream(_path: String) -> anyhow::Result<UnixListenerStream> {
+    let listen_fds = libsystemd::activation::receive_descriptors(true)?;
+    if listen_fds.len() == 1 {
+        if let Some(fd) = listen_fds.first() {
+            if !fd.is_unix() {
+                return Err(anyhow!("Wrong Socket"));
+            }
+            let std_listener =
+                unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd.clone().into_raw_fd()) };
+            std_listener.set_nonblocking(true)?;
+            let tokio_listener = UnixListener::from_std(std_listener)?;
+            info!("Using a Unix socket from systemd");
+            return Ok(UnixListenerStream::new(tokio_listener));
+        }
+    }
+
+    Err(anyhow!("Unable to retrieve fd from systemd"))
+}
+
+async fn std_unix_stream(path: String) -> anyhow::Result<UnixListenerStream> {
     // Listen on Unix socket
     if Path::new(&path).exists() {
         // Attempt to remove the socket, since bind fails if it exists
@@ -136,19 +199,10 @@ async fn serve_unix(
     }
 
     let uds = UnixListener::bind(&path)?;
-    let uds_stream = UnixListenerStream::new(uds);
+    let stream = UnixListenerStream::new(uds);
     // Always set the file permissions of our listening socket.
     set_file_permissions(&path.clone(), SOCK_MODE).await;
 
-    let serve = Server::builder()
-        .add_service(service)
-        .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
-
-    Ok(tokio::spawn(async move {
-        info!("Listening on {path}");
-        if let Err(e) = serve.await {
-            eprintln!("Error = {e:?}");
-        }
-        info!("Shutdown Unix Handler {}", path);
-    }))
+    info!("Using default Unix socket");
+    Ok(stream)
 }

--- a/bpfman/src/storage.rs
+++ b/bpfman/src/storage.rs
@@ -361,7 +361,7 @@ impl StorageManager {
         }
     }
 
-    pub async fn run(self) {
+    pub async fn run(self, use_activity_timer: bool) {
         let path: &Path = Path::new(RTPATH_BPFMAN_CSI_SOCKET);
         // Listen on Unix socket
         if path.exists() {
@@ -379,7 +379,7 @@ impl StorageManager {
         let serve = Server::builder()
             .add_service(node_service)
             .add_service(identity_service)
-            .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
+            .serve_with_incoming_shutdown(uds_stream, shutdown_handler(use_activity_timer));
 
         tokio::spawn(async move {
             info!("CSI Plugin Listening on {}", path.display());

--- a/scripts/bpfman.service
+++ b/scripts/bpfman.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Run bpfman as a service
 DefaultDependencies=no
-After=network.target
+Requires=bpfman.socket
 
 [Service]
 Environment="RUST_LOG=Info"

--- a/scripts/bpfman.socket
+++ b/scripts/bpfman.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=bpfman API Socket
+
+[Socket]
+ListenStream=/run/bpfman/sock/bpfman.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,8 @@ SRC_DEBUG_BIN_PATH="../target/debug"
 SRC_RELEASE_BIN_PATH="../target/x86_64-unknown-linux-musl/release"
 DST_BIN_PATH="/usr/sbin"
 DST_SVC_PATH="/usr/lib/systemd/system"
+SVC_BPFMAN_SOCK="${BIN_BPFMAN}.socket"
+SVC_BPFMAN_SVC="${BIN_BPFMAN}.service"
 
 # ConfigurationDirectory: /etc/bpfman/
 CONFIGURATION_DIR="/etc/bpfman"


### PR DESCRIPTION
When loading bpfman as a systemd service, implement socket activation. Socket activation is a systemd feature in which a given service is not started until it is needed, in this case, a request is received on a socket. To reduce the attack surface, it is preferred that bpfman not run forever, but instead stop after a period of inactivity. The current
implementation has a hard stop of bpfman after 15 seconds. Trying to restart timers over multiple async threads was not worth the effort since async nature of bpfman is going to be ripped out over the nextcouple of weeks.

NOTE: Systemd can support stopping a service after a specified time of inactivity. But it requires the builtin systemd proxy, where systemd listens on the primary socket and when a request comes in the request is sent to bpfman over a private socket. It was decided that this was not the correct solution for bpfman.

Resolves: #463