### PR TITLE
Sled integration for the core program type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -242,7 +242,7 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#b1769678f48f7abf6c987a1d686bbaffd5d1e664"
+source = "git+https://github.com/aya-rs/aya?branch=main#44f416a617a1ef5555420cb45ee6db3d1a561b0f"
 dependencies = [
  "assert_matches",
  "aya-obj",
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#b1769678f48f7abf6c987a1d686bbaffd5d1e664"
+source = "git+https://github.com/aya-rs/aya?branch=main#44f416a617a1ef5555420cb45ee6db3d1a561b0f"
 dependencies = [
  "bytes",
  "core-error",
@@ -380,6 +380,7 @@ dependencies = [
  "netlink-packet-route",
  "nix 0.27.1",
  "oci-distribution",
+ "rand",
  "rtnetlink",
  "serde",
  "serde_json",
@@ -657,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-error"
@@ -706,22 +707,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset 0.9.0",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
@@ -1320,9 +1320,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -1338,11 +1338,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -1401,9 +1401,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1416,7 +1416,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1574,7 +1574,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jni"
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libm"
@@ -2899,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2912,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.7",
@@ -2949,9 +2949,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "salsa20"
@@ -3241,16 +3241,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -3449,7 +3439,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4283,9 +4273,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]
@@ -4340,18 +4330,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
+ "lazy_static",
  "libsystemd 0.7.0",
  "log",
  "netlink-packet-route",

--- a/bpfman-api/src/lib.rs
+++ b/bpfman-api/src/lib.rs
@@ -7,6 +7,8 @@ pub mod util;
 #[rustfmt::skip]
 #[allow(clippy::all)]
 pub mod v1;
+use std::iter::FromIterator;
+
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -159,6 +161,45 @@ impl TryFrom<u32> for ProgramType {
     }
 }
 
+impl From<ProgramType> for u32 {
+    fn from(val: ProgramType) -> Self {
+        match val {
+            ProgramType::Unspec => 0,
+            ProgramType::SocketFilter => 1,
+            ProgramType::Probe => 2,
+            ProgramType::Tc => 3,
+            ProgramType::SchedAct => 4,
+            ProgramType::Tracepoint => 5,
+            ProgramType::Xdp => 6,
+            ProgramType::PerfEvent => 7,
+            ProgramType::CgroupSkb => 8,
+            ProgramType::CgroupSock => 9,
+            ProgramType::LwtIn => 10,
+            ProgramType::LwtOut => 11,
+            ProgramType::LwtXmit => 12,
+            ProgramType::SockOps => 13,
+            ProgramType::SkSkb => 14,
+            ProgramType::CgroupDevice => 15,
+            ProgramType::SkMsg => 16,
+            ProgramType::RawTracepoint => 17,
+            ProgramType::CgroupSockAddr => 18,
+            ProgramType::LwtSeg6Local => 19,
+            ProgramType::LircMode2 => 20,
+            ProgramType::SkReuseport => 21,
+            ProgramType::FlowDissector => 22,
+            ProgramType::CgroupSysctl => 23,
+            ProgramType::RawTracepointWritable => 24,
+            ProgramType::CgroupSockopt => 25,
+            ProgramType::Tracing => 26,
+            ProgramType::StructOps => 27,
+            ProgramType::Ext => 28,
+            ProgramType::Lsm => 29,
+            ProgramType::SkLookup => 30,
+            ProgramType::Syscall => 31,
+        }
+    }
+}
+
 impl std::fmt::Display for ProgramType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let v = match self {
@@ -256,6 +297,18 @@ pub enum XdpProceedOnEntry {
     Tx,
     Redirect,
     DispatcherReturn = 31,
+}
+
+impl FromIterator<XdpProceedOnEntry> for XdpProceedOn {
+    fn from_iter<I: IntoIterator<Item = XdpProceedOnEntry>>(iter: I) -> Self {
+        let mut c = Vec::new();
+
+        for i in iter {
+            c.push(i);
+        }
+
+        XdpProceedOn(c)
+    }
 }
 
 impl TryFrom<String> for XdpProceedOnEntry {
@@ -457,6 +510,18 @@ impl Default for TcProceedOn {
             TcProceedOnEntry::Pipe,
             TcProceedOnEntry::DispatcherReturn,
         ])
+    }
+}
+
+impl FromIterator<TcProceedOnEntry> for TcProceedOn {
+    fn from_iter<I: IntoIterator<Item = TcProceedOnEntry>>(iter: I) -> Self {
+        let mut c = Vec::new();
+
+        for i in iter {
+            c.push(i);
+        }
+
+        TcProceedOn(c)
     }
 }
 

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -69,6 +69,7 @@ tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true }
 url = { workspace = true }
 users = { workspace = true }
+lazy_static = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
+lazy_static = { workspace = true }
 libsystemd = { workspace = true }
 log = { workspace = true }
 netlink-packet-route = { workspace = true }
@@ -48,6 +49,7 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "rustls-tls",
     "trust-dns",
 ] }
+rand = { workspace = true }
 rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
@@ -69,7 +71,6 @@ tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true }
 url = { workspace = true }
 users = { workspace = true }
-lazy_static = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -19,9 +19,9 @@ use bpfman_api::{
     config::Config,
     util::directories::*,
     ProbeType::{self, *},
-    ProgramType, TcProceedOn,
+    ProgramType,
 };
-use log::{debug, info, warn};
+use log::{debug, info};
 use tokio::{
     fs::{create_dir_all, read_dir, remove_dir_all},
     select,
@@ -35,13 +35,13 @@ use crate::{
     command::{
         BpfMap, Command, Direction,
         Direction::{Egress, Ingress},
-        Program, ProgramData, PullBytecodeArgs, TcProgram, UnloadArgs,
+        Program, ProgramData, PullBytecodeArgs, UnloadArgs,
     },
     errors::BpfmanError,
     multiprog::{Dispatcher, DispatcherId, DispatcherInfo, TcDispatcher, XdpDispatcher},
     oci_utils::image_manager::Command as ImageManagerCommand,
     serve::shutdown_handler,
-    utils::{get_ifindex, set_dir_permissions, should_map_be_pinned},
+    utils::{bytes_to_string, get_ifindex, set_dir_permissions, should_map_be_pinned},
     ROOT_DB,
 };
 
@@ -90,57 +90,82 @@ impl ProgramMap {
         direction: &'a Option<Direction>,
     ) -> impl Iterator<Item = &'a mut Program> {
         self.programs.values_mut().filter(|p| {
-            p.kind() == *program_type && p.if_index() == *if_index && p.direction() == *direction
+            p.kind() == *program_type
+                && p.if_index().unwrap() == *if_index
+                && p.direction().unwrap() == *direction
         })
+    }
+
+    // Adds a new program and sets the positions of programs that are to be attached via a dispatcher.
+    // Positions are set based on order of priority. Ties are broken based on:
+    // - Already attached programs are preferred
+    // - Program name. Lowest lexical order wins.
+    fn add_and_set_program_positions(&mut self, program: &mut Program) {
+        let program_type = program.kind();
+        let if_index = program.if_index().unwrap();
+        let direction = program.direction().unwrap();
+
+        let mut extensions = self
+            .programs
+            .values_mut()
+            .filter(|p| {
+                p.kind() == program_type
+                    && p.if_index().unwrap() == if_index
+                    && p.direction().unwrap() == direction
+            })
+            .collect::<Vec<&mut Program>>();
+
+        // add program we're loading
+        extensions.push(program);
+
+        extensions.sort_by_key(|b| {
+            (
+                b.priority().unwrap(),
+                b.attached(),
+                b.get_data().get_name().unwrap().to_owned(),
+            )
+        });
+        for (i, v) in extensions.iter_mut().enumerate() {
+            v.set_position(i).expect("unable to set program position");
+        }
     }
 
     // Sets the positions of programs that are to be attached via a dispatcher.
     // Positions are set based on order of priority. Ties are broken based on:
     // - Already attached programs are preferred
     // - Program name. Lowest lexical order wins.
-    fn set_program_positions(&mut self, program: &mut Program, is_add: bool) {
-        let program_type = program.kind();
-        let if_index = program.if_index();
-        let direction = program.direction();
-
+    fn set_program_positions(
+        &mut self,
+        program_type: ProgramType,
+        if_index: u32,
+        direction: Option<Direction>,
+    ) {
         let mut extensions = self
             .programs
             .values_mut()
             .filter(|p| {
-                p.kind() == program_type && p.if_index() == if_index && p.direction() == direction
+                p.kind() == program_type
+                    && p.if_index().unwrap() == Some(if_index)
+                    && p.direction().unwrap() == direction
             })
             .collect::<Vec<&mut Program>>();
 
-        if is_add {
-            // add program we're loading
-            extensions.push(program);
-        }
-
         extensions.sort_by_key(|b| {
             (
-                b.priority(),
-                b.attached().unwrap(),
-                b.data()
-                    .expect("All Bpfman programs should have ProgramData")
-                    .name()
-                    .to_owned(),
+                b.priority().unwrap(),
+                b.attached(),
+                b.get_data().get_name().unwrap().to_owned(),
             )
         });
         for (i, v) in extensions.iter_mut().enumerate() {
-            v.set_position(Some(i));
+            v.set_position(i).expect("unable to set program position");
         }
     }
 
     fn get_programs_iter(&self) -> impl Iterator<Item = (u32, &Program)> {
-        self.programs.values().map(|p| {
-            let kernel_info = p
-                .data()
-                .expect("All Bpfman programs should have ProgramData")
-                .kernel_info()
-                .expect("Loaded Bpfman programs should have kernel information");
-
-            (kernel_info.id, p)
-        })
+        self.programs
+            .values()
+            .map(|p| (p.get_data().get_id().unwrap(), p))
     }
 }
 
@@ -192,17 +217,42 @@ impl BpfManager {
 
     pub(crate) async fn rebuild_state(&mut self) -> Result<(), anyhow::Error> {
         debug!("BpfManager::rebuild_state()");
-        let mut programs_dir = read_dir(RTDIR_PROGRAMS).await?;
-        while let Some(entry) = programs_dir.next_entry().await? {
-            let id = entry.file_name().to_string_lossy().parse().unwrap();
-            let mut program = Program::load(id)
-                .map_err(|e| BpfmanError::Error(format!("cant read program state {e}")))?;
-            // TODO: Should probably check for pinned prog on bpffs rather than assuming they are attached
-            program.set_attached();
+
+        // re-build programs from database
+        for tree_name in ROOT_DB.tree_names() {
+            let name = &bytes_to_string(&tree_name);
+            let tree = ROOT_DB
+                .open_tree(name)
+                .expect("unable to open database tree");
+
+            let id = match name.parse::<u32>() {
+                Ok(id) => id,
+                Err(_) => {
+                    debug!("Ignoring non-numeric tree name: {} on rebuild", name);
+                    continue;
+                }
+            };
+
             debug!("rebuilding state for program {}", id);
-            self.rebuild_map_entry(id, &mut program).await;
-            self.programs.insert(id, program);
+
+            // If there's an error here remove broken tree and continue
+            match Program::new_from_db(id, tree) {
+                Ok(mut program) => {
+                    program
+                        .get_data_mut()
+                        .set_program_bytes(self.image_manager.clone())
+                        .await?;
+                    self.rebuild_map_entry(id, &mut program).await;
+                    self.programs.insert(id, program);
+                }
+                Err(_) => {
+                    ROOT_DB
+                        .drop_tree(name)
+                        .expect("unable to remove broken program tree");
+                }
+            }
         }
+
         self.rebuild_dispatcher_state(ProgramType::Xdp, None, RTDIR_XDP_DISPATCHER)
             .await?;
         self.rebuild_dispatcher_state(ProgramType::Tc, Some(Ingress), RTDIR_TC_INGRESS_DISPATCHER)
@@ -247,23 +297,13 @@ impl BpfManager {
                         Dispatcher::Tc(dispatcher),
                     );
 
-                    // This is just used to collect and sort the dispatcher's
-                    // programs in `rebuild_multiattach_dispatcher`.
-                    // TODO(astoycos) rebuilding dispacthers need to be actual helpers
-                    // on BpfManager.Dispatchers not BpfManager itself.
-                    let fake_prog_filter = Program::Tc(TcProgram {
-                        data: ProgramData::default(),
-                        priority: 0,
-                        if_index: Some(if_index),
-                        iface: String::new(),
-                        proceed_on: TcProceedOn::default(),
-                        direction,
-                        current_position: None,
-                        attached: false,
-                    });
-
-                    self.rebuild_multiattach_dispatcher(fake_prog_filter, did)
-                        .await?;
+                    self.rebuild_multiattach_dispatcher(
+                        did,
+                        if_index,
+                        ProgramType::Tc,
+                        Some(direction),
+                    )
+                    .await?;
                 }
                 _ => return Err(anyhow!("invalid program type {:?}", program_type)),
             }
@@ -276,23 +316,21 @@ impl BpfManager {
         &mut self,
         mut program: Program,
     ) -> Result<Program, BpfmanError> {
-        let map_owner_id = program.data()?.map_owner_id();
+        let map_owner_id = program.get_data().get_map_owner_id()?;
         // Set map_pin_path if we're using another program's maps
         if let Some(map_owner_id) = map_owner_id {
             let map_pin_path = self.is_map_owner_id_valid(map_owner_id)?;
-            program
-                .data_mut()?
-                .set_map_pin_path(Some(map_pin_path.clone()));
+            program.get_data_mut().set_map_pin_path(&map_pin_path)?;
         }
 
         program
-            .data_mut()?
+            .get_data_mut()
             .set_program_bytes(self.image_manager.clone())
             .await?;
 
         let result = match program {
             Program::Xdp(_) | Program::Tc(_) => {
-                program.set_if_index(get_ifindex(&program.if_name().unwrap())?);
+                program.set_if_index(get_ifindex(&program.if_name().unwrap())?)?;
 
                 self.add_multi_attach_program(&mut program).await
             }
@@ -303,19 +341,23 @@ impl BpfManager {
         };
 
         // Program bytes MUST be cleared after load.
-        program.data_mut()?.clear_program_bytes();
+        program.get_data_mut().clear_program_bytes();
 
         match result {
             Ok(id) => {
                 info!(
                     "Added {} program with name: {} and id: {id}",
                     program.kind(),
-                    program.data()?.name()
+                    program.get_data().get_name()?
                 );
 
                 // Now that program is successfully loaded, update the id, maps hash table,
                 // and allow access to all maps by bpfman group members.
                 self.save_map(&mut program, id, map_owner_id).await?;
+
+                // Swap the db tree to be persisted with the unique program ID generated
+                // by the kernel.
+                program.get_data_mut().swap_tree(id)?;
 
                 // Only add program to bpfManager if we've completed all mutations and it's successfully loaded.
                 self.programs.insert(id, program.to_owned());
@@ -324,12 +366,10 @@ impl BpfManager {
             }
             Err(e) => {
                 // Cleanup any directories associated with the map_pin_path.
-                // Data and map_pin_path may or may not exist depending on where the original
+                // map_pin_path may or may not exist depending on where the original
                 // error occured, so don't error if not there and preserve original error.
-                if let Ok(data) = program.data() {
-                    if let Some(pin_path) = data.map_pin_path() {
-                        let _ = self.cleanup_map_pin_path(pin_path, map_owner_id).await;
-                    }
+                if let Some(pin_path) = program.get_data().get_map_pin_path()? {
+                    let _ = self.cleanup_map_pin_path(&pin_path, map_owner_id).await;
                 }
                 Err(e)
             }
@@ -341,7 +381,7 @@ impl BpfManager {
         program: &mut Program,
     ) -> Result<u32, BpfmanError> {
         debug!("BpfManager::add_multi_attach_program()");
-        let name = program.data()?.name();
+        let name = &program.get_data().get_name()?;
 
         // This load is just to verify the BPF Function Name is valid.
         // The actual load is performed in the XDP or TC logic.
@@ -349,7 +389,7 @@ impl BpfManager {
         let mut ext_loader = BpfLoader::new()
             .allow_unsupported_maps()
             .extension(name)
-            .load(program.data()?.program_bytes())?;
+            .load(program.get_data().program_bytes())?;
 
         match ext_loader.program_mut(name) {
             Some(_) => Ok(()),
@@ -357,7 +397,7 @@ impl BpfManager {
         }?;
 
         let did = program
-            .dispatcher_id()
+            .dispatcher_id()?
             .ok_or(BpfmanError::DispatcherNotRequired)?;
 
         let next_available_id = self.dispatchers.attached_programs(&did);
@@ -368,11 +408,11 @@ impl BpfManager {
         debug!("next_available_id={next_available_id}");
 
         let program_type = program.kind();
-        let if_index = program.if_index();
-        let if_name = program.if_name().unwrap();
-        let direction = program.direction();
+        let if_index = program.if_index()?;
+        let if_name = program.if_name().unwrap().to_string();
+        let direction = program.direction()?;
 
-        self.programs.set_program_positions(program, true);
+        self.programs.add_and_set_program_positions(program);
 
         let mut programs: Vec<&mut Program> = self
             .programs
@@ -404,24 +444,17 @@ impl BpfManager {
         .await
         .or_else(|e| {
             // If kernel ID was never set there's no pins to cleanup here so just continue
-            if let Some(info) = program.kernel_info() {
+            if program.get_data().get_id().is_ok() {
                 program
-                    .delete(info.id)
+                    .delete()
                     .map_err(BpfmanError::BpfmanProgramDeleteError)?;
             }
             Err(e)
         })?;
 
         self.dispatchers.insert(did, dispatcher);
-        let id = program
-            .kernel_info()
-            .expect("kernel info should be set after load")
-            .id;
-
+        let id = program.get_data().get_id()?;
         program.set_attached();
-        program
-            .save(id)
-            .map_err(|e| BpfmanError::Error(format!("unable to save program state: {e}")))?;
 
         Ok(id)
     }
@@ -431,16 +464,17 @@ impl BpfManager {
         p: &mut Program,
     ) -> Result<u32, BpfmanError> {
         debug!("BpfManager::add_single_attach_program()");
-        let name = p.data()?.name();
+        let name = &p.get_data().get_name()?;
         let mut bpf = BpfLoader::new();
 
-        for (key, value) in p.data()?.global_data() {
+        let data = &p.get_data().get_global_data()?;
+        for (key, value) in data {
             bpf.set_global(key, value.as_slice(), true);
         }
 
         // If map_pin_path is set already it means we need to use a pin
         // path which should already exist on the system.
-        if let Some(map_pin_path) = p.data()?.map_pin_path() {
+        if let Some(map_pin_path) = p.get_data().get_map_pin_path()? {
             debug!(
                 "single-attach program {name} is using maps from {:?}",
                 map_pin_path
@@ -450,7 +484,7 @@ impl BpfManager {
 
         let mut loader = bpf
             .allow_unsupported_maps()
-            .load(p.data()?.program_bytes())?;
+            .load(p.get_data().program_bytes())?;
 
         let raw_program = loader
             .program_mut(name)
@@ -458,9 +492,12 @@ impl BpfManager {
 
         let res = match p {
             Program::Tracepoint(ref mut program) => {
-                let parts: Vec<&str> = program.tracepoint.split('/').collect();
+                let tracepoint = program.get_tracepoint()?;
+                let parts: Vec<&str> = tracepoint.split('/').collect();
                 if parts.len() != 2 {
-                    return Err(BpfmanError::InvalidAttach(program.tracepoint.to_string()));
+                    return Err(BpfmanError::InvalidAttach(
+                        program.get_tracepoint()?.to_string(),
+                    ));
                 }
                 let category = parts[0].to_owned();
                 let name = parts[1].to_owned();
@@ -469,8 +506,10 @@ impl BpfManager {
 
                 tracepoint.load()?;
                 program
-                    .data
-                    .set_kernel_info(Some(tracepoint.info()?.try_into()?));
+                    .get_data_mut()
+                    .set_kernel_info(&tracepoint.info()?)?;
+
+                let id = program.data.get_id()?;
 
                 let link_id = tracepoint.attach(&category, &name)?;
 
@@ -478,8 +517,6 @@ impl BpfManager {
                 let fd_link: FdLink = owned_link
                     .try_into()
                     .expect("unable to get owned tracepoint attach link");
-
-                let id = program.data.id().expect("id should be set after load");
 
                 fd_link
                     .pin(format!("{RTDIR_FS}/prog_{}_link", id))
@@ -492,12 +529,12 @@ impl BpfManager {
                 Ok(id)
             }
             Program::Kprobe(ref mut program) => {
-                let requested_probe_type = match program.retprobe {
+                let requested_probe_type = match program.get_retprobe()? {
                     true => Kretprobe,
                     false => Kprobe,
                 };
 
-                if requested_probe_type == Kretprobe && program.offset != 0 {
+                if requested_probe_type == Kretprobe && program.get_offset()? != 0 {
                     return Err(BpfmanError::Error(format!(
                         "offset not allowed for {Kretprobe}"
                     )));
@@ -515,18 +552,16 @@ impl BpfManager {
                     )));
                 }
 
-                program
-                    .data
-                    .set_kernel_info(Some(kprobe.info()?.try_into()?));
+                program.get_data_mut().set_kernel_info(&kprobe.info()?)?;
 
-                let link_id = kprobe.attach(program.fn_name.as_str(), program.offset)?;
+                let id = program.data.get_id()?;
+
+                let link_id = kprobe.attach(program.get_fn_name()?, program.get_offset()?)?;
 
                 let owned_link: KProbeLink = kprobe.take_link(link_id)?;
                 let fd_link: FdLink = owned_link
                     .try_into()
                     .expect("unable to get owned kprobe attach link");
-
-                let id = program.data.id().expect("id should be set after load");
 
                 fd_link
                     .pin(format!("{RTDIR_FS}/prog_{}_link", id))
@@ -539,7 +574,7 @@ impl BpfManager {
                 Ok(id)
             }
             Program::Uprobe(ref mut program) => {
-                let requested_probe_type = match program.retprobe {
+                let requested_probe_type = match program.get_retprobe()? {
                     true => Uretprobe,
                     false => Uprobe,
                 };
@@ -556,25 +591,24 @@ impl BpfManager {
                     )));
                 }
 
-                program
-                    .data
-                    .set_kernel_info(Some(uprobe.info()?.try_into()?));
+                program.get_data_mut().set_kernel_info(&uprobe.info()?)?;
 
-                let id = program.data.id().expect("id should be set after load");
+                let id = program.data.get_id()?;
 
                 let program_pin_path = format!("{RTDIR_FS}/prog_{id}");
+                let fn_name = program.get_fn_name()?;
 
                 uprobe
                     .pin(program_pin_path.clone())
                     .map_err(BpfmanError::UnableToPinProgram)?;
 
-                match program.container_pid {
+                match program.get_container_pid()? {
                     None => {
                         // Attach uprobe in same container as the bpfman process
                         let link_id = uprobe.attach(
-                            program.fn_name.as_deref(),
-                            program.offset,
-                            program.target.clone(),
+                            fn_name.as_deref(),
+                            program.get_offset()?,
+                            program.get_target()?,
                             None,
                         )?;
 
@@ -589,7 +623,7 @@ impl BpfManager {
                     }
                     Some(p) => {
                         // Attach uprobe in different container from the bpfman process
-                        let offset = program.offset.to_string();
+                        let offset = program.get_offset()?.to_string();
                         let container_pid = p.to_string();
                         let mut prog_args = vec![
                             "uprobe".to_string(),
@@ -598,20 +632,20 @@ impl BpfManager {
                             "--offset".to_string(),
                             offset,
                             "--target".to_string(),
-                            program.target.clone(),
+                            program.get_target()?.to_string(),
                             "--container-pid".to_string(),
                             container_pid,
                         ];
 
-                        if let Some(fn_name) = &program.fn_name {
+                        if let Some(fn_name) = &program.get_fn_name()? {
                             prog_args.extend(["--fn-name".to_string(), fn_name.to_string()])
                         }
 
-                        if program.retprobe {
+                        if program.get_retprobe()? {
                             prog_args.push("--retprobe".to_string());
                         }
 
-                        if let Some(pid) = program.pid {
+                        if let Some(pid) = program.get_pid()? {
                             prog_args.extend(["--pid".to_string(), pid.to_string()])
                         }
 
@@ -625,7 +659,7 @@ impl BpfManager {
                         if !status.success() {
                             return Err(BpfmanError::ContainerAttachError {
                                 program_type: "uprobe".to_string(),
-                                container_pid: program.container_pid.unwrap(),
+                                container_pid: program.get_container_pid()?.unwrap(),
                             });
                         }
                     }
@@ -639,9 +673,9 @@ impl BpfManager {
         match res {
             Ok(id) => {
                 // If this program is the map(s) owner pin all maps (except for .rodata and .bss) by name.
-                if p.data()?.map_pin_path().is_none() {
+                if p.get_data().get_map_pin_path()?.is_none() {
                     let map_pin_path = calc_map_pin_path(id);
-                    p.data_mut()?.set_map_pin_path(Some(map_pin_path.clone()));
+                    p.get_data_mut().set_map_pin_path(&map_pin_path)?;
                     create_map_pin_path(&map_pin_path).await?;
 
                     for (name, map) in loader.maps_mut() {
@@ -656,19 +690,11 @@ impl BpfManager {
                             .map_err(BpfmanError::UnableToPinMap)?;
                     }
                 }
-
-                p.save(id)
-                    // we might want to log or ignore this error instead of returning here...
-                    // because otherwise it will hide the original error (from res above)
-                    .map_err(|_| {
-                        BpfmanError::Error("unable to persist program data".to_string())
-                    })?;
             }
             Err(_) => {
                 // If kernel ID was never set there's no pins to cleanup here so just continue
-                if let Some(info) = p.kernel_info() {
-                    p.delete(info.id)
-                        .map_err(BpfmanError::BpfmanProgramDeleteError)?;
+                if p.get_data().get_id().is_ok() {
+                    p.delete().map_err(BpfmanError::BpfmanProgramDeleteError)?;
                 };
             }
         };
@@ -688,10 +714,7 @@ impl BpfManager {
             }
         };
 
-        let map_owner_id = prog.data()?.map_owner_id();
-
-        prog.delete(id)
-            .map_err(BpfmanError::BpfmanProgramDeleteError)?;
+        let map_owner_id = prog.get_data().get_map_owner_id()?;
 
         match prog {
             Program::Xdp(_) | Program::Tc(_) => self.remove_multi_attach_program(&mut prog).await?,
@@ -702,6 +725,10 @@ impl BpfManager {
         }
 
         self.delete_map(id, map_owner_id).await?;
+
+        prog.delete()
+            .map_err(BpfmanError::BpfmanProgramDeleteError)?;
+
         Ok(())
     }
 
@@ -712,7 +739,7 @@ impl BpfManager {
         debug!("BpfManager::remove_multi_attach_program()");
 
         let did = program
-            .dispatcher_id()
+            .dispatcher_id()?
             .ok_or(BpfmanError::DispatcherNotRequired)?;
 
         let next_available_id = self.dispatchers.attached_programs(&did) - 1;
@@ -727,12 +754,16 @@ impl BpfManager {
             }
         }
 
-        self.programs.set_program_positions(program, false);
+        self.programs.set_program_positions(
+            program.kind(),
+            program.if_index()?.unwrap(),
+            program.direction()?,
+        );
 
         let program_type = program.kind();
-        let if_index = program.if_index();
+        let if_index = program.if_index()?;
         let if_name = program.if_name().unwrap();
-        let direction = program.direction();
+        let direction = program.direction()?;
 
         // Intentionally don't add filter program here
         let mut programs: Vec<&mut Program> = self
@@ -765,20 +796,19 @@ impl BpfManager {
 
     pub(crate) async fn rebuild_multiattach_dispatcher(
         &mut self,
-        mut filter_prog: Program,
         did: DispatcherId,
+        if_index: u32,
+        program_type: ProgramType,
+        direction: Option<Direction>,
     ) -> Result<(), BpfmanError> {
-        let program_type = filter_prog.kind();
-        let if_index = filter_prog.if_index();
-        let direction = filter_prog.direction();
-
         debug!("BpfManager::rebuild_multiattach_dispatcher() for program type {program_type} on if_index {if_index:?}");
         let mut old_dispatcher = self.dispatchers.remove(&did);
 
         if let Some(ref mut old) = old_dispatcher {
             debug!("Rebuild Multiattach Dispatcher for {did:?}");
-            self.programs.set_program_positions(&mut filter_prog, false);
-
+            self.programs
+                .set_program_positions(program_type, if_index, direction);
+            let if_index = Some(if_index);
             let mut programs: Vec<&mut Program> = self
                 .programs
                 .programs_mut(&program_type, &if_index, &direction)
@@ -833,11 +863,20 @@ impl BpfManager {
                 let prog = p.map_err(BpfmanError::BpfProgramError)?;
                 let prog_id = prog.id();
 
-                // If the program was loaded by bpfman (check the hash map), then us it.
+                // If the program was loaded by bpfman (check the hash map), then use it.
                 // Otherwise, convert the data returned from Aya into an Unsupported Program Object.
                 match bpfman_progs.remove(&prog_id) {
                     Some(p) => Ok(p.to_owned()),
-                    None => Ok(Program::Unsupported(prog.try_into()?)),
+                    None => {
+                        let db_tree = ROOT_DB
+                            .open_tree(prog_id.to_string())
+                            .expect("Unable to open program database tree for listing programs");
+
+                        let mut data = ProgramData::new(db_tree, prog_id);
+                        data.set_kernel_info(&prog)?;
+
+                        Ok(Program::Unsupported(data))
+                    }
                 }
             })
             .collect()
@@ -854,7 +893,15 @@ impl BpfManager {
                 .find_map(|p| {
                     let prog = p.ok()?;
                     if prog.id() == id {
-                        Some(Program::Unsupported(prog.try_into().ok()?))
+                        let db_tree = ROOT_DB
+                            .open_tree(prog.id().to_string())
+                            .expect("Unable to open program database tree for listing programs");
+
+                        let mut data = ProgramData::new(db_tree, prog.id());
+                        data.set_kernel_info(&prog)
+                            .expect("unable to set kernel info");
+
+                        Some(Program::Unsupported(data))
                     } else {
                         None
                     }
@@ -980,7 +1027,7 @@ impl BpfManager {
         id: u32,
         map_owner_id: Option<u32>,
     ) -> Result<(), BpfmanError> {
-        let data = program.data_mut()?;
+        let data = program.get_data_mut();
 
         match map_owner_id {
             Some(m) => {
@@ -989,18 +1036,14 @@ impl BpfManager {
 
                     // This program has no been inserted yet, so set map_used_by to
                     // newly updated list.
-                    data.set_maps_used_by(Some(map.used_by.clone()));
+                    data.set_maps_used_by(map.used_by.clone())?;
 
                     // Update all the programs using the same map with the updated map_used_by.
                     for used_by_id in map.used_by.iter() {
                         if let Some(program) = self.programs.get_mut(used_by_id) {
-                            if let Ok(data) = program.data_mut() {
-                                data.set_maps_used_by(Some(map.used_by.clone()));
-                            } else {
-                                return Err(BpfmanError::Error(
-                                    "unable to retrieve data for {id}".to_string(),
-                                ));
-                            }
+                            program
+                                .get_data_mut()
+                                .set_maps_used_by(map.used_by.clone())?;
                         }
                     }
                 } else {
@@ -1015,10 +1058,10 @@ impl BpfManager {
                 self.maps.insert(id, map);
 
                 // Update this program with the updated map_used_by
-                data.set_maps_used_by(Some(vec![id]));
+                data.set_maps_used_by(vec![id])?;
 
                 // Set the permissions on the map_pin_path directory.
-                if let Some(map_pin_path) = data.map_pin_path() {
+                if let Some(map_pin_path) = data.get_map_pin_path()? {
                     if let Some(path) = map_pin_path.to_str() {
                         debug!("bpf set dir permissions for {}", path);
                         set_dir_permissions(path, MAPS_MODE).await;
@@ -1069,9 +1112,9 @@ impl BpfManager {
                 // Update all the programs still using the same map with the updated map_used_by.
                 for id in map.used_by.iter() {
                     if let Some(program) = self.programs.get_mut(id) {
-                        if let Ok(data) = program.data_mut() {
-                            data.set_maps_used_by(Some(map.used_by.clone()));
-                        }
+                        program
+                            .get_data_mut()
+                            .set_maps_used_by(map.used_by.clone())?;
                     }
                 }
             }
@@ -1085,13 +1128,7 @@ impl BpfManager {
     }
 
     async fn rebuild_map_entry(&mut self, id: u32, program: &mut Program) {
-        let map_owner_id = match program.data() {
-            Ok(data) => data.map_owner_id(),
-            Err(_) => {
-                warn!("unable to retrieve data for {id} retrieving map_owner_id on rebuild");
-                return;
-            }
-        };
+        let map_owner_id = program.get_data().get_map_owner_id().unwrap();
         let index = match map_owner_id {
             Some(i) => i,
             None => id,
@@ -1102,32 +1139,25 @@ impl BpfManager {
 
             // This program has not been inserted yet, so update it with the
             // updated map_used_by.
-            if let Ok(data) = program.data_mut() {
-                data.set_maps_used_by(Some(map.used_by.clone()));
-            } else {
-                warn!("unable to retrieve data for {id} during rebuild of maps");
-            }
+            program
+                .get_data_mut()
+                .set_maps_used_by(map.used_by.clone())
+                .expect("unable to set map_used_by");
 
             // Update all the other programs using the same map with the updated map_used_by.
             for used_by_id in map.used_by.iter() {
                 // program may not exist yet on rebuild, so ignore if not there
                 if let Some(prog) = self.programs.get_mut(used_by_id) {
-                    if let Ok(data) = prog.data_mut() {
-                        data.set_maps_used_by(Some(map.used_by.clone()));
-                    } else {
-                        warn!("unable to retrieve data for {used_by_id} when setting map_used_by on rebuild");
-                    }
+                    prog.get_data_mut()
+                        .set_maps_used_by(map.used_by.clone())
+                        .unwrap();
                 }
             }
         } else {
             let map = BpfMap { used_by: vec![id] };
             self.maps.insert(index, map);
 
-            if let Ok(data) = program.data_mut() {
-                data.set_maps_used_by(Some(vec![id]));
-            } else {
-                warn!("unable to retrieve data for {id} during rebuild of maps");
-            }
+            program.get_data_mut().set_maps_used_by(vec![id]).unwrap();
         }
     }
 }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -91,7 +91,8 @@ pub(crate) fn execute_service(args: &ServiceArgs, config: &Config) -> anyhow::Re
             set_dir_permissions(RTDIR, RTDIR_MODE).await;
             set_dir_permissions(STDIR, STDIR_MODE).await;
 
-            serve(config, CFGDIR_STATIC_PROGRAMS, args.csi_support).await?;
+            //TODO https://github.com/bpfman/bpfman/issues/881
+            serve(config, args.csi_support).await?;
             Ok(())
         })
 }

--- a/bpfman/src/errors.rs
+++ b/bpfman/src/errors.rs
@@ -54,4 +54,6 @@ pub enum BpfmanError {
         program_type: String,
         container_pid: i32,
     },
+    #[error("{0}: {1}")]
+    DatabaseError(String, String),
 }

--- a/bpfman/src/main.rs
+++ b/bpfman/src/main.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
+use bpfman_api::util::directories::STDIR_DB;
 use clap::Parser;
+use lazy_static::lazy_static;
+use sled::{Config, Db};
 
 mod bpf;
 mod cli;
@@ -17,6 +20,13 @@ mod storage;
 mod utils;
 
 const BPFMAN_ENV_LOG_LEVEL: &str = "RUST_LOG";
+
+lazy_static! {
+    pub static ref ROOT_DB: Db = Config::default()
+        .path(STDIR_DB)
+        .open()
+        .expect("Unable to open root database");
+}
 
 fn main() -> anyhow::Result<()> {
     let cli = cli::args::Cli::parse();

--- a/bpfman/src/main.rs
+++ b/bpfman/src/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
-
+#[cfg(not(test))]
 use bpfman_api::util::directories::STDIR_DB;
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -21,11 +21,20 @@ mod utils;
 
 const BPFMAN_ENV_LOG_LEVEL: &str = "RUST_LOG";
 
+#[cfg(not(test))]
 lazy_static! {
     pub static ref ROOT_DB: Db = Config::default()
         .path(STDIR_DB)
         .open()
         .expect("Unable to open root database");
+}
+
+#[cfg(test)]
+lazy_static! {
+    pub static ref ROOT_DB: Db = Config::default()
+        .temporary(true)
+        .open()
+        .expect("Unable to open temporary root database");
 }
 
 fn main() -> anyhow::Result<()> {

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -37,12 +37,10 @@ impl Dispatcher {
             .first()
             .ok_or_else(|| BpfmanError::Error("No programs to load".to_string()))?;
         let if_index = p
-            .if_index()
+            .if_index()?
             .ok_or_else(|| BpfmanError::Error("missing ifindex".to_string()))?;
-        let if_name = p
-            .if_name()
-            .ok_or_else(|| BpfmanError::Error("missing ifname".to_string()))?;
-        let direction = p.direction();
+        let if_name = p.if_name()?;
+        let direction = p.direction()?;
         let xdp_mode = if let Some(c) = config {
             c.xdp_mode
         } else {
@@ -53,7 +51,7 @@ impl Dispatcher {
                 let x = XdpDispatcher::new(
                     xdp_mode,
                     &if_index,
-                    if_name,
+                    if_name.to_string(),
                     programs,
                     revision,
                     old_dispatcher,
@@ -63,12 +61,10 @@ impl Dispatcher {
                 Dispatcher::Xdp(x)
             }
             ProgramType::Tc => {
-                let direction = direction
-                    .ok_or_else(|| BpfmanError::Error("direction required".to_string()))?;
                 let t = TcDispatcher::new(
-                    direction,
+                    direction.expect("missing direction"),
                     &if_index,
-                    if_name,
+                    if_name.to_string(),
                     programs,
                     revision,
                     old_dispatcher,

--- a/bpfman/src/serve.rs
+++ b/bpfman/src/serve.rs
@@ -9,13 +9,10 @@ use std::{
 
 use anyhow::anyhow;
 use bpfman_api::{
-    config::Config,
-    util::directories::{RTPATH_BPFMAN_SOCKET, STDIR_DB},
-    v1::bpfman_server::BpfmanServer,
+    config::Config, util::directories::RTPATH_BPFMAN_SOCKET, v1::bpfman_server::BpfmanServer,
 };
 use libsystemd::activation::IsType;
 use log::{debug, info};
-use sled::Config as DbConfig;
 use tokio::{
     join,
     net::UnixListener,
@@ -34,6 +31,7 @@ use crate::{
     static_program::get_static_programs,
     storage::StorageManager,
     utils::{set_file_permissions, SOCK_MODE},
+    ROOT_DB,
 };
 
 pub async fn serve(
@@ -55,17 +53,12 @@ pub async fn serve(
     let allow_unsigned = config.signing.as_ref().map_or(true, |s| s.allow_unsigned);
     let (itx, irx) = mpsc::channel(32);
 
-    let database = DbConfig::default()
-        .path(STDIR_DB)
-        .open()
-        .expect("Unable to open database");
-
-    let mut image_manager = ImageManager::new(database.clone(), allow_unsigned, irx).await?;
+    let mut image_manager = ImageManager::new(ROOT_DB.clone(), allow_unsigned, irx).await?;
     let image_manager_handle = tokio::spawn(async move {
         image_manager.run(use_activity_timer).await;
     });
 
-    let mut bpf_manager = BpfManager::new(config.clone(), rx, itx, database);
+    let mut bpf_manager = BpfManager::new(config.clone(), rx, itx);
     bpf_manager.rebuild_state().await?;
 
     let static_programs = get_static_programs(static_program_path).await?;

--- a/bpfman/src/static_program.rs
+++ b/bpfman/src/static_program.rs
@@ -1,262 +1,264 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
 
-use anyhow::bail;
-use bpfman_api::{
-    util::directories::CFGDIR_STATIC_PROGRAMS, ProgramType, TcProceedOn, XdpProceedOn,
-};
-use log::{info, warn};
-use serde::Deserialize;
-use tokio::fs;
+// TODO(astoycos) see issue #881
+// use std::{
+//     collections::HashMap,
+//     path::{Path, PathBuf},
+// };
 
-use crate::{
-    command::{
-        Direction,
-        Location::{File, Image},
-        Program, ProgramData, TcProgram, TracepointProgram, XdpProgram,
-    },
-    oci_utils::image_manager::BytecodeImage,
-    utils::read_to_string,
-};
+// use anyhow::bail;
+// use bpfman_api::{
+//     util::directories::CFGDIR_STATIC_PROGRAMS, ProgramType, TcProceedOn, XdpProceedOn,
+// };
+// use log::{info, warn};
+// use serde::Deserialize;
+// use tokio::fs;
 
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct XdpAttachInfo {
-    pub(crate) priority: i32,
-    pub(crate) iface: String,
-    pub(crate) proceed_on: XdpProceedOn,
-}
+// use crate::{
+//     command::{
+//         Direction,
+//         Location::{File, Image},
+//         Program, ProgramData, TcProgram, TracepointProgram, XdpProgram,
+//     },
+//     oci_utils::image_manager::BytecodeImage,
+//     utils::read_to_string,
+// };
 
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct TcAttachInfo {
-    pub(crate) priority: i32,
-    pub(crate) iface: String,
-    pub(crate) proceed_on: TcProceedOn,
-    pub(crate) direction: Direction,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct TracepointAttachInfo {
-    pub(crate) tracepoint: String,
-}
-
-// TODO not yet implemented
 // #[derive(Debug, Clone, Deserialize)]
-// pub(crate) struct KprobeAttachInfo {
-//     pub(crate) fn_name: String,
-//     pub(crate) offset: u64,
-//     pub(crate) retprobe: bool,
-//     pub(crate) container_pid: Option<i32>,
+// pub(crate) struct XdpAttachInfo {
+//     pub(crate) priority: i32,
+//     pub(crate) iface: String,
+//     pub(crate) proceed_on: XdpProceedOn,
 // }
 
 // #[derive(Debug, Clone, Deserialize)]
-// pub(crate) struct UprobeAttachInfo {
-//     pub(crate) fn_name: Option<String>,
-//     pub(crate) offset: u64,
-//     pub(crate) target: String,
-//     pub(crate) retprobe: bool,
-//     pub(crate) pid: Option<i32>,
-//     pub(crate) container_pid: Option<i32>,
+// pub(crate) struct TcAttachInfo {
+//     pub(crate) priority: i32,
+//     pub(crate) iface: String,
+//     pub(crate) proceed_on: TcProceedOn,
+//     pub(crate) direction: Direction,
 // }
 
-#[derive(Debug, Deserialize, Clone)]
-pub struct StaticProgramEntry {
-    bytecode_image: Option<BytecodeImage>,
-    file_path: Option<String>,
-    name: String,
-    global_data: HashMap<String, Vec<u8>>,
-    program_type: ProgramType,
-    xdp_attach: Option<XdpAttachInfo>,
-    tc_attach: Option<TcAttachInfo>,
-    tracepoint_attach: Option<TracepointAttachInfo>,
-}
+// #[derive(Debug, Clone, Deserialize)]
+// pub(crate) struct TracepointAttachInfo {
+//     pub(crate) tracepoint: String,
+// }
 
-impl StaticProgramEntry {
-    pub(crate) fn get_bytecode_image(self) -> Option<BytecodeImage> {
-        self.bytecode_image
-    }
-}
+// // TODO not yet implemented
+// // #[derive(Debug, Clone, Deserialize)]
+// // pub(crate) struct KprobeAttachInfo {
+// //     pub(crate) fn_name: String,
+// //     pub(crate) offset: u64,
+// //     pub(crate) retprobe: bool,
+// //     pub(crate) container_pid: Option<i32>,
+// // }
 
-#[derive(Debug, Deserialize)]
-pub struct NetworkAttach {
-    pub interface: String,
-    pub priority: i32,
-    pub proceed_on: Vec<String>,
-}
+// // #[derive(Debug, Clone, Deserialize)]
+// // pub(crate) struct UprobeAttachInfo {
+// //     pub(crate) fn_name: Option<String>,
+// //     pub(crate) offset: u64,
+// //     pub(crate) target: String,
+// //     pub(crate) retprobe: bool,
+// //     pub(crate) pid: Option<i32>,
+// //     pub(crate) container_pid: Option<i32>,
+// // }
 
-#[derive(Debug, Deserialize, Clone)]
-struct StaticProgramManager {
-    #[serde(skip)]
-    path: PathBuf,
-    programs: Vec<StaticProgramEntry>,
-}
+// #[derive(Debug, Deserialize, Clone)]
+// pub struct StaticProgramEntry {
+//     bytecode_image: Option<BytecodeImage>,
+//     file_path: Option<String>,
+//     name: String,
+//     global_data: HashMap<String, Vec<u8>>,
+//     program_type: ProgramType,
+//     xdp_attach: Option<XdpAttachInfo>,
+//     tc_attach: Option<TcAttachInfo>,
+//     tracepoint_attach: Option<TracepointAttachInfo>,
+// }
 
-impl StaticProgramManager {
-    async fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
-        if let Ok(mut entries) = fs::read_dir(self.path).await {
-            while let Some(file) = entries.next_entry().await? {
-                let path = &file.path();
-                // ignore directories
-                if path.is_dir() {
-                    continue;
-                }
+// impl StaticProgramEntry {
+//     pub(crate) fn get_bytecode_image(self) -> Option<BytecodeImage> {
+//         self.bytecode_image
+//     }
+// }
 
-                if let Ok(contents) = read_to_string(path).await {
-                    let program = toml::from_str(&contents)?;
+// #[derive(Debug, Deserialize)]
+// pub struct NetworkAttach {
+//     pub interface: String,
+//     pub priority: i32,
+//     pub proceed_on: Vec<String>,
+// }
 
-                    self.programs.push(program);
-                } else {
-                    warn!("Failed to parse program static file {:?}.", path.to_str());
-                    continue;
-                }
-            }
-        }
-        Ok(())
-    }
-}
+// #[derive(Debug, Deserialize, Clone)]
+// struct StaticProgramManager {
+//     #[serde(skip)]
+//     path: PathBuf,
+//     programs: Vec<StaticProgramEntry>,
+// }
 
-pub(crate) async fn get_static_programs<P: AsRef<Path>>(
-    path: P,
-) -> Result<Vec<Program>, anyhow::Error> {
-    let static_program_manager = StaticProgramManager {
-        path: path.as_ref().to_path_buf(),
-        programs: Vec::new(),
-    };
+// impl StaticProgramManager {
+//     async fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
+//         if let Ok(mut entries) = fs::read_dir(self.path).await {
+//             while let Some(file) = entries.next_entry().await? {
+//                 let path = &file.path();
+//                 // ignore directories
+//                 if path.is_dir() {
+//                     continue;
+//                 }
 
-    static_program_manager
-        .clone()
-        .programs_from_directory()
-        .await?;
+//                 if let Ok(contents) = read_to_string(path).await {
+//                     let program = toml::from_str(&contents)?;
 
-    let mut programs: Vec<Program> = Vec::new();
+//                     self.programs.push(program);
+//                 } else {
+//                     warn!("Failed to parse program static file {:?}.", path.to_str());
+//                     continue;
+//                 }
+//             }
+//         }
+//         Ok(())
+//     }
+// }
 
-    // Load any static programs first
-    if !static_program_manager.programs.is_empty() {
-        info!("Loading static programs from {CFGDIR_STATIC_PROGRAMS}");
-        for program in static_program_manager.programs {
-            let location = match program.file_path {
-                Some(p) => File(p),
-                None => Image(
-                    program
-                        .clone()
-                        .get_bytecode_image()
-                        .expect("static program did not provide bytecode"),
-                ),
-            };
+// pub(crate) async fn get_static_programs<P: AsRef<Path>>(
+//     path: P,
+// ) -> Result<Vec<Program>, anyhow::Error> {
+//     let static_program_manager = StaticProgramManager {
+//         path: path.as_ref().to_path_buf(),
+//         programs: Vec::new(),
+//     };
 
-            let data = ProgramData::new(
-                location,
-                program.name,
-                HashMap::new(),
-                program.global_data,
-                None,
-            );
-            let prog = match program.program_type {
-                ProgramType::Xdp => {
-                    if let Some(m) = program.xdp_attach {
-                        Program::Xdp(XdpProgram::new(data, m.priority, m.iface, m.proceed_on))
-                    } else {
-                        bail!("invalid info for xdp program")
-                    }
-                }
-                ProgramType::Tc => {
-                    if let Some(m) = program.tc_attach {
-                        Program::Tc(TcProgram::new(
-                            data,
-                            m.priority,
-                            m.iface,
-                            m.proceed_on,
-                            m.direction,
-                        ))
-                    } else {
-                        bail!("invalid attach type for tc program")
-                    }
-                }
-                ProgramType::Tracepoint => {
-                    if let Some(m) = program.tracepoint_attach {
-                        Program::Tracepoint(TracepointProgram::new(data, m.tracepoint))
-                    } else {
-                        bail!("invalid attach type for tc program")
-                    }
-                }
-                m => bail!("program type not yet supported to load statically: {:?}", m),
-            };
+//     static_program_manager
+//         .clone()
+//         .programs_from_directory()
+//         .await?;
 
-            programs.push(prog)
-        }
-    };
+//     let mut programs: Vec<Program> = Vec::new();
 
-    Ok(programs)
-}
+//     // Load any static programs first
+//     if !static_program_manager.programs.is_empty() {
+//         info!("Loading static programs from {CFGDIR_STATIC_PROGRAMS}");
+//         for program in static_program_manager.programs {
+//             let location = match program.file_path {
+//                 Some(p) => File(p),
+//                 None => Image(
+//                     program
+//                         .clone()
+//                         .get_bytecode_image()
+//                         .expect("static program did not provide bytecode"),
+//                 ),
+//             };
 
-#[cfg(test)]
-mod test {
-    use super::*;
+//             let data = ProgramData::new(
+//                 location,
+//                 program.name,
+//                 HashMap::new(),
+//                 program.global_data,
+//                 None,
+//             );
+//             let prog = match program.program_type {
+//                 ProgramType::Xdp => {
+//                     if let Some(m) = program.xdp_attach {
+//                         Program::Xdp(XdpProgram::new(data, m.priority, m.iface, m.proceed_on))
+//                     } else {
+//                         bail!("invalid info for xdp program")
+//                     }
+//                 }
+//                 ProgramType::Tc => {
+//                     if let Some(m) = program.tc_attach {
+//                         Program::Tc(TcProgram::new(
+//                             data,
+//                             m.priority,
+//                             m.iface,
+//                             m.proceed_on,
+//                             m.direction,
+//                         ))
+//                     } else {
+//                         bail!("invalid attach type for tc program")
+//                     }
+//                 }
+//                 ProgramType::Tracepoint => {
+//                     if let Some(m) = program.tracepoint_attach {
+//                         Program::Tracepoint(TracepointProgram::new(data, m.tracepoint))
+//                     } else {
+//                         bail!("invalid attach type for tc program")
+//                     }
+//                 }
+//                 m => bail!("program type not yet supported to load statically: {:?}", m),
+//             };
 
-    #[tokio::test]
-    async fn test_parse_program_from_invalid_path() {
-        let static_program_manager = StaticProgramManager {
-            path: "/tmp/file.toml".into(),
-            programs: Vec::new(),
-        };
+//             programs.push(prog)
+//         }
+//     };
 
-        static_program_manager
-            .clone()
-            .programs_from_directory()
-            .await
-            .unwrap();
-        assert!(static_program_manager.programs.is_empty())
-    }
+//     Ok(programs)
+// }
 
-    #[test]
-    fn test_parse_single_file() {
-        let input: &str = r#"
-        [[programs]]
-        name = "firewall"
-        file_path = "/opt/bin/myapp/lib/myebpf.o"
-        global_data = { }
-        program_type ="Xdp"
-        xdp_attach = { iface = "eth0", priority = 50, proceed_on = [], position=0 }
+// #[cfg(test)]
+// mod test {
+//     use super::*;
 
-        [[programs]]
-        name = "pass"
-        bytecode_image = { image_url = "quay.io/bpfman-bytecode/xdp_pass:latest", image_pull_policy="Always" }
-        global_data = { }
-        program_type ="Xdp"
-        xdp_attach = { iface = "eth0", priority = 55, proceed_on = [], position=0 }
+//     #[tokio::test]
+//     async fn test_parse_program_from_invalid_path() {
+//         let static_program_manager = StaticProgramManager {
+//             path: "/tmp/file.toml".into(),
+//             programs: Vec::new(),
+//         };
 
-        [[programs]]
-        name = "counter"
-        bytecode_image = { image_url = "quay.io/bpfman-bytecode/xdp_pass:latest", image_pull_policy="Always" }
-        global_data = { }
-        program_type ="Tc"
-        tc_attach = { iface = "eth0", priority = 55, proceed_on = [], position=0, direction="Ingress" }
-        
-        [[programs]]
-        name = "tracepoint"
-        bytecode_image = { image_url = "quay.io/bpfman-bytecode/tracepoint:latest", image_pull_policy="Always" }
-        global_data = { }
-        program_type ="Tracepoint"
-        tracepoint_attach = { tracepoint = "syscalls/sys_enter_openat" }
-        "#;
+//         static_program_manager
+//             .clone()
+//             .programs_from_directory()
+//             .await
+//             .unwrap();
+//         assert!(static_program_manager.programs.is_empty())
+//     }
 
-        let mut programs: StaticProgramManager =
-            toml::from_str(input).expect("error parsing toml input");
-        match programs.programs.pop() {
-            Some(i) => {
-                if let Some(m) = i.xdp_attach {
-                    assert_eq!(m.iface, "eth0");
-                    assert_eq!(m.priority, 55);
-                } else if let Some(m) = i.tracepoint_attach {
-                    assert_eq!(m.tracepoint, "syscalls/sys_enter_openat")
-                } else {
-                    panic!("incorrect attach type")
-                }
-            }
-            None => panic!("expected programs to be present"),
-        }
-    }
-}
+//     #[test]
+//     fn test_parse_single_file() {
+//         let input: &str = r#"
+//         [[programs]]
+//         name = "firewall"
+//         file_path = "/opt/bin/myapp/lib/myebpf.o"
+//         global_data = { }
+//         program_type ="Xdp"
+//         xdp_attach = { iface = "eth0", priority = 50, proceed_on = [], position=0 }
+
+//         [[programs]]
+//         name = "pass"
+//         bytecode_image = { image_url = "quay.io/bpfman-bytecode/xdp_pass:latest", image_pull_policy="Always" }
+//         global_data = { }
+//         program_type ="Xdp"
+//         xdp_attach = { iface = "eth0", priority = 55, proceed_on = [], position=0 }
+
+//         [[programs]]
+//         name = "counter"
+//         bytecode_image = { image_url = "quay.io/bpfman-bytecode/xdp_pass:latest", image_pull_policy="Always" }
+//         global_data = { }
+//         program_type ="Tc"
+//         tc_attach = { iface = "eth0", priority = 55, proceed_on = [], position=0, direction="Ingress" }
+
+//         [[programs]]
+//         name = "tracepoint"
+//         bytecode_image = { image_url = "quay.io/bpfman-bytecode/tracepoint:latest", image_pull_policy="Always" }
+//         global_data = { }
+//         program_type ="Tracepoint"
+//         tracepoint_attach = { tracepoint = "syscalls/sys_enter_openat" }
+//         "#;
+
+//         let mut programs: StaticProgramManager =
+//             toml::from_str(input).expect("error parsing toml input");
+//         match programs.programs.pop() {
+//             Some(i) => {
+//                 if let Some(m) = i.xdp_attach {
+//                     assert_eq!(m.iface, "eth0");
+//                     assert_eq!(m.priority, 55);
+//                 } else if let Some(m) = i.tracepoint_attach {
+//                     assert_eq!(m.tracepoint, "syscalls/sys_enter_openat")
+//                 } else {
+//                     panic!("incorrect attach type")
+//                 }
+//             }
+//             None => panic!("expected programs to be present"),
+//         }
+//     }
+// }

--- a/bpfman/src/storage.rs
+++ b/bpfman/src/storage.rs
@@ -151,20 +151,20 @@ impl Node for CsiNode {
                             let prog_data = results
                                 .into_iter()
                                 .find(|p| {
-                                    if let Ok(data) = p.data() {
-                                        data.metadata().get(OPERATOR_PROGRAM_KEY)
-                                            == Some(program_name)
-                                    } else {
-                                        false
-                                    }
+                                    p.get_data()
+                                        .get_metadata()
+                                        .expect("unable to get program metadata")
+                                        .get(OPERATOR_PROGRAM_KEY)
+                                        == Some(program_name)
                                 })
                                 .ok_or(Status::new(
                                     NPV_NOT_FOUND.into(),
                                     format!("Bpfman Program {program_name} not found"),
                                 ))?;
                             Ok(prog_data
-                                .data().expect("program data is valid because we just checked it")
-                                .map_pin_path()
+                                .get_data()
+                                .get_map_pin_path()
+                                .map_err(|e| Status::aborted(format!("failed to get map_pin_path: {e}")))?
                                 .expect("map pin path should be set since the program is already loaded")
                                 .to_owned())
                         }


### PR DESCRIPTION
Works towards #860 

This commit is huge and it re-writes the memory layout for all Program
related information. More specifically it removed the KernelInfo struct
and collapses all information for bpfman programs AND other programs
into a single Program enum. This program Enum is essentially a wrapper
for a sled database tree. Each program will get it's own sled database tree
and anytime a getter/setter is called on a Program it will interact with
the database.

Special considerations: 

- On load we have to use a random number generator to generate a unique id
for the program tree prior to load.  Once the program is successfully
loaded we can then swap the root index of the database tree to the
correct id.  From then on it's always safe to assume the tree name will
correlate to a given program id.

- On list and get we will write the kernel information for programs not loaded via bpfman to the database in ONLY TEMPORARILY, specifically they will be written in bpf.rs's list_programs and deleted from the db in rpc.rs.  This will most likey be removed when removing our GRPC service, and we can instead write a function to just return the necessary information from aya::program::loaded_programs.

- The ROOT DB last static handle is the global "root" for our sled db instance, currently we use it in the BPFMANAGER and IMAGEMANAGER and we make sure to flush before exiting either of those threads.

- TODO The next PR will try and move even more of the Dispatcher related state to the in memory-db with the goal of being able to completely remove 90% of our "rebuild" logic.

**Please focus review on our internal API (command.rs) which contains many of the core bits.**