### PR TITLE
bpfman: Make ImageManager a singleton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,20 +209,23 @@ jobs:
       - name: Build bpfman
         run: cargo build --verbose
 
-      - name: Run the bpfman installer
-        run: sudo ./scripts/setup.sh install
+      # Disable testing using the systemd socket activation for now.
+      # We'll use the RPM test framework to test this soon.
 
-      - name: Give certs time to be created
-        run: sleep 5
+      # - name: Run the bpfman installer
+      #   run: sudo ./scripts/setup.sh install
 
-      - name: Verify the bpfman systemd service is active
-        run: systemctl is-active bpfman.socket
+      # - name: Give certs time to be created
+      #   run: sleep 5
 
-      - name: Verify the CLI can reach bpfman
-        run: sudo bpfman list
+      # - name: Verify the bpfman systemd service is active
+      #   run: systemctl is-active bpfman.socket
 
-      - name: Stop the bpfman systemd service
-        run: sudo systemctl stop bpfman
+      # - name: Verify the CLI can reach bpfman
+      #   run: sudo bpfman list
+
+      # - name: Stop the bpfman systemd service
+      #   run: sudo systemctl stop bpfman
 
       - name: Run integration tests
         run: cargo xtask integration-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,11 +377,12 @@ dependencies = [
  "lazy_static",
  "libsystemd 0.7.0",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-sys",
  "nix 0.27.1",
  "oci-distribution",
  "rand",
- "rtnetlink",
  "serde",
  "serde_json",
  "sha2",
@@ -1885,14 +1886,14 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "dd9ccdfabb457e05c7c61e66eb39262a204fbb376c53968b5e52dce15b423fc5"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
  "byteorder",
  "libc",
+ "log",
  "netlink-packet-core",
  "netlink-packet-utils",
 ]
@@ -1910,31 +1911,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-proto"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842c6770fc4bb33dd902f41829c61ef872b8e38de1405aa0b938b27b8fba12c3"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-sys",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "netlink-sys"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
  "bytes",
- "futures",
  "libc",
  "log",
- "tokio",
 ]
 
 [[package]]
@@ -2862,24 +2846,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.26.4",
- "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,9 @@ inventory = { version = "0.3", default-features = false }
 lazy_static = { version = "1", default-features = false }
 libsystemd = { version = "0.7.0", default-features = false }
 log = { version = "0.4", default-features = false }
-netlink-packet-route = { version = "0.17.1", default-features = false }
+netlink-packet-core = { version = "0.7.0", default-features = false }
+netlink-packet-route = { version = "0.18.0", default-features = false }
+netlink-sys = { version = "0.8.5", default-features = false }
 nix = { version = "0.27", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
 opentelemetry = { version = "0.21.0", default-features = false }
@@ -60,7 +62,6 @@ prost-types = { version = "0.12.3", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 regex = { version = "1.9.6", default-features = false }
-rtnetlink = { version = "0.13.1", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -36,7 +36,9 @@ hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
 libsystemd = { workspace = true }
 log = { workspace = true }
+netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
+netlink-sys = { workspace = true }
 nix = { workspace = true, features = [
     "fs",
     "mount",
@@ -50,7 +52,6 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "trust-dns",
 ] }
 rand = { workspace = true }
-rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -87,9 +87,9 @@ pub(crate) fn execute_service(args: &ServiceArgs, config: &Config) -> anyhow::Re
             create_dir_all(CFGDIR_STATIC_PROGRAMS)
                 .context("unable to create static programs directory")?;
 
-            set_dir_permissions(CFGDIR, CFGDIR_MODE).await;
-            set_dir_permissions(RTDIR, RTDIR_MODE).await;
-            set_dir_permissions(STDIR, STDIR_MODE).await;
+            set_dir_permissions(CFGDIR, CFGDIR_MODE);
+            set_dir_permissions(RTDIR, RTDIR_MODE);
+            set_dir_permissions(STDIR, STDIR_MODE);
 
             //TODO https://github.com/bpfman/bpfman/issues/881
             serve(config, args.csi_support).await?;

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -23,12 +23,12 @@ use chrono::{prelude::DateTime, Local};
 use log::info;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::oneshot;
 
 use crate::{
     errors::BpfmanError,
     multiprog::{DispatcherId, DispatcherInfo},
-    oci_utils::image_manager::{BytecodeImage, Command as ImageManagerCommand},
+    oci_utils::image_manager::{BytecodeImage, IMAGE_MANAGER},
     utils::{
         bytes_to_bool, bytes_to_i32, bytes_to_string, bytes_to_u32, bytes_to_u64, bytes_to_usize,
     },
@@ -95,36 +95,24 @@ pub(crate) enum Location {
 impl Location {
     async fn get_program_bytes(
         &self,
-        image_manager: Sender<ImageManagerCommand>,
+        allow_unsigned: bool,
     ) -> Result<(Vec<u8>, String), BpfmanError> {
         match self {
             Location::File(l) => Ok((crate::utils::read(l).await?, "".to_owned())),
             Location::Image(l) => {
-                let (tx, rx) = oneshot::channel();
-                image_manager
-                    .send(ImageManagerCommand::Pull {
-                        image: l.image_url.clone(),
-                        pull_policy: l.image_pull_policy.clone(),
-                        username: l.username.clone(),
-                        password: l.password.clone(),
-                        resp: tx,
-                    })
-                    .await
-                    .map_err(|e| BpfmanError::RpcSendError(e.into()))?;
-                let (path, bpf_function_name) = rx
-                    .await
-                    .map_err(BpfmanError::RpcRecvError)?
+                let mut image_manager = IMAGE_MANAGER.lock().expect("Unable to lock image manager");
+                let (path, bpf_function_name) = image_manager
+                    .pull(
+                        &l.image_url,
+                        l.image_pull_policy.clone(),
+                        l.username.clone(),
+                        l.password.clone(),
+                        allow_unsigned,
+                    )
                     .map_err(BpfmanError::BpfBytecodeError)?;
 
-                let (tx, rx) = oneshot::channel();
-                image_manager
-                    .send(ImageManagerCommand::GetBytecode { path, resp: tx })
-                    .await
-                    .map_err(|e| BpfmanError::RpcSendError(e.into()))?;
-
-                let bytecode = rx
-                    .await
-                    .map_err(BpfmanError::RpcRecvError)?
+                let bytecode = image_manager
+                    .get_bytecode(path)
                     .map_err(BpfmanError::BpfBytecodeError)?;
 
                 Ok((bytecode, bpf_function_name))
@@ -777,10 +765,10 @@ impl ProgramData {
 
     pub(crate) async fn set_program_bytes(
         &mut self,
-        image_manager: Sender<ImageManagerCommand>,
+        allow_unsigned: bool,
     ) -> Result<(), BpfmanError> {
         let loc = self.get_location()?;
-        match loc.get_program_bytes(image_manager).await {
+        match loc.get_program_bytes(allow_unsigned).await {
             Err(e) => Err(e),
             Ok((v, s)) => {
                 match loc {

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -93,12 +93,9 @@ pub(crate) enum Location {
 }
 
 impl Location {
-    async fn get_program_bytes(
-        &self,
-        allow_unsigned: bool,
-    ) -> Result<(Vec<u8>, String), BpfmanError> {
+    fn get_program_bytes(&self, allow_unsigned: bool) -> Result<(Vec<u8>, String), BpfmanError> {
         match self {
-            Location::File(l) => Ok((crate::utils::read(l).await?, "".to_owned())),
+            Location::File(l) => Ok((std::fs::read(l)?, "".to_owned())),
             Location::Image(l) => {
                 let mut image_manager = IMAGE_MANAGER.lock().expect("Unable to lock image manager");
                 let (path, bpf_function_name) = image_manager
@@ -763,12 +760,9 @@ impl ProgramData {
         self.program_bytes = Vec::new();
     }
 
-    pub(crate) async fn set_program_bytes(
-        &mut self,
-        allow_unsigned: bool,
-    ) -> Result<(), BpfmanError> {
+    pub(crate) fn set_program_bytes(&mut self, allow_unsigned: bool) -> Result<(), BpfmanError> {
         let loc = self.get_location()?;
-        match loc.get_program_bytes(allow_unsigned).await {
+        match loc.get_program_bytes(allow_unsigned) {
             Err(e) => Err(e),
             Ok((v, s)) => {
                 match loc {

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -10,13 +10,11 @@ use bpfman_api::{
 };
 use log::debug;
 pub use tc::TcDispatcher;
-use tokio::sync::mpsc::Sender;
 pub use xdp::XdpDispatcher;
 
 use crate::{
     command::{Direction, Program},
     errors::BpfmanError,
-    oci_utils::image_manager::Command as ImageManagerCommand,
 };
 
 pub(crate) enum Dispatcher {
@@ -30,7 +28,7 @@ impl Dispatcher {
         programs: &mut [&mut Program],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
-        image_manager: Sender<ImageManagerCommand>,
+        allow_unsigned: bool,
     ) -> Result<Dispatcher, BpfmanError> {
         debug!("Dispatcher::new()");
         let p = programs
@@ -55,7 +53,7 @@ impl Dispatcher {
                     programs,
                     revision,
                     old_dispatcher,
-                    image_manager,
+                    allow_unsigned,
                 )
                 .await?;
                 Dispatcher::Xdp(x)
@@ -68,7 +66,7 @@ impl Dispatcher {
                     programs,
                     revision,
                     old_dispatcher,
-                    image_manager,
+                    allow_unsigned,
                 )
                 .await?;
                 Dispatcher::Tc(t)

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -23,7 +23,7 @@ pub(crate) enum Dispatcher {
 }
 
 impl Dispatcher {
-    pub async fn new(
+    pub fn new(
         config: Option<&InterfaceConfig>,
         programs: &mut [&mut Program],
         revision: u32,
@@ -54,8 +54,7 @@ impl Dispatcher {
                     revision,
                     old_dispatcher,
                     allow_unsigned,
-                )
-                .await?;
+                )?;
                 Dispatcher::Xdp(x)
             }
             ProgramType::Tc => {
@@ -67,8 +66,7 @@ impl Dispatcher {
                     revision,
                     old_dispatcher,
                     allow_unsigned,
-                )
-                .await?;
+                )?;
                 Dispatcher::Tc(t)
             }
             _ => return Err(BpfmanError::DispatcherNotRequired),

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -42,7 +42,7 @@ pub struct XdpDispatcher {
 // dropped before we call await.
 #[allow(clippy::await_holding_lock)]
 impl XdpDispatcher {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         mode: XdpMode,
         if_index: &u32,
         if_name: String,
@@ -121,7 +121,7 @@ impl XdpDispatcher {
             loader: Some(loader),
             program_name: Some(bpf_function_name),
         };
-        dispatcher.attach_extensions(&mut extensions).await?;
+        dispatcher.attach_extensions(&mut extensions)?;
         dispatcher.attach()?;
         dispatcher.save()?;
         if let Some(mut old) = old_dispatcher {
@@ -172,10 +172,7 @@ impl XdpDispatcher {
         Ok(())
     }
 
-    async fn attach_extensions(
-        &mut self,
-        extensions: &mut [&mut XdpProgram],
-    ) -> Result<(), BpfmanError> {
+    fn attach_extensions(&mut self, extensions: &mut [&mut XdpProgram]) -> Result<(), BpfmanError> {
         debug!(
             "XdpDispatcher::attach_extensions() for if_index {}, revision {}",
             self.if_index, self.revision
@@ -258,7 +255,7 @@ impl XdpDispatcher {
                 if v.get_data().get_map_pin_path()?.is_none() {
                     let map_pin_path = calc_map_pin_path(id);
                     v.get_data_mut().set_map_pin_path(&map_pin_path)?;
-                    create_map_pin_path(&map_pin_path).await?;
+                    create_map_pin_path(&map_pin_path)?;
 
                     for (name, map) in loader.maps_mut() {
                         if !should_map_be_pinned(name) {

--- a/bpfman/src/oci_utils/client.rs
+++ b/bpfman/src/oci_utils/client.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use oci_distribution::{
+    client::{ClientConfig, ImageData},
+    errors::OciDistributionError,
+    manifest::OciImageManifest,
+    secrets::RegistryAuth,
+    Client as OciClient, Reference,
+};
+use tokio::runtime::Runtime;
+
+pub struct Client {
+    inner: OciClient,
+    rt: Runtime,
+}
+
+impl Client {
+    pub fn new(config: ClientConfig) -> Result<Self, anyhow::Error> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let inner = OciClient::new(config);
+        Ok(Self { inner, rt })
+    }
+
+    pub fn pull_manifest_and_config(
+        &mut self,
+        image: &Reference,
+        auth: &RegistryAuth,
+    ) -> Result<(OciImageManifest, String, String), OciDistributionError> {
+        self.rt
+            .block_on(async { self.inner.pull_manifest_and_config(image, auth).await })
+    }
+
+    pub fn pull(
+        &mut self,
+        image: &Reference,
+        auth: &RegistryAuth,
+        accepted_media_types: Vec<&str>,
+    ) -> Result<ImageData, OciDistributionError> {
+        self.rt
+            .block_on(async { self.inner.pull(image, auth, accepted_media_types).await })
+    }
+}

--- a/bpfman/src/oci_utils/client.rs
+++ b/bpfman/src/oci_utils/client.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
+use log::debug;
 use oci_distribution::{
     client::{ClientConfig, ImageData},
     errors::OciDistributionError,
@@ -17,6 +18,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(config: ClientConfig) -> Result<Self, anyhow::Error> {
+        debug!("Creating OCI client");
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;

--- a/bpfman/src/oci_utils/cosign.rs
+++ b/bpfman/src/oci_utils/cosign.rs
@@ -24,6 +24,7 @@ pub struct CosignVerifier {
 
 impl CosignVerifier {
     pub(crate) fn new() -> Result<Self, anyhow::Error> {
+        debug!("CosignVerifier::new()");
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;

--- a/bpfman/src/oci_utils/cosign.rs
+++ b/bpfman/src/oci_utils/cosign.rs
@@ -14,49 +14,55 @@ use sigstore::{
     registry::{Auth, ClientConfig, ClientProtocol, OciReference},
     tuf::SigstoreRepository,
 };
-use tokio::task::spawn_blocking;
+use tokio::{runtime::Runtime, task::spawn_blocking};
 
+/// A blocking wrapper around the sigstore cosign client.
 pub struct CosignVerifier {
-    pub client: sigstore::cosign::Client,
-    pub allow_unsigned: bool,
+    client: sigstore::cosign::Client,
+    rt: Runtime,
 }
 
 impl CosignVerifier {
-    pub(crate) async fn new(allow_unsigned: bool) -> Result<Self, anyhow::Error> {
-        // We must use spawn_blocking here.
-        // See: https://docs.rs/sigstore/0.7.2/sigstore/oauth/openidflow/index.html
-        let repo: sigstore::errors::Result<SigstoreRepository> = spawn_blocking(|| {
-            info!("Starting Cosign Verifier, downloading data from Sigstore TUF repository");
-            sigstore::tuf::SigstoreRepository::fetch(None)
-        })
-        .await
-        .map_err(|e| anyhow!("Error spawning blocking task inside of tokio: {}", e))?;
-
-        let repo: SigstoreRepository = repo?;
-
-        let oci_config = ClientConfig {
-            protocol: ClientProtocol::Https,
-            ..Default::default()
-        };
-
-        let cosign_client = ClientBuilder::default()
-            .with_oci_client_config(oci_config)
-            .with_rekor_pub_key(repo.rekor_pub_key())
-            .with_fulcio_certs(repo.fulcio_certs())
-            .enable_registry_caching()
+    pub(crate) fn new() -> Result<Self, anyhow::Error> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()?;
 
-        Ok(Self {
-            client: cosign_client,
-            allow_unsigned,
-        })
+        let client = rt.block_on(async {
+            // We must use spawn_blocking here.
+            // See: https://docs.rs/sigstore/0.7.2/sigstore/oauth/openidflow/index.html
+            let repo: sigstore::errors::Result<SigstoreRepository> = spawn_blocking(|| {
+                info!("Starting Cosign Verifier, downloading data from Sigstore TUF repository");
+                sigstore::tuf::SigstoreRepository::fetch(None)
+            })
+            .await
+            .map_err(|e| anyhow!("Error fetching sigstore repository: {}", e))?;
+
+            let repo = repo?;
+
+            let oci_config = ClientConfig {
+                protocol: ClientProtocol::Https,
+                ..Default::default()
+            };
+
+            ClientBuilder::default()
+                .with_oci_client_config(oci_config)
+                .with_rekor_pub_key(repo.rekor_pub_key())
+                .with_fulcio_certs(repo.fulcio_certs())
+                .enable_registry_caching()
+                .build()
+                .map_err(|e| anyhow!("Error building cosign client: {}", e))
+        })?;
+
+        Ok(Self { client, rt })
     }
 
-    pub(crate) async fn verify(
+    pub(crate) fn verify(
         &mut self,
         image: &str,
         username: Option<&str>,
         password: Option<&str>,
+        allow_unsigned: bool,
     ) -> Result<(), anyhow::Error> {
         debug!("CosignVerifier::verify()");
         let image = OciReference::from_str(image)?;
@@ -66,39 +72,41 @@ impl CosignVerifier {
             Auth::Anonymous
         };
 
-        debug!("Triangulating image: {}", image);
-        let (cosign_signature_image, source_image_digest) =
-            self.client.triangulate(&image, &auth).await?;
+        self.rt.block_on(async {
+            debug!("Triangulating image: {}", image);
+            let (cosign_signature_image, source_image_digest) =
+                self.client.triangulate(&image, &auth).await?;
 
-        debug!("Getting trusted layers");
-        match self
-            .client
-            .trusted_signature_layers(&auth, &source_image_digest, &cosign_signature_image)
-            .await
-        {
-            Ok(trusted_layers) => {
-                debug!("Found trusted layers");
-                debug!("Verifying constraints");
-                info!("The bytecode image: {} is signed", image);
-                // TODO: Add some constraints here
-                let verification_constraints: VerificationConstraintVec = Vec::new();
-                verify_constraints(&trusted_layers, verification_constraints.iter())
-                    .map_err(|e| anyhow!("Error verifying constraints: {}", e))?;
-                Ok(())
-            }
-            Err(e) => match e {
-                RegistryPullManifestError { .. } => {
-                    if !self.allow_unsigned {
-                        bail!("Error triangulating image: {}", e);
-                    } else {
-                        warn!("The bytecode image: {} is unsigned", image);
-                        Ok(())
+            debug!("Getting trusted layers");
+            match self
+                .client
+                .trusted_signature_layers(&auth, &source_image_digest, &cosign_signature_image)
+                .await
+            {
+                Ok(trusted_layers) => {
+                    debug!("Found trusted layers");
+                    debug!("Verifying constraints");
+                    info!("The bytecode image: {} is signed", image);
+                    // TODO: Add some constraints here
+                    let verification_constraints: VerificationConstraintVec = Vec::new();
+                    verify_constraints(&trusted_layers, verification_constraints.iter())
+                        .map_err(|e| anyhow!("Error verifying constraints: {}", e))?;
+                    Ok(())
+                }
+                Err(e) => match e {
+                    RegistryPullManifestError { .. } => {
+                        if !allow_unsigned {
+                            bail!("Error triangulating image: {}", e);
+                        } else {
+                            warn!("The bytecode image: {} is unsigned", image);
+                            Ok(())
+                        }
                     }
-                }
-                _ => {
-                    bail!("Error triangulating image: {}", e);
-                }
-            },
-        }
+                    _ => {
+                        bail!("Error triangulating image: {}", e);
+                    }
+                },
+            }
+        })
     }
 }

--- a/bpfman/src/oci_utils/image_manager.rs
+++ b/bpfman/src/oci_utils/image_manager.rs
@@ -109,6 +109,7 @@ pub(crate) struct ImageManager {
 
 impl ImageManager {
     pub(crate) fn new() -> Result<Self, anyhow::Error> {
+        debug!("ImageManager::new() Creating CosignVerifier");
         let cosign_verifier = CosignVerifier::new()?;
         let config = ClientConfig {
             protocol: ClientProtocol::Https,

--- a/bpfman/src/oci_utils/mod.rs
+++ b/bpfman/src/oci_utils/mod.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
+pub(crate) mod client;
 pub(crate) mod cosign;
 pub(crate) mod image_manager;
 
-pub(crate) use image_manager::ImageManager;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/bpfman/src/serve.rs
+++ b/bpfman/src/serve.rs
@@ -44,7 +44,7 @@ pub async fn serve(config: &Config, csi_support: bool) -> anyhow::Result<()> {
     listeners.push(handle);
 
     let mut bpf_manager = BpfManager::new(config.clone(), rx);
-    bpf_manager.rebuild_state().await?;
+    bpf_manager.rebuild_state()?;
 
     // TODO(astoycos) see issue #881
     //let static_programs = get_static_programs(static_program_path).await?;
@@ -172,7 +172,7 @@ async fn std_unix_stream(path: String) -> anyhow::Result<UnixListenerStream> {
     let uds = UnixListener::bind(&path)?;
     let stream = UnixListenerStream::new(uds);
     // Always set the file permissions of our listening socket.
-    set_file_permissions(&path.clone(), SOCK_MODE).await;
+    set_file_permissions(&path.clone(), SOCK_MODE);
 
     info!("Using default Unix socket");
     Ok(stream)

--- a/bpfman/src/storage.rs
+++ b/bpfman/src/storage.rs
@@ -188,7 +188,7 @@ impl Node for CsiNode {
                             format!("failed creating target path {target_path:?}: {e}"),
                         )
                     })?;
-                    set_dir_permissions(target_path, OWNER_READ_WRITE).await;
+                    set_dir_permissions(target_path, OWNER_READ_WRITE);
                 }
 
                 // Make a new bpf fs specifically for the pod.
@@ -372,7 +372,7 @@ impl StorageManager {
         let uds = UnixListener::bind(path)
             .unwrap_or_else(|_| panic!("failed to bind {RTPATH_BPFMAN_CSI_SOCKET}"));
         let uds_stream = UnixListenerStream::new(uds);
-        set_file_permissions(RTPATH_BPFMAN_CSI_SOCKET, SOCK_MODE).await;
+        set_file_permissions(RTPATH_BPFMAN_CSI_SOCKET, SOCK_MODE);
 
         let node_service = NodeServer::new(self.csi_node);
         let identity_service = IdentityServer::new(self.csi_identity);

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use std::{os::unix::fs::PermissionsExt, path::Path, str};
+use std::{os::unix::fs::PermissionsExt, str};
 
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
@@ -9,28 +9,12 @@ use nix::{
     mount::{mount, MsFlags},
     net::if_::if_nametoindex,
 };
-use tokio::{fs, io::AsyncReadExt};
 
 use crate::errors::BpfmanError;
 
 // The bpfman socket should always allow the same users and members of the same group
 // to Read/Write to it.
 pub(crate) const SOCK_MODE: u32 = 0o0660;
-
-// Like tokio::fs::read, but with O_NOCTTY set
-pub(crate) async fn read<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, BpfmanError> {
-    let mut data = vec![];
-    tokio::fs::OpenOptions::new()
-        .custom_flags(nix::libc::O_NOCTTY)
-        .read(true)
-        .open(path)
-        .await
-        .map_err(|e| BpfmanError::Error(format!("can't open file: {e}")))?
-        .read_to_end(&mut data)
-        .await
-        .map_err(|e| BpfmanError::Error(format!("can't read file: {e}")))?;
-    Ok(data)
-}
 
 pub(crate) fn get_ifindex(iface: &str) -> Result<u32, BpfmanError> {
     match if_nametoindex(iface) {
@@ -45,19 +29,18 @@ pub(crate) fn get_ifindex(iface: &str) -> Result<u32, BpfmanError> {
     }
 }
 
-pub(crate) async fn set_file_permissions(path: &str, mode: u32) {
+pub(crate) fn set_file_permissions(path: &str, mode: u32) {
     // Set the permissions on the file based on input
-    if (tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await).is_err() {
+    if (std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))).is_err() {
         warn!("Unable to set permissions on file {}. Continuing", path);
     }
 }
 
-pub(crate) async fn set_dir_permissions(directory: &str, mode: u32) {
+pub(crate) fn set_dir_permissions(directory: &str, mode: u32) {
     // Iterate through the files in the provided directory
-    let mut entries = fs::read_dir(directory).await.unwrap();
-    while let Some(file) = entries.next_entry().await.unwrap() {
-        // Set the permissions on the file based on input
-        set_file_permissions(&file.path().into_os_string().into_string().unwrap(), mode).await;
+    for entry in std::fs::read_dir(directory).unwrap() {
+        let entry = entry.unwrap();
+        set_file_permissions(&entry.path().into_os_string().into_string().unwrap(), mode);
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,6 +110,8 @@ install() {
         echo "  Starting \"${SVC_BPFMAN_SOCK}\""
         systemctl enable --now ${SVC_BPFMAN_SOCK}
     fi
+
+    systemctl daemon-reload
 }
 
 uninstall() {


### PR DESCRIPTION
This turns image manager from running in a dedicated thread, to being a lazy static singleton. In order to do this we provide sync wrappers around the oci_utils client and the cosign client, which safely allows for these functions to be called from sync code.