### PR TITLE
Tidy up async code and shutdown handling

### DIFF
--- a/Containerfile.bpfman
+++ b/Containerfile.bpfman
@@ -24,4 +24,4 @@ FROM scratch
 
 COPY --from=bpfman-build  /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman .
 
-ENTRYPOINT ["./bpfman"]
+ENTRYPOINT ["./bpfman", "system", "service", "--timeout=0"]

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -37,4 +37,4 @@ RUN dnf makecache --refresh && dnf -y install bpftool tcpdump
 
 COPY --from=bpfman-build  ./usr/src/bpfman/bpfman .
 
-ENTRYPOINT ["./bpfman", "system", "service"]
+ENTRYPOINT ["./bpfman", "system", "service", "--timeout=0"]

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -704,7 +704,7 @@ impl BpfManager {
 
     pub(crate) async fn remove_program(&mut self, id: u32) -> Result<(), BpfmanError> {
         info!("Removing program with id: {id}");
-        let mut prog = match self.programs.remove(&id) {
+        let prog = match self.programs.remove(&id) {
             Some(p) => p,
             None => {
                 return Err(BpfmanError::Error(format!(
@@ -717,7 +717,7 @@ impl BpfManager {
         let map_owner_id = prog.get_data().get_map_owner_id()?;
 
         match prog {
-            Program::Xdp(_) | Program::Tc(_) => self.remove_multi_attach_program(&mut prog).await?,
+            Program::Xdp(_) | Program::Tc(_) => self.remove_multi_attach_program(&prog).await?,
             Program::Tracepoint(_)
             | Program::Kprobe(_)
             | Program::Uprobe(_)
@@ -734,7 +734,7 @@ impl BpfManager {
 
     pub(crate) async fn remove_multi_attach_program(
         &mut self,
-        program: &mut Program,
+        program: &Program,
     ) -> Result<(), BpfmanError> {
         debug!("BpfManager::remove_multi_attach_program()");
 

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -26,6 +26,7 @@ use tokio::{
     fs::{create_dir_all, read_dir, remove_dir_all},
     select,
     sync::{
+        broadcast,
         mpsc::{Receiver, Sender},
         oneshot,
     },
@@ -40,7 +41,6 @@ use crate::{
     errors::BpfmanError,
     multiprog::{Dispatcher, DispatcherId, DispatcherInfo, TcDispatcher, XdpDispatcher},
     oci_utils::image_manager::Command as ImageManagerCommand,
-    serve::shutdown_handler,
     utils::{bytes_to_string, get_ifindex, set_dir_permissions, should_map_be_pinned},
     ROOT_DB,
 };
@@ -935,12 +935,12 @@ impl BpfManager {
         Ok(())
     }
 
-    pub(crate) async fn process_commands(&mut self, use_activity_timer: bool) {
+    pub(crate) async fn process_commands(&mut self, mut shutdown_channel: broadcast::Receiver<()>) {
         loop {
             // Start receiving messages
             select! {
                 biased;
-                _ = shutdown_handler(use_activity_timer) => {
+                _ = shutdown_channel.recv() => {
                     info!("Signal received to stop command processing");
                     ROOT_DB.flush().expect("Unable to flush database to disk before shutting down BpfManager");
                     break;

--- a/bpfman/src/cli/args.rs
+++ b/bpfman/src/cli/args.rs
@@ -312,6 +312,9 @@ pub(crate) struct ServiceArgs {
     /// Enable CSI support.
     #[clap(long)]
     pub(crate) csi_support: bool,
+    /// Shutdown after N seconds of inactivity. Use 0 to disable.
+    #[clap(long, default_value = "15")]
+    pub(crate) timeout: u64,
 }
 
 #[derive(Subcommand, Debug)]

--- a/bpfman/src/cli/get.rs
+++ b/bpfman/src/cli/get.rs
@@ -5,19 +5,13 @@ use bpfman_api::v1::{bpfman_client::BpfmanClient, GetRequest};
 
 use crate::cli::{args::GetArgs, select_channel, table::ProgTable};
 
-pub(crate) fn execute_get(args: &GetArgs) -> Result<(), anyhow::Error> {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            let channel = select_channel().expect("failed to select channel");
-            let mut client = BpfmanClient::new(channel);
-            let request = tonic::Request::new(GetRequest { id: args.id });
-            let response = client.get(request).await?.into_inner();
+pub(crate) async fn execute_get(args: &GetArgs) -> Result<(), anyhow::Error> {
+    let channel = select_channel().expect("failed to select channel");
+    let mut client = BpfmanClient::new(channel);
+    let request = tonic::Request::new(GetRequest { id: args.id });
+    let response = client.get(request).await?.into_inner();
 
-            ProgTable::new_get_bpfman(&response.info)?.print();
-            ProgTable::new_get_unsupported(&response.kernel_info)?.print();
-            Ok::<(), anyhow::Error>(())
-        })
+    ProgTable::new_get_bpfman(&response.info)?.print();
+    ProgTable::new_get_unsupported(&response.kernel_info)?.print();
+    Ok(())
 }

--- a/bpfman/src/cli/list.rs
+++ b/bpfman/src/cli/list.rs
@@ -6,37 +6,31 @@ use bpfman_api::v1::{bpfman_client::BpfmanClient, ListRequest};
 
 use crate::cli::{args::ListArgs, select_channel, table::ProgTable};
 
-pub(crate) fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            let channel = select_channel().unwrap();
-            let mut client = BpfmanClient::new(channel);
-            let prog_type_filter = args.program_type.map(|p| p as u32);
+pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
+    let channel = select_channel().unwrap();
+    let mut client = BpfmanClient::new(channel);
+    let prog_type_filter = args.program_type.map(|p| p as u32);
 
-            let request = tonic::Request::new(ListRequest {
-                program_type: prog_type_filter,
-                // Transform metadata from a vec of tuples to an owned map.
-                match_metadata: args
-                    .metadata_selector
-                    .clone()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                    .collect(),
-                bpfman_programs_only: Some(!args.all),
-            });
-            let response = client.list(request).await?.into_inner();
-            let mut table = ProgTable::new_list();
+    let request = tonic::Request::new(ListRequest {
+        program_type: prog_type_filter,
+        // Transform metadata from a vec of tuples to an owned map.
+        match_metadata: args
+            .metadata_selector
+            .clone()
+            .unwrap_or_default()
+            .iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect(),
+        bpfman_programs_only: Some(!args.all),
+    });
+    let response = client.list(request).await?.into_inner();
+    let mut table = ProgTable::new_list();
 
-            for r in response.results {
-                if let Err(e) = table.add_response_prog(r) {
-                    bail!(e)
-                }
-            }
-            table.print();
-            Ok::<(), anyhow::Error>(())
-        })
+    for r in response.results {
+        if let Err(e) = table.add_response_prog(r) {
+            bail!(e)
+        }
+    }
+    table.print();
+    Ok(())
 }

--- a/bpfman/src/cli/mod.rs
+++ b/bpfman/src/cli/mod.rs
@@ -25,7 +25,7 @@ use tower::service_fn;
 use unload::execute_unload;
 
 impl Commands {
-    pub(crate) fn execute(&self) -> Result<(), anyhow::Error> {
+    pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
         let config = if let Ok(c) = fs::read_to_string(CFGPATH_BPFMAN_CONFIG) {
             c.parse().unwrap_or_else(|_| {
                 warn!("Unable to parse config file, using defaults");
@@ -37,12 +37,12 @@ impl Commands {
         };
 
         match self {
-            Commands::Load(l) => l.execute(),
-            Commands::Unload(args) => execute_unload(args),
-            Commands::List(args) => execute_list(args),
-            Commands::Get(args) => execute_get(args),
-            Commands::Image(i) => i.execute(),
-            Commands::System(s) => s.execute(&config),
+            Commands::Load(l) => l.execute().await,
+            Commands::Unload(args) => execute_unload(args).await,
+            Commands::List(args) => execute_list(args).await,
+            Commands::Get(args) => execute_get(args).await,
+            Commands::Image(i) => i.execute().await,
+            Commands::System(s) => s.execute(&config).await,
         }
     }
 }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -83,7 +83,7 @@ pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyh
     set_dir_permissions(STDIR, STDIR_MODE).await;
 
     //TODO https://github.com/bpfman/bpfman/issues/881
-    serve(config, args.csi_support).await?;
+    serve(config, args.csi_support, args.timeout).await?;
     Ok(())
 }
 

--- a/bpfman/src/cli/unload.rs
+++ b/bpfman/src/cli/unload.rs
@@ -5,16 +5,10 @@ use bpfman_api::v1::{bpfman_client::BpfmanClient, UnloadRequest};
 
 use crate::cli::{args::UnloadArgs, select_channel};
 
-pub(crate) fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            let channel = select_channel().expect("failed to select channel");
-            let mut client = BpfmanClient::new(channel);
-            let request = tonic::Request::new(UnloadRequest { id: args.id });
-            let _response = client.unload(request).await?.into_inner();
-            Ok::<(), anyhow::Error>(())
-        })
+pub(crate) async fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
+    let channel = select_channel().expect("failed to select channel");
+    let mut client = BpfmanClient::new(channel);
+    let request = tonic::Request::new(UnloadRequest { id: args.id });
+    let _response = client.unload(request).await?.into_inner();
+    Ok(())
 }

--- a/bpfman/src/main.rs
+++ b/bpfman/src/main.rs
@@ -37,7 +37,8 @@ lazy_static! {
         .expect("Unable to open temporary root database");
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let cli = cli::args::Cli::parse();
-    cli.command.execute()
+    cli.command.execute().await
 }

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -76,7 +76,7 @@ pub fn start_bpfman() -> Result<ChildGuard> {
     debug!("Starting bpfman");
 
     let bpfman_process = Command::cargo_bin("bpfman")?
-        .args(["system", "service"])
+        .args(["system", "service", "--timeout=0"])
         .env("RUST_LOG", "bpfman=debug")
         .spawn()
         .map(|c| ChildGuard {


### PR DESCRIPTION
1. Removes custom Tokio runtime construction
2. Uses a broadcast channel for the shutdown handler so each of the "managers" may recieve the message and shutdown.