### PR TITLE
add daemonless doc to website fixup sled article 

### DIFF
--- a/docs/blog/posts/sled-integration.md
+++ b/docs/blog/posts/sled-integration.md
@@ -17,6 +17,8 @@ of the details of the actual implementation.
 [bpfman completely damonless]:https://github.com/bpfman/bpfman/blob/main/docs/design/daemonless.md
 [issue #860]:https://github.com/bpfman/bpfman/issues/860
 
+<!-- more -->
+
 ## Why?
 
 State management in bpfman has always been a headache, not

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,8 @@ nav:
       - Testing: developer-guide/testing.md
       - Debugging: developer-guide/debugging.md
       - Releasing: developer-guide/release.md
+  - Design:
+      - Daemonless: design/daemonless.md
   - Blog:
       - blog/index.md
   - Community:


### PR DESCRIPTION
Fix this failure I saw in CI 

```
mike deploy --push main
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/bpfman/bpfman/actions/runs/7613204594/job/20732554473#step:10:3).8.18/x6[4](https://github.com/bpfman/bpfman/actions/runs/7613204594/job/20732554473#step:10:4)
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x[6](https://github.com/bpfman/bpfman/actions/runs/7613204594/job/20732554473#step:10:6)4/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.[8](https://github.com/bpfman/bpfman/actions/runs/7613204594/job/20732554473#step:10:8).18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/runner/work/bpfman/bpfman/site
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - design/daemonless.md
ERROR   -  Error reading page 'blog/posts/sled-integration.md':
ERROR   -  Couldn't find '<!-- more -->' separator in 'blog/posts/sled-integration.md'

Aborted with a BuildError!
error: Command '['mkdocs', 'build', '--clean', '--config-file', 'mkdocs.yml']' returned non-zero exit status 1.
```

Locally this worked for me 🤷‍♂️ 