### PR TITLE
cli: fix nits in manpage and tab-completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,12 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+      - name: Build manpages
+        run: cargo xtask build-man-page
+
+      - name: Build CLI TAB Completion
+        run: cargo xtask build-completion
+
       ## If the push is a tag....build and upload the release bpfman binaries to an archive
       - name: Build-Release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -209,6 +215,12 @@ jobs:
       - name: Build bpfman
         run: cargo build --verbose
 
+      - name: Build manpages
+        run: cargo xtask build-man-page
+
+      - name: Build CLI TAB Completion
+        run: cargo xtask build-completion
+
       - name: Run the bpfman installer
         run: sudo ./scripts/setup.sh install
 
@@ -220,6 +232,9 @@ jobs:
 
       - name: Verify the CLI can reach bpfman
         run: sudo bpfman list
+
+      - name: Verify the manpages are installed
+        run: man bpfman list
 
       - name: Stop the bpfman systemd service
         run: sudo systemctl stop bpfman

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.76"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -242,11 +242,11 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#44f416a617a1ef5555420cb45ee6db3d1a561b0f"
+source = "git+https://github.com/aya-rs/aya?branch=main#79c1d8495e49acea45a952170acbbd41a8cb6485"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bytes",
  "lazy_static",
  "libc",
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#44f416a617a1ef5555420cb45ee6db3d1a561b0f"
+source = "git+https://github.com/aya-rs/aya?branch=main#79c1d8495e49acea45a952170acbbd41a8cb6485"
 dependencies = [
  "bytes",
  "core-error",
@@ -315,9 +315,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf7dcb7c21d8ca1a2482ee0f1d341f437c9a7af6ca6da359dc5e1b164e98215"
+checksum = "df631ae429f6613fcd3a7c1adbdb65f637271e561b03680adaa6573015dfb106"
 dependencies = [
  "clap",
 ]
@@ -689,9 +689,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -707,24 +707,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
@@ -732,7 +726,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
  "parking_lot 0.12.1",
@@ -998,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "log",
 ]
@@ -1214,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1261,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1308,9 +1302,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -1369,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "http-auth"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430cacd7a1f9a02fbeb350dfc81a0e5ed42d81f3398cb0ba184017f85bdcfbc"
+checksum = "643c9bbf6a4ea8a656d6b4cd53d34f79e3f841ad5203c1a55fb7d761923bc255"
 dependencies = [
  "memchr",
 ]
@@ -1451,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1634,9 +1628,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1658,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -1676,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -1724,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1741,9 +1735,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1806,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -1955,7 +1949,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
  "memoffset 0.9.0",
@@ -2041,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -2488,15 +2482,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "platforms"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "poly1305"
@@ -2517,13 +2511,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -2545,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
  "syn 2.0.48",
@@ -2564,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2599,7 +2592,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -2633,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -2719,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2731,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2748,9 +2741,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2899,11 +2892,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3015,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
@@ -3030,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
@@ -3050,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.109"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -3070,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -3213,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "snafu"
@@ -3424,6 +3417,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38a1d5fcfa859f0ec2b5e111dc903890bd7dac7f34713232bf9aa4fd7cad7b2"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e00e3e7a54e0f1c8834ce72ed49c8487fbd3f801d8cfe1a0ad0640382f8e15"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "tokio"
@@ -3763,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3844,18 +3858,18 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "7cdbaf5e132e593e9fc1de6a15bbec912395b11fb9719e061cf64f804524c503"
 
 [[package]]
 name = "vcpkg"
@@ -3905,9 +3919,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3915,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -3930,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3942,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3952,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
@@ -3984,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4066,11 +4080,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -4273,9 +4287,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]
@@ -4304,13 +4318,14 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eefca1d99701da3a57feb07e5079fc62abba059fc139e98c13bbb250f3ef29"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid",
  "der",
  "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -4330,18 +4345,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bpfman/src/cli/args.rs
+++ b/bpfman/src/cli/args.rs
@@ -6,7 +6,11 @@ use clap::{Args, Parser, Subcommand};
 use hex::FromHex;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    long_about = "An eBPF manager focusing on simplifying the deployment and administration of eBPF programs."
+)]
+#[command(name = "bpfman")]
+#[command(disable_version_flag = true)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Commands,
@@ -32,6 +36,7 @@ pub(crate) enum Commands {
 }
 
 #[derive(Subcommand, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) enum LoadSubcommand {
     /// Load an eBPF program from a local .o file.
     File(LoadFileArgs),
@@ -126,7 +131,9 @@ pub(crate) struct GlobalArg {
 }
 
 #[derive(Subcommand, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) enum LoadCommands {
+    #[command(disable_version_flag = true)]
     /// Install an eBPF program on the XDP hook point for a given interface.
     Xdp {
         /// Required: Interface to load program on.
@@ -147,6 +154,7 @@ pub(crate) enum LoadCommands {
         #[clap(long, verbatim_doc_comment, num_args(1..))]
         proceed_on: Vec<String>,
     },
+    #[command(disable_version_flag = true)]
     /// Install an eBPF program on the TC hook point for a given interface.
     Tc {
         /// Required: Direction to apply program.
@@ -174,6 +182,7 @@ pub(crate) enum LoadCommands {
         #[clap(long, verbatim_doc_comment, num_args(1..))]
         proceed_on: Vec<String>,
     },
+    #[command(disable_version_flag = true)]
     /// Install an eBPF program on a Tracepoint.
     Tracepoint {
         /// Required: The tracepoint to attach to.
@@ -181,6 +190,7 @@ pub(crate) enum LoadCommands {
         #[clap(short, long, verbatim_doc_comment)]
         tracepoint: String,
     },
+    #[command(disable_version_flag = true)]
     /// Install an eBPF kprobe or kretprobe
     Kprobe {
         /// Required: Function to attach the kprobe to.
@@ -203,6 +213,7 @@ pub(crate) enum LoadCommands {
         #[clap(short, long)]
         container_pid: Option<i32>,
     },
+    #[command(disable_version_flag = true)]
     /// Install an eBPF uprobe or uretprobe
     Uprobe {
         /// Optional: Function to attach the uprobe to.
@@ -240,12 +251,14 @@ pub(crate) enum LoadCommands {
 }
 
 #[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) struct UnloadArgs {
     /// Required: Program id to be unloaded.
     pub(crate) id: u32,
 }
 
 #[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) struct ListArgs {
     /// Optional: List a specific program type
     /// Example: --program-type xdp
@@ -275,18 +288,21 @@ pub(crate) struct ListArgs {
 }
 
 #[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) struct GetArgs {
     /// Required: Program id to get.
     pub(crate) id: u32,
 }
 
 #[derive(Subcommand, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) enum ImageSubCommand {
     /// Pull an eBPF bytecode image from a remote registry.
     Pull(PullBytecodeArgs),
 }
 
 #[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) struct PullBytecodeArgs {
     /// Required: Container Image URL.
     /// Example: --image-url quay.io/bpfman-bytecode/xdp_pass:latest
@@ -308,6 +324,7 @@ pub(crate) struct PullBytecodeArgs {
 }
 
 #[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) struct ServiceArgs {
     /// Enable CSI support.
     #[clap(long)]
@@ -318,6 +335,7 @@ pub(crate) struct ServiceArgs {
 }
 
 #[derive(Subcommand, Debug)]
+#[command(disable_version_flag = true)]
 pub(crate) enum SystemSubcommand {
     /// Load an eBPF program from a local .o file.
     Service(ServiceArgs),

--- a/docs/getting-started/building-bpfman.md
+++ b/docs/getting-started/building-bpfman.md
@@ -95,6 +95,75 @@ To build bpfman:
 cargo build
 ```
 
+## Building CLI TAB completion files
+
+Optionally, to build the CLI TAB completion files, run the following command:
+
+```console
+cargo xtask build-completion
+```
+
+Files are generated for different shells:
+
+```console
+ls .output/completions/
+_bpfman  bpfman.bash  bpfman.elv  bpfman.fish  _bpfman.ps1
+```
+
+### bash
+
+For `bash`, this generates a file that can be used by the linux `bash-completion`
+utility (see [Install bash-completion](#install-bash-completion) for installation
+instructions).
+
+If the files are generated, they are installed automatically when running `bpfman` as
+a systemd service and using the `sudo ./scripts/setup.sh install` install script
+(see [Systemd Service](tutorial.md#systemd-service)).
+To install the files manually, copy the file associated with a given shell to
+`/usr/share/bash-completion/completions/`.
+For example:
+
+```console
+sudo cp .output/completions/bpfman.bash /usr/share/bash-completion/completions/.
+
+bpfman g<TAB>
+```
+
+### Other shells
+
+Files are generated other shells (Elvish, Fish, PowerShell and zsh).
+For these shells, generated file must be manually installed.
+
+## Building CLI Manpages
+
+Optionally, to build the CLI Manpage files, run the following command:
+
+```console
+cargo xtask build-man-page
+```
+
+If the files are generated, they are installed automatically when running `bpfman` as
+a systemd service and using the `sudo ./scripts/setup.sh install` install script
+(see [Systemd Service](tutorial.md#systemd-service)).
+To install the files manually, copy the generated files to `/usr/local/share/man/man1/`.
+For example:
+
+```console
+sudo cp .output/manpage/bpfman*.1 /usr/local/share/man/man1/.
+```
+
+Once installed, use `man` to view the pages.
+
+```console
+man bpfman list
+```
+
+> **NOTE:**
+> `bpfman` commands with subcommands (specifically `bpfman load`) have `-` in the
+> manpage subcommand generation.
+> So use `bpfman load-file`, `bpfman load-image`, `bpfman load-image-xdp`, etc. to
+> display the subcommand manpage files.
+
 ## Development Environment Setup
 
 To build bpfman, the following packages must be installed.
@@ -172,12 +241,39 @@ sudo dnf install perl
 sudo apt install perl
 ```
 
+### Install bash-completion
+
+`bpfman` uses the Rust crate `clap` for the CLI implementation.
+`clap` has an optional Rust crate `clap_complete`. For `bash` shell, it leverages
+`bash-completion` for CLI Command <TAB> completion.
+So in order for CLI <TAB> completion to work in a `bash` shell, `bash-completion`
+must be installed.
+This feature is optional.
+
+For the CLI <TAB> completion to work after installation, `/etc/profile.d/bash_completion.sh`
+must be sourced in the running sessions.
+New login sessions should pick it up automatically.
+
+`dnf` based OS:
+
+```console
+sudo dnf install bash-completion
+source /etc/profile.d/bash_completion.sh
+```
+
+`apt` based OS:
+
+```console
+sudo apt install bash-completion
+source /etc/profile.d/bash_completion.sh
+```
+
 ### Install Yaml Formatter
 
 As part of CI, the Yaml files are validated with a Yaml formatter.
 Optionally, to verify locally, install the
 [YAML Language Support by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
-VsCode Extension, or to format in bulk, install`prettier`.
+VsCode Extension, or to format in bulk, install `prettier`.
 
 To install `prettier`:
 
@@ -195,4 +291,19 @@ And to write changes in place, run:
 
 ```console
  prettier -f "*.yaml"
+```
+
+### Install toml Formatter
+
+As part of CI, the toml files are validated with a toml formatter.
+Optionally, to verify locally, install `taplo`.
+
+```console
+cargo install taplo-cli
+```
+
+And to verify locally:
+
+```console
+taplo fmt --check
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,6 +73,51 @@ del_svc() {
     fi
 }
 
+copy_cli_tab_completion() {
+    if [ -d ${SRC_CLI_TAB_COMPLETE_PATH} ] && [ "$(ls -A ${SRC_CLI_TAB_COMPLETE_PATH})" ]; then
+    #if [ -d ${SRC_CLI_TAB_COMPLETE_PATH} ] && [ "$(find ${SRC_CLI_TAB_COMPLETE_PATH} -mindepth 1 -maxdepth 1)" ]; then
+        case $SHELL in
+        "/bin/bash")
+            echo "  Copying \"${SRC_CLI_TAB_COMPLETE_PATH}}/bpfman.bash\" to \"${DST_CLI_TAB_COMPLETE_PATH}/.\""
+            cp ${SRC_CLI_TAB_COMPLETE_PATH}/bpfman.bash ${DST_CLI_TAB_COMPLETE_PATH}/.
+            ;;
+
+        *)
+            echo "Currently only bash is supported by this script. For other shells, manually install."
+            ;;
+        esac
+
+
+    else
+        echo "  CLI TAB Completion files not generated yet. Use \"cargo xtask build-completion\" to generate."
+    fi
+}
+
+del_cli_tab_completion() {
+    if [ -d ${DST_CLI_TAB_COMPLETE_PATH} ] && [ -f ${DST_CLI_TAB_COMPLETE_PATH}/bpfman.bash ]; then
+        echo "  Removing CLI TAB Completion files from \"${DST_CLI_TAB_COMPLETE_PATH}/bpfman.bash\""
+        rm ${DST_CLI_TAB_COMPLETE_PATH}/bpfman.bash &>/dev/null
+    fi
+}
+
+copy_manpages() {
+    if [ -d ${SRC_MANPAGE_PATH} ] && [ "$(ls -A ${SRC_MANPAGE_PATH})" ]; then
+    #if [ -d ${SRC_MANPAGE_PATH} ] && [ -z "$(find ${SRC_MANPAGE_PATH} -mindepth 1 -maxdepth 1)" ]; then
+        echo "  Copying \"${SRC_MANPAGE_PATH}\" to \"${DST_MANPAGE_PATH}\""
+        rm ${DST_MANPAGE_PATH}/bpfman*.1  &>/dev/null
+        cp ${SRC_MANPAGE_PATH}/bpfman*.1 ${DST_MANPAGE_PATH}/.
+    else
+        echo "  CLI Manpage files not generated yet. Use \"cargo xtask build-man-page\" to generate."
+    fi
+}
+
+del_manpages() {
+    if [ -d ${DST_MANPAGE_PATH} ] && [ -f ${DST_MANPAGE_PATH}/bpfman.1 ]; then
+        echo "  Removing Manpage files from \"${DST_MANPAGE_PATH}\""
+        rm ${DST_MANPAGE_PATH}/bpfman*.1 &>/dev/null
+    fi
+}
+
 install() {
     reinstall=$1
     if [ -z "${reinstall}" ]; then
@@ -86,6 +131,12 @@ install() {
     if [ -z "${release}" ]; then
         release=false
     fi
+
+    echo "Copy CLI TAB Completion files:"
+    copy_cli_tab_completion
+
+    echo "Copy Manpage files:"
+    copy_manpages
 
     echo "Copy binaries:"
 
@@ -113,6 +164,12 @@ install() {
 }
 
 uninstall() {
+    echo "Remove CLI TAB Completion files:"
+    del_cli_tab_completion
+
+    echo "Remove Manpage files:"
+    del_manpages
+
     echo "Remove service files:"
     del_svc "${SVC_BPFMAN_SOCK}"
     del_svc "${SVC_BPFMAN_SVC}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,12 @@ DST_SVC_PATH="/usr/lib/systemd/system"
 SVC_BPFMAN_SOCK="${BIN_BPFMAN}.socket"
 SVC_BPFMAN_SVC="${BIN_BPFMAN}.service"
 
+SRC_CLI_TAB_COMPLETE_PATH="../.output/completions"
+DST_CLI_TAB_COMPLETE_PATH="/usr/share/bash-completion/completions"
+
+SRC_MANPAGE_PATH="../.output/manpage"
+DST_MANPAGE_PATH="/usr/local/share/man/man1"
+
 # ConfigurationDirectory: /etc/bpfman/
 CONFIGURATION_DIR="/etc/bpfman"
 CFG_CA_CERT_DIR="/etc/bpfman/certs/ca"
@@ -39,8 +45,12 @@ usage() {
     echo "    Prepare system for running \"bpfman\" as a systemd service. Performs the"
     echo "    following tasks:"
     echo "    * Copy \"bpfman\" binaries to \"/usr/sbin/.\"."
+    echo "    * Copy \"bpfman\" CLI TAB completeion files to"
+    echo "       \"/usr/share/bash-completion/completions/.\", if they have been generated."
+    echo "    * Copy \"bpfman\" manpages to \"/usr/local/share/man/man1/.\", if they have"
+    echo "      been generated."
     echo "    * Copy \"bpfman.service\" to \"/usr/lib/systemd/system/\"."
-    echo "    * Run \"systemctl start bpfman.service\" to start the sevice."
+    echo "    * Run \"systemctl start bpfman.socket\" to start the sevice."
     echo "sudo ./scripts/setup.sh setup [--release]"
     echo "    Same as \"install\" above, but don't start the service."
     echo "sudo ./scripts/setup.sh reinstall [--release]"

--- a/xtask/src/build_completion.rs
+++ b/xtask/src/build_completion.rs
@@ -3,11 +3,13 @@ mod cli {
     include!("../../bpfman/src/cli/args.rs");
 }
 
-use std::{env, ffi::OsStr};
+use std::{ffi::OsStr, fs::create_dir_all, path::PathBuf};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::{Generator, Shell};
 use cli::Cli;
+
+use crate::workspace::WORKSPACE_ROOT;
 
 #[derive(Debug, Parser)]
 pub struct Options {}
@@ -19,7 +21,10 @@ fn write_completions_file<G: Generator + Copy, P: AsRef<OsStr>>(generator: G, ou
 }
 
 pub fn build_completion(_opts: Options) -> Result<(), anyhow::Error> {
-    let out_dir = env::var_os("OUT_DIR").expect("out dir not set");
+    let mut out_dir = PathBuf::from(WORKSPACE_ROOT.to_string());
+    out_dir.push(".output/completions");
+    create_dir_all(&out_dir)?;
+
     write_completions_file(Shell::Bash, &out_dir);
     write_completions_file(Shell::Elvish, &out_dir);
     write_completions_file(Shell::Fish, &out_dir);

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -8,8 +8,8 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use lazy_static::lazy_static;
-use serde_json::Value;
+
+use crate::workspace::WORKSPACE_ROOT;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Architecture {
@@ -52,20 +52,6 @@ pub struct Options {
     /// Required: Libbpf dir, required for compiling C code
     #[clap(long, action)]
     pub libbpf_dir: PathBuf,
-}
-
-lazy_static! {
-    pub static ref WORKSPACE_ROOT: String = workspace_root();
-}
-
-fn workspace_root() -> String {
-    let output = Command::new("cargo").arg("metadata").output().unwrap();
-    if !output.status.success() {
-        panic!("unable to run cargo metadata")
-    }
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let v: Value = serde_json::from_str(&stdout).unwrap();
-    v["workspace_root"].as_str().unwrap().to_string()
 }
 
 fn get_libbpf_headers<P: AsRef<Path>>(libbpf_dir: P, include_path: P) -> anyhow::Result<()> {

--- a/xtask/src/copy.rs
+++ b/xtask/src/copy.rs
@@ -1,28 +1,14 @@
-use std::{path::PathBuf, process::Command, string::String};
+use std::{path::PathBuf, process::Command};
 
 use clap::Parser;
-use lazy_static::lazy_static;
-use serde_json::Value;
+
+use crate::workspace::WORKSPACE_ROOT;
 
 #[derive(Debug, Parser)]
 pub struct Options {
     /// Optional: Copy from the release target
     #[clap(long)]
     pub release: bool,
-}
-
-lazy_static! {
-    pub static ref WORKSPACE_ROOT: String = workspace_root();
-}
-
-fn workspace_root() -> String {
-    let output = Command::new("cargo").arg("metadata").output().unwrap();
-    if !output.status.success() {
-        panic!("unable to run cargo metadata")
-    }
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let v: Value = serde_json::from_str(&stdout).unwrap();
-    v["workspace_root"].as_str().unwrap().to_string()
 }
 
 /// Copy the binaries

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,7 @@ mod copy;
 mod integration_test;
 mod protobuf;
 mod run;
+mod workspace;
 
 use std::process::exit;
 

--- a/xtask/src/protobuf.rs
+++ b/xtask/src/protobuf.rs
@@ -1,25 +1,11 @@
-use std::{path::PathBuf, process::Command, string::String};
+use std::{path::PathBuf, process::Command};
 
 use clap::Parser;
-use lazy_static::lazy_static;
-use serde_json::Value;
+
+use crate::workspace::WORKSPACE_ROOT;
 
 #[derive(Debug, Parser)]
 pub struct Options {}
-
-lazy_static! {
-    pub static ref WORKSPACE_ROOT: String = workspace_root();
-}
-
-fn workspace_root() -> String {
-    let output = Command::new("cargo").arg("metadata").output().unwrap();
-    if !output.status.success() {
-        panic!("unable to run cargo metadata")
-    }
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let v: Value = serde_json::from_str(&stdout).unwrap();
-    v["workspace_root"].as_str().unwrap().to_string()
-}
 
 pub fn build(_opts: Options) -> anyhow::Result<()> {
     build_bpfman(&_opts)?;

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+use lazy_static::lazy_static;
+use serde_json::Value;
+
+lazy_static! {
+    pub static ref WORKSPACE_ROOT: String = workspace_root();
+}
+
+fn workspace_root() -> String {
+    let output = Command::new("cargo").arg("metadata").output().unwrap();
+    if !output.status.success() {
+        panic!("unable to run cargo metadata")
+    }
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(&stdout).unwrap();
+    v["workspace_root"].as_str().unwrap().to_string()
+}


### PR DESCRIPTION
There are a couple of nits in the CLI manpage and tab-completion generation. This PR addresses most of them.

* Document how to build and install. It's not obvious how to install the generated files.
* We tend not to use environment variables to build bpfman. Moved OUT_DIR to a fixed location.
* Only top level manpages are generated. `man bpfman get` and `man bpfman list` are implemented, but those with subcommands, primarily `man bpfman load`, don't document any of the subcommand parameter or usage.
* Update the install scripts/setup.sh to copy the generated files, if they have been generated. Remove them on uninstall.
* Call the new xtask commands in CI

Not completed:
* Add the generated files to the RPM build
* To show the load subcommands, hyphens are required, this should be fixed: `man bpfman load-file-xdp`