### PR TITLE
sled fixups and prefixes for final conversion bits

### DIFF
--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -1380,7 +1380,7 @@ impl Program {
 
     pub(crate) fn delete(&self) -> Result<(), anyhow::Error> {
         let id = self.get_data().get_id()?;
-        ROOT_DB.drop_tree(id.to_string())?;
+        ROOT_DB.drop_tree(PROGRAM_PREFIX.to_string() + id.to_string().as_str())?;
 
         let path = format!("{RTDIR_FS}/prog_{id}");
         if PathBuf::from(&path).exists() {
@@ -1498,5 +1498,5 @@ impl Program {
 // it.
 #[derive(Debug, Clone)]
 pub(crate) struct BpfMap {
-    pub(crate) used_by: Vec<u32>,
+    pub(crate) _used_by: Vec<u32>,
 }

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -38,6 +38,7 @@ use crate::{
 
 /// These constants define the key of SLED DB
 pub(crate) const PROGRAM_PREFIX: &str = "program_";
+pub(crate) const PROGRAM_PRE_LOAD_PREFIX: &str = "pre_load_program_";
 const KIND: &str = "kind";
 const NAME: &str = "name";
 const ID: &str = "id";
@@ -365,7 +366,7 @@ impl ProgramData {
         let id_rand = rng.gen::<u32>();
 
         let db_tree = ROOT_DB
-            .open_tree(PROGRAM_PREFIX.to_string() + &id_rand.to_string())
+            .open_tree(PROGRAM_PRE_LOAD_PREFIX.to_string() + &id_rand.to_string())
             .expect("Unable to open program database tree");
 
         let mut pd = Self { db_tree };
@@ -1490,13 +1491,4 @@ impl Program {
             None => Err(BpfmanError::Error("Unsupported program type".to_string())),
         }
     }
-}
-
-// BpfMap represents a single map pin path used by a Program.  It has to be a
-// separate object because it's lifetime is slightly different from a Program.
-// More specifically a BpfMap can outlive a Program if other Programs are using
-// it.
-#[derive(Debug, Clone)]
-pub(crate) struct BpfMap {
-    pub(crate) _used_by: Vec<u32>,
 }

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -27,7 +27,7 @@ pub(crate) enum Dispatcher {
 impl Dispatcher {
     pub async fn new(
         config: Option<&InterfaceConfig>,
-        programs: &mut [&mut Program],
+        programs: &mut [Program],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
         image_manager: Sender<ImageManagerCommand>,

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -92,7 +92,7 @@ impl TcDispatcher {
 
     pub(crate) async fn load(
         &mut self,
-        programs: &mut [&mut Program],
+        programs: &mut [Program],
         old_dispatcher: Option<Dispatcher>,
         image_manager: Sender<ImageManagerCommand>,
     ) -> Result<(), BpfmanError> {
@@ -335,7 +335,7 @@ impl TcDispatcher {
                 }
 
                 let mut loader = bpf
-                    .load(v.data.program_bytes())
+                    .load(&v.get_data().get_program_bytes()?)
                     .map_err(BpfmanError::BpfLoadError)?;
 
                 let ext: &mut Extension = loader

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -39,6 +39,7 @@ const DEFAULT_PRIORITY: u32 = 50; // Default priority for user programs in the d
 const TC_DISPATCHER_PRIORITY: u16 = 50; // Default TC priority for TC Dispatcher
 
 /// These constants define the key of SLED DB
+const TC_DISPATCHER_PREFIX: &str = "tc_dispatcher_";
 const REVISION: &str = "revision";
 const IF_INDEX: &str = "if_index";
 const IF_NAME: &str = "if_name";
@@ -63,8 +64,8 @@ impl TcDispatcher {
     ) -> Result<Self, BpfmanError> {
         let db_tree = ROOT_DB
             .open_tree(format!(
-                "tc_dispatcher_{}_{}_{}",
-                if_index, direction, revision
+                "{}_{}_{}_{}",
+                TC_DISPATCHER_PREFIX, if_index, direction, revision
             ))
             .expect("Unable to open tc dispatcher database tree");
 

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     dispatcher_config::TcDispatcherConfig,
     errors::BpfmanError,
-    multiprog::Dispatcher,
+    multiprog::{Dispatcher, TC_DISPATCHER_PREFIX},
     oci_utils::image_manager::{BytecodeImage, Command as ImageManagerCommand},
     utils::{
         bytes_to_string, bytes_to_u16, bytes_to_u32, bytes_to_usize, should_map_be_pinned,
@@ -39,7 +39,6 @@ const DEFAULT_PRIORITY: u32 = 50; // Default priority for user programs in the d
 const TC_DISPATCHER_PRIORITY: u16 = 50; // Default TC priority for TC Dispatcher
 
 /// These constants define the key of SLED DB
-const TC_DISPATCHER_PREFIX: &str = "tc_dispatcher_";
 const REVISION: &str = "revision";
 const IF_INDEX: &str = "if_index";
 const IF_NAME: &str = "if_name";

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -80,7 +80,7 @@ impl XdpDispatcher {
 
     pub(crate) async fn load(
         &mut self,
-        programs: &mut [&mut Program],
+        programs: &mut [Program],
         old_dispatcher: Option<Dispatcher>,
         image_manager: Sender<ImageManagerCommand>,
     ) -> Result<(), BpfmanError> {
@@ -272,7 +272,7 @@ impl XdpDispatcher {
                 }
 
                 let mut loader = bpf
-                    .load(v.get_data().program_bytes())
+                    .load(&v.get_data().get_program_bytes()?)
                     .map_err(BpfmanError::BpfLoadError)?;
 
                 let ext: &mut Extension = loader

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -30,6 +30,7 @@ use crate::{
 pub(crate) const DEFAULT_PRIORITY: u32 = 50;
 
 /// These constants define the key of SLED DB
+const XDP_DISPATCHER_PREFIX: &str = "xdp_dispatcher_";
 const REVISION: &str = "revision";
 const IF_INDEX: &str = "if_index";
 const IF_NAME: &str = "if_name";
@@ -51,7 +52,10 @@ impl XdpDispatcher {
         revision: u32,
     ) -> Result<Self, BpfmanError> {
         let db_tree = ROOT_DB
-            .open_tree(format!("xdp_dispatcher_{}_{}", if_index, revision))
+            .open_tree(format!(
+                "{}_{}_{}",
+                XDP_DISPATCHER_PREFIX, if_index, revision
+            ))
             .expect("Unable to open xdp dispatcher database tree");
 
         let mut dp = Self {

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -19,7 +19,7 @@ use crate::{
     command::{Program, XdpProgram},
     dispatcher_config::XdpDispatcherConfig,
     errors::BpfmanError,
-    multiprog::Dispatcher,
+    multiprog::{Dispatcher, XDP_DISPATCHER_PREFIX},
     oci_utils::image_manager::{BytecodeImage, Command as ImageManagerCommand},
     utils::{
         bytes_to_string, bytes_to_u32, bytes_to_usize, should_map_be_pinned, sled_get, sled_insert,
@@ -30,7 +30,6 @@ use crate::{
 pub(crate) const DEFAULT_PRIORITY: u32 = 50;
 
 /// These constants define the key of SLED DB
-const XDP_DISPATCHER_PREFIX: &str = "xdp_dispatcher_";
 const REVISION: &str = "revision";
 const IF_INDEX: &str = "if_index";
 const IF_NAME: &str = "if_name";
@@ -326,8 +325,8 @@ impl XdpDispatcher {
         let if_index = self.get_ifindex()?;
         let revision = self.get_revision()?;
         debug!(
-            "XdpDispatcher::delete() for if_index {}, revision {}",
-            if_index, revision
+            "XdpDispatcher::delete() for if_index {}, revision {}, full {}",
+            if_index, revision, full
         );
         ROOT_DB.drop_tree(self.db_tree.name()).map_err(|e| {
             BpfmanError::DatabaseError(


### PR DESCRIPTION
Add prefixes to the program tree names in sled and remove the erroneous id structure field which was no longer needed.

Still need to 

- [x] Add a `new_from_db` method for the `Program` enumeration
- [x] Flatten the ProgramMap and DispatcherMap into BpfManager
- [x] Convert all bpfMap bits into sled