### PR TITLE
bpfman: move bpfman.sock to standalone directory

### DIFF
--- a/bpfman-api/src/util.rs
+++ b/bpfman-api/src/util.rs
@@ -32,8 +32,8 @@ pub mod directories {
     pub const RTDIR_FS_XDP: &str = "/run/bpfman/fs/xdp";
     pub const RTDIR_FS_MAPS: &str = "/run/bpfman/fs/maps";
     pub const RTDIR_PROGRAMS: &str = "/run/bpfman/programs";
-    pub const RTDIR_SOCK: &str = "/run/bpfman/sock";
-    pub const RTPATH_BPFMAN_SOCKET: &str = "/run/bpfman/sock/bpfman.sock";
+    pub const RTDIR_SOCK: &str = "/run/bpfman-sock";
+    pub const RTPATH_BPFMAN_SOCKET: &str = "/run/bpfman-sock/bpfman.sock";
     // The CSI socket must be in it's own sub directory so we can easily create a dedicated
     // K8s volume mount for it.
     pub const RTDIR_BPFMAN_CSI: &str = "/run/bpfman/csi";

--- a/bpfman-operator/config/bpfman-deployment/daemonset.yaml
+++ b/bpfman-operator/config/bpfman-deployment/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: bpfman-sock
-              mountPath: /run/bpfman/sock
+              mountPath: /run/bpfman-sock
             - name: runtime
               mountPath: /run/bpfman
               mountPropagation: Bidirectional
@@ -118,7 +118,7 @@ spec:
                   key: bpfman.agent.log.level
           volumeMounts:
             - name: bpfman-sock
-              mountPath: /run/bpfman/sock
+              mountPath: /run/bpfman-sock
             - name: bpfman-config
               mountPath: /etc/bpfman/bpfman.toml
               subPath: bpfman.toml

--- a/bpfman-operator/internal/constants.go
+++ b/bpfman-operator/internal/constants.go
@@ -41,7 +41,7 @@ const (
 	BpfmanCsiDriverPath         = "./config/bpfman-deployment/csidriverinfo.yaml"
 	BpfmanMapFs                 = "/run/bpfman/fs/maps"
 	DefaultType                 = "tcp"
-	DefaultPath                 = "/run/bpfman/sock/bpfman.sock"
+	DefaultPath                 = "/run/bpfman-sock/bpfman.sock"
 	DefaultPort                 = 50051
 	DefaultEnabled              = true
 )

--- a/docs/getting-started/running-rpm.md
+++ b/docs/getting-started/running-rpm.md
@@ -54,7 +54,7 @@ $ sudo systemctl status bpfman.socket
      Loaded: loaded (/usr/lib/systemd/system/bpfman.socket; enabled; preset: disabled)
      Active: active (listening) since Thu 2024-01-18 21:19:29 EST; 5s ago
    Triggers: ● bpfman.service
-     Listen: /run/bpfman/sock/bpfman.sock (Stream)
+     Listen: /run/bpfman-sock/bpfman.sock (Stream)
      CGroup: /system.slice/bpfman.socket
 :
 
@@ -149,7 +149,7 @@ $ sudo systemctl status bpfman.socket
      Loaded: loaded (/usr/lib/systemd/system/bpfman.socket; enabled; preset: disabled)
      Active: active (listening) since Thu 2024-01-18 21:19:29 EST; 5s ago
    Triggers: ● bpfman.service
-     Listen: /run/bpfman/sock/bpfman.sock (Stream)
+     Listen: /run/bpfman-sock/bpfman.sock (Stream)
      CGroup: /system.slice/bpfman.socket
 :
 

--- a/examples/pkg/config-mgmt/configfile.go
+++ b/examples/pkg/config-mgmt/configfile.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	DefaultPath = "/run/bpfman/sock/bpfman.sock"
+	DefaultPath = "/run/bpfman-sock/bpfman.sock"
 )
 
 func CreateConnection(ctx context.Context) (*grpc.ClientConn, error) {

--- a/scripts/bpfman.socket
+++ b/scripts/bpfman.socket
@@ -2,7 +2,7 @@
 Description=bpfman API Socket
 
 [Socket]
-ListenStream=/run/bpfman/sock/bpfman.sock
+ListenStream=/run/bpfman-sock/bpfman.sock
 SocketMode=0660
 
 [Install]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,6 +34,7 @@ CFG_CA_CERT_DIR="/etc/bpfman/certs/ca"
 # RuntimeDirectory: /run/bpfman/
 RUNTIME_DIR="/run/bpfman"
 RTDIR_FS="/run/bpfman/fs"
+RUNTIME_SOCKET_DIR="/run/bpfman-sock"
 
 # StateDirectory: /var/lib/bpfman/
 STATE_DIR="/var/lib/bpfman"

--- a/scripts/user.sh
+++ b/scripts/user.sh
@@ -12,6 +12,10 @@ delete_directories() {
         umount "${RTDIR_FS}"
         rm -rf "${RUNTIME_DIR}"
     fi
+    if test -d "${RUNTIME_SOCKET_DIR}"; then
+        echo "  Deleting \"${RUNTIME_SOCKET_DIR}\""
+        rm -rf "${RUNTIME_SOCKET_DIR}"
+    fi
     if test -d "${STATE_DIR}"; then
         echo "  Deleting \"${STATE_DIR}\""
         rm -rf "${STATE_DIR}"


### PR DESCRIPTION
On a redeploy of bpfman in a Kubernetes deployment (for example, edit the bpfman ConfigMap and change one of the log level values), bpfman fails to come back up. `/run/bpfman/sock/` is defined in the bpfman-deployment as an empty-dir, but on a restart, `/run/bpfman/` is remounted, but contains a non-empty `/run/bpfman/sock/` directory. This causes the container not to come up.

The fix is to rename `/run/bpfman/sock/bpfman.sock` to `/run/bpfman-sock/bpfman.sock`.

To reproduce:

```
kubectl edit configmap -n bpfman bpfman-config
apiVersion: v1
data:
  bpfman.agent.image: quay.io/bpfman/bpfman-agent:latest
  bpfman.agent.log.level: info
  bpfman.image: quay.io/bpfman/bpfman:latest
  bpfman.log.level: info -> debug
:

kubectl describe pod -n bpfman bpfman-daemon-sb95t
:
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Warning  Failed     23s (x3 over 36s)  kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/kubelet/pods/102843fe-2d3d-42d5-8c2d-c258d846b81e/volumes/kubernetes.io~empty-dir/bpfman-sock" to rootfs at "/run/bpfman/sock": possibly malicious path detected -- refusing to operate on /run/containerd/io.containerd.runtime.v2.task/k8s.io/bpfman/rootfs/run/bpfman/sock (deleted): unknown
```

See Issue #915, specifically https://github.com/bpfman/bpfman/issues/915#issuecomment-1894472712