### PR TITLE
bpfman: Make the listening socket configurable

### DIFF
--- a/bpfman/src/cli/args.rs
+++ b/bpfman/src/cli/args.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
+use std::path::PathBuf;
+
 use bpfman_api::ProgramType;
 use clap::{Args, Parser, Subcommand};
 use hex::FromHex;
@@ -332,6 +334,9 @@ pub(crate) struct ServiceArgs {
     /// Shutdown after N seconds of inactivity. Use 0 to disable.
     #[clap(long, default_value = "15")]
     pub(crate) timeout: u64,
+    #[clap(long, default_value = "/run/bpfman-sock/bpfman.sock")]
+    /// Configure the location of the bpfman unix socket.
+    pub(crate) socket_path: PathBuf,
 }
 
 #[derive(Subcommand, Debug)]

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -83,7 +83,7 @@ pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyh
     set_dir_permissions(STDIR, STDIR_MODE).await;
 
     //TODO https://github.com/bpfman/bpfman/issues/881
-    serve(config, args.csi_support, args.timeout).await?;
+    serve(config, args.csi_support, args.timeout, &args.socket_path).await?;
     Ok(())
 }
 

--- a/bpfman/src/storage.rs
+++ b/bpfman/src/storage.rs
@@ -371,7 +371,7 @@ impl StorageManager {
         let uds = UnixListener::bind(path)
             .unwrap_or_else(|_| panic!("failed to bind {RTPATH_BPFMAN_CSI_SOCKET}"));
         let uds_stream = UnixListenerStream::new(uds);
-        set_file_permissions(RTPATH_BPFMAN_CSI_SOCKET, SOCK_MODE).await;
+        set_file_permissions(Path::new(RTPATH_BPFMAN_CSI_SOCKET), SOCK_MODE).await;
 
         let node_service = NodeServer::new(self.csi_node);
         let identity_service = IdentityServer::new(self.csi_identity);

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -46,10 +46,13 @@ pub(crate) fn get_ifindex(iface: &str) -> Result<u32, BpfmanError> {
     }
 }
 
-pub(crate) async fn set_file_permissions(path: &str, mode: u32) {
+pub(crate) async fn set_file_permissions(path: &Path, mode: u32) {
     // Set the permissions on the file based on input
     if (tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).await).is_err() {
-        warn!("Unable to set permissions on file {}. Continuing", path);
+        warn!(
+            "Unable to set permissions on file {}. Continuing",
+            path.to_path_buf().display()
+        );
     }
 }
 
@@ -58,7 +61,7 @@ pub(crate) async fn set_dir_permissions(directory: &str, mode: u32) {
     let mut entries = fs::read_dir(directory).await.unwrap();
     while let Some(file) = entries.next_entry().await.unwrap() {
         // Set the permissions on the file based on input
-        set_file_permissions(&file.path().into_os_string().into_string().unwrap(), mode).await;
+        set_file_permissions(&file.path(), mode).await;
     }
 }
 


### PR DESCRIPTION
Make the socket bpfman listen's on configurable. This isn't currently useful for the CLI since the socket can't be configured there, but for external users like the bpfman-agent it is.

Follow up to #962 