### PR TITLE
operator: make health and metrics ports configurable

### DIFF
--- a/bpfman-operator/cmd/bpfman-agent/main.go
+++ b/bpfman-operator/cmd/bpfman-agent/main.go
@@ -59,8 +59,8 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var opts zap.Options
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8174", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8175", "The address the probe endpoint binds to.")
 	flag.Parse()
 
 	// Get the Log level for bpfman deployment where this pod is running

--- a/bpfman-operator/cmd/bpfman-operator/main.go
+++ b/bpfman-operator/cmd/bpfman-operator/main.go
@@ -52,8 +52,8 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var opts zap.Options
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8174", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8175", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/bpfman-operator/config/bpfman-deployment/config.yaml
+++ b/bpfman-operator/config/bpfman-deployment/config.yaml
@@ -11,3 +11,5 @@ data:
   bpfman.agent.log.level: "info"
   ## See https://docs.rs/env_logger/latest/env_logger/ for configuration options
   bpfman.log.level: "info"
+  bpfman.agent.healthprobe.addr: ":8175"
+  bpfman.agent.metric.addr: "127.0.0.1:8174"

--- a/bpfman-operator/config/bpfman-deployment/daemonset.yaml
+++ b/bpfman-operator/config/bpfman-deployment/daemonset.yaml
@@ -102,6 +102,9 @@ spec:
               name: host-proc
         - name: bpfman-agent
           command: [/bpfman-agent]
+          args:
+            - "--health-probe-bind-address=:8175"
+            - "--metrics-bind-address=127.0.0.1:8174"
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true

--- a/bpfman-operator/config/bpfman-operator-deployment/deployment.yaml
+++ b/bpfman-operator/config/bpfman-operator-deployment/deployment.yaml
@@ -84,13 +84,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: 8175
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: 8175
             initialDelaySeconds: 5
             periodSeconds: 10
           # TODO(user): Configure the resources accordingly based on the project requirements.

--- a/bpfman-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/default/manager_auth_proxy_patch.yaml
@@ -34,7 +34,7 @@ spec:
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8080/"
+            - "--upstream=http://127.0.0.1:8174/"
             - "--logtostderr=true"
             - "--v=0"
           ports:
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8081"
-            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--health-probe-bind-address=:8175"
+            - "--metrics-bind-address=127.0.0.1:8174"
             - "--leader-elect"

--- a/bpfman-operator/config/openshift/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/openshift/manager_auth_proxy_patch.yaml
@@ -34,7 +34,7 @@ spec:
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8080/"
+            - "--upstream=http://127.0.0.1:8174/"
             - "--logtostderr=true"
             - "--v=0"
           ports:
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8081"
-            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--health-probe-bind-address=:8175"
+            - "--metrics-bind-address=127.0.0.1:8174"
             - "--leader-elect"

--- a/bpfman-operator/config/test/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/test/manager_auth_proxy_patch.yaml
@@ -34,7 +34,7 @@ spec:
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8080/"
+            - "--upstream=http://127.0.0.1:8174/"
             - "--logtostderr=true"
             - "--v=0"
           ports:
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8081"
-            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--health-probe-bind-address=:8175"
+            - "--metrics-bind-address=127.0.0.1:8174"
             - "--leader-elect"

--- a/bpfman-operator/internal/constants.go
+++ b/bpfman-operator/internal/constants.go
@@ -37,6 +37,8 @@ const (
 	BpfmanDsName                = "bpfman-daemon"
 	BpfmanConfigName            = "bpfman-config"
 	BpfmanCsiDriverName         = "csi.bpfman.io"
+	BpfmanContainerName         = "bpfman"
+	BpfmanAgentContainerName    = "bpfman-agent"
 	BpfmanDaemonManifestPath    = "./config/bpfman-deployment/daemonset.yaml"
 	BpfmanCsiDriverPath         = "./config/bpfman-deployment/csidriverinfo.yaml"
 	BpfmanMapFs                 = "/run/bpfman/fs/maps"

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -11,7 +11,7 @@
             "program": "<ABSOLUTE_PATH>/github.com/bpfman/bpfman/target/debug/bpfman", // Local path to latest debug binary.
             "initCommands": [
                 "platform select remote-linux", // Execute `platform list` for a list of available remote platform plugins.
-                "platform connect connect://<IP_ADDRESS_OF_VM>:8081", // replace <IP_ADDRESS_OF_VM>
+                "platform connect connect://<IP_ADDRESS_OF_VM>:8175", // replace <IP_ADDRESS_OF_VM>
                 "settings set target.inherit-env false",
             ],
             "env": {

--- a/docs/developer-guide/logging.md
+++ b/docs/developer-guide/logging.md
@@ -109,7 +109,7 @@ To view the `bpfman-agent` logs:
 
 ```console
 kubectl logs -n bpfman bpfman-daemon-dgqzw -c bpfman-agent
-{"level":"info","ts":"2023-12-20T20:15:34Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
+{"level":"info","ts":"2023-12-20T20:15:34Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8174"}
 {"level":"info","ts":"2023-12-20T20:15:34Z","logger":"setup","msg":"Waiting for active connection to bpfman"}
 {"level":"info","ts":"2023-12-20T20:15:34Z","logger":"setup","msg":"starting Bpfman-Agent"}
 :
@@ -165,10 +165,10 @@ To view the `bpfman-operator` logs:
 
 ```console
 kubectl logs -n bpfman bpfman-operator-7fbf4888c4-z8w76 -c bpfman-operator
-{"level":"info","ts":"2023-05-09T18:37:11Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":"127.0.0.1:8080"}
+{"level":"info","ts":"2023-05-09T18:37:11Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":"127.0.0.1:8174"}
 {"level":"info","ts":"2023-05-09T18:37:11Z","logger":"setup","msg":"starting manager"}
-{"level":"info","ts":"2023-05-09T18:37:11Z","msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
-{"level":"info","ts":"2023-05-09T18:37:11Z","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"127.0.0.1:8080"}
+{"level":"info","ts":"2023-05-09T18:37:11Z","msg":"Starting server","kind":"health probe","addr":"[::]:8175"}
+{"level":"info","ts":"2023-05-09T18:37:11Z","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"127.0.0.1:8174"}
 I0509 18:37:11.262885       1 leaderelection.go:248] attempting to acquire leader lease bpfman/8730d955.bpfman.io...
 I0509 18:37:11.268918       1 leaderelection.go:258] successfully acquired lease bpfman/8730d955.bpfman.io
 {"level":"info","ts":"2023-05-09T18:37:11Z","msg":"Starting EventSource","controller":"configmap","controllerGroup":"","controllerKind":"ConfigMap","source":"kind source: *v1.ConfigMap"}
@@ -212,8 +212,8 @@ spec:
       - args:
 :
       - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --health-probe-bind-address=:8175
+        - --metrics-bind-address=127.0.0.1:8174
         - --leader-elect
         command:
         - /bpfman-operator


### PR DESCRIPTION
In some scenarios, the health and metric ports may are already in use by other services on the system. When this happens the bpfman-agent container fails to deploy. The current default is 8080 and 8081. First, move the port numbers to something less common. Then make the values configurable.
    
The ports are passed in through the yaml files. However, the bpfd-agent releated yaml files are built into the bpfman-operator image, so the values cannot be easily changed without rebuilding the image. So add fields to the ConfigMap so they can be overwritten without rebuilding the bpfman-operator image.

Resolves: #914 