### PR TITLE
DROP: Temporarily drop  rust-cache action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
           components: rustfmt, clippy, rust-src
           override: false
 
-      - uses: Swatinem/rust-cache@v2
+      ## TODO(astoycos) Deactivate the rust-cache action until we can determine
+      ## why it's freezing at the end of the install.
+      ## - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
Temporarily drop the rust-cache action since it just hangs following it's run, we'll need to go back and re-activate this at some point 
