### PR TITLE
build: set golang to 1.21 for github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.19"
+          go-version: '^1.21'
 
       - name: cache go modules
         uses: actions/cache@v4


### PR DESCRIPTION
Upstream main builds have been failing:
```
Run cd bpfman-operator && make bundle
:
go: downloading golang.org/x/text v0.5.0
/home/runner/work/bpfman/bpfman/bpfman-operator/bin/controller-gen crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
controllers/bpfman-agent/common.go:25:2: package slices is not in GOROOT (/opt/hostedtoolcache/go/1.20.13/x64/src/slices)
Error: not all generators ran successfully
run `controller-gen crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [Makefile:192: manifests] Error 1
```

The error mentions `/opt/hostedtoolcache/go/1.20.13/x64/src/slices` but I believe slices package wasn't introduced until go 1.21.
