### PR TITLE
build: make bundle failing on upstream main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-02-03
           components: rustfmt, clippy, rust-src
           override: false
 
@@ -83,11 +83,11 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +nightly fmt --all -- --check
+          cargo +nightly-2024-02-03 fmt --all -- --check
 
       - name: Run clippy
         run: |
-          cargo +nightly clippy --all -- --deny warnings
+          cargo +nightly-2024-02-03 clippy --all -- --deny warnings
 
       - name: Build
         run: cargo build --verbose
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-02-03
           components: rust-src
           override: true
 

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         image:
           - registry: quay.io
+            build_language: rust
             repository: bpfman
             image: bpfman
             dockerfile: ./Containerfile.bpfman
@@ -35,6 +36,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman
             image: bpfman-agent
             dockerfile: ./bpfman-operator/Containerfile.bpfman-agent
@@ -48,6 +50,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman
             image: bpfman-operator
             dockerfile: ./bpfman-operator/Containerfile.bpfman-operator
@@ -61,6 +64,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman
             image: bpfman-operator-bundle
             context: ./bpfman-operator
@@ -74,6 +78,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman-userspace
             image: go-xdp-counter
             context: .
@@ -87,6 +92,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman-userspace
             image: go-tc-counter
             context: .
@@ -100,6 +106,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             repository: bpfman-userspace
             image: go-tracepoint-counter
             context: .
@@ -113,6 +120,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             bpf_build_wrapper: go
             repository: bpfman-bytecode
             image: go-xdp-counter
@@ -132,6 +140,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             bpf_build_wrapper: go
             repository: bpfman-bytecode
             image: go-tc-counter
@@ -151,6 +160,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
             bpf_build_wrapper: go
             repository: bpfman-bytecode
             image: go-tracepoint-counter
@@ -170,6 +180,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: xdp_pass
@@ -189,6 +200,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: xdp_pass_private
@@ -208,6 +220,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: tc_pass
@@ -227,6 +240,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: tracepoint
@@ -246,6 +260,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: uprobe
@@ -265,6 +280,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: uretprobe
@@ -284,6 +300,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: kprobe
@@ -303,6 +320,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
             image: kretprobe
@@ -322,6 +340,7 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman
             image: xdp-dispatcher
@@ -332,6 +351,7 @@ jobs:
               type=raw,value=v1,enable=true
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman
             image: xdp-dispatcher
@@ -342,6 +362,7 @@ jobs:
               type=raw,value=v2,enable=true
 
           - registry: quay.io
+            build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman
             image: tc-dispatcher
@@ -356,7 +377,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
-        if: ${{ matrix.image.bpf_build_wrapper == 'go' }}
+        if: ${{ matrix.image.build_language == 'go' }}
         with:
           go-version: "1.21"
 
@@ -369,7 +390,7 @@ jobs:
           path: libbpf
 
       - uses: actions-rs/toolchain@v1
-        if: ${{ matrix.image.bpf_build_wrapper == 'rust' }}
+        if: ${{ matrix.image.build_language == 'rust' }}
         with:
           toolchain: stable
           override: true


### PR DESCRIPTION
Upstream main builds have been failing:

```
Run cd bpfman-operator && make bundle
:
go: downloading golang.org/x/text v0.5.0
/home/runner/work/bpfman/bpfman/bpfman-operator/bin/controller-gen crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
controllers/bpfman-agent/common.go:25:2: package slices is not in GOROOT (/opt/hostedtoolcache/go/1.20.13/x64/src/slices)
Error: not all generators ran successfully
run `controller-gen crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [Makefile:192: manifests] Error 1
```

The error mentions `/opt/hostedtoolcache/go/1.20.13/x64/src/slices` but I believe slices package wasn't introduced until go 1.21.


While working on the above issue, clippy errors started. This also includes a commit to pin the rust toolchain to nightly-2024-02-03 until the clippy issue gets fixed. Backing out this change is tracked by #977 