### PR TITLE
bpfman: add retries to sled access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -242,7 +242,7 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.11.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#c31cce4a368ac56b42196604ef110139d28a2f8e"
+source = "git+https://github.com/aya-rs/aya?branch=main#963dd1321925c95f80c8a2bf656b88a39497ca01"
 dependencies = [
  "assert_matches",
  "aya-obj",
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?branch=main#c31cce4a368ac56b42196604ef110139d28a2f8e"
+source = "git+https://github.com/aya-rs/aya?branch=main#963dd1321925c95f80c8a2bf656b88a39497ca01"
 dependencies = [
  "bytes",
  "core-error",
@@ -374,12 +374,12 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "lazy_static",
  "libsystemd 0.7.0",
  "log",
  "netlink-packet-route",
  "nix 0.27.1",
  "oci-distribution",
+ "once_cell",
  "rand",
  "rtnetlink",
  "serde",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -1265,7 +1265,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1302,9 +1302,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -1504,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1985,19 +1985,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2006,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -2107,7 +2106,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2341,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -3548,7 +3547,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4293,9 +4292,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ log = { version = "0.4", default-features = false }
 netlink-packet-route = { version = "^0.19", default-features = false }
 nix = { version = "0.27", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
+once_cell = { version = "1.19.0", default-features = false }
 opentelemetry = { version = "0.21.0", default-features = false }
 opentelemetry-otlp = { version = "0.14.0", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.13.0" }

--- a/bpfman-api/src/config.rs
+++ b/bpfman-api/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub interfaces: Option<HashMap<String, InterfaceConfig>>,
     #[serde(default)]
     pub signing: Option<SigningConfig>,
+    pub database: Option<DatabaseConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -26,6 +27,23 @@ impl Default for SigningConfig {
         Self {
             // Allow unsigned programs by default
             allow_unsigned: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct DatabaseConfig {
+    pub max_retries: u32,
+    pub millisec_delay: u64,
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            // Maximum numbers of times to attempt to open the database after a failed attempt
+            max_retries: 4,
+            // Number of milli-seconds to wait between failed database attempts
+            millisec_delay: 500,
         }
     }
 }

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -33,7 +33,6 @@ env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
-lazy_static = { workspace = true }
 libsystemd = { workspace = true }
 log = { workspace = true }
 netlink-packet-route = { workspace = true }
@@ -49,6 +48,7 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "rustls-tls",
     "trust-dns",
 ] }
+once_cell = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }

--- a/bpfman/src/cli/args.rs
+++ b/bpfman/src/cli/args.rs
@@ -20,7 +20,7 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum Commands {
-    /// Load an eBPF program from a local .o file.
+    /// Load an eBPF program on the system.
     #[command(subcommand)]
     Load(LoadSubcommand),
     /// Unload an eBPF program using the program id.
@@ -328,11 +328,12 @@ pub(crate) struct PullBytecodeArgs {
 #[derive(Args, Debug)]
 #[command(disable_version_flag = true)]
 pub(crate) struct ServiceArgs {
-    /// Enable CSI support.
-    #[clap(long)]
+    /// Optional: Enable CSI support. Only supported when run in a Kubernetes
+    /// environment with bpfman-agent.
+    #[clap(long, verbatim_doc_comment)]
     pub(crate) csi_support: bool,
-    /// Shutdown after N seconds of inactivity. Use 0 to disable.
-    #[clap(long, default_value = "15")]
+    /// Optional: Shutdown after N seconds of inactivity. Use 0 to disable.
+    #[clap(long, verbatim_doc_comment, default_value = "15")]
     pub(crate) timeout: u64,
     #[clap(long, default_value = "/run/bpfman-sock/bpfman.sock")]
     /// Configure the location of the bpfman unix socket.
@@ -342,7 +343,7 @@ pub(crate) struct ServiceArgs {
 #[derive(Subcommand, Debug)]
 #[command(disable_version_flag = true)]
 pub(crate) enum SystemSubcommand {
-    /// Load an eBPF program from a local .o file.
+    /// Run bpfman as a service.
     Service(ServiceArgs),
 }
 

--- a/bpfman/src/cli/get.rs
+++ b/bpfman/src/cli/get.rs
@@ -1,17 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use bpfman_api::v1::{bpfman_client::BpfmanClient, GetRequest};
+use bpfman_api::{
+    config::Config,
+    v1::{KernelProgramInfo, ProgramInfo},
+};
+use log::warn;
 
-use crate::cli::{args::GetArgs, select_channel, table::ProgTable};
+use crate::{
+    bpf::BpfManager,
+    cli::{args::GetArgs, table::ProgTable},
+    command::Program,
+    errors::BpfmanError,
+};
 
-pub(crate) async fn execute_get(args: &GetArgs) -> Result<(), anyhow::Error> {
-    let channel = select_channel().expect("failed to select channel");
-    let mut client = BpfmanClient::new(channel);
-    let request = tonic::Request::new(GetRequest { id: args.id });
-    let response = client.get(request).await?.into_inner();
+pub(crate) async fn execute_get(config: &Config, args: &GetArgs) -> Result<(), BpfmanError> {
+    //let channel = select_channel().expect("failed to select channel");
+    //let mut client = BpfmanClient::new(channel);
+    //let request = tonic::Request::new(GetRequest { id: args.id });
+    //let response = client.get(request).await?.into_inner();
+    let mut bpf_manager = BpfManager::new(config.clone(), None, None);
 
-    ProgTable::new_get_bpfman(&response.info)?.print();
-    ProgTable::new_get_unsupported(&response.kernel_info)?.print();
-    Ok(())
+    match bpf_manager.get_program(args.id) {
+        Ok(program) => {
+            let info: Option<ProgramInfo> = if let Program::Unsupported(_) = program {
+                None
+            } else {
+                Some((&program).try_into()?)
+            };
+            let kernel_info: Option<KernelProgramInfo> = match (&program).try_into() {
+                Ok(i) => {
+                    if let Program::Unsupported(_) = program {
+                        program.delete()?;
+                    };
+                    Some(i)
+                }
+                Err(e) => return Err(e),
+            };
+
+            ProgTable::new_get_bpfman(&info)?.print();
+            ProgTable::new_get_unsupported(&kernel_info)?.print();
+            Ok(())
+        }
+        Err(e) => {
+            warn!("BPFMAN get error: {}", e);
+            Err(e)
+        }
+    }
 }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -33,6 +33,14 @@ impl SystemSubcommand {
 }
 
 pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyhow::Result<()> {
+    initialize_bpfman().await?;
+
+    //TODO https://github.com/bpfman/bpfman/issues/881
+    serve(config, args.csi_support, args.timeout, &args.socket_path).await?;
+    Ok(())
+}
+
+pub(crate) async fn initialize_bpfman() -> anyhow::Result<()> {
     if connected_to_journal() {
         // If bpfman is running as a service, log to journald.
         JournalLog::default()
@@ -82,8 +90,6 @@ pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyh
     set_dir_permissions(RTDIR, RTDIR_MODE).await;
     set_dir_permissions(STDIR, STDIR_MODE).await;
 
-    //TODO https://github.com/bpfman/bpfman/issues/881
-    serve(config, args.csi_support, args.timeout, &args.socket_path).await?;
     Ok(())
 }
 

--- a/bpfman/src/errors.rs
+++ b/bpfman/src/errors.rs
@@ -56,4 +56,6 @@ pub enum BpfmanError {
     },
     #[error("{0}: {1}")]
     DatabaseError(String, String),
+    #[error("Internal error occurred. {0}")]
+    InternalError(String),
 }

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -62,6 +62,8 @@ impl TcDispatcher {
         revision: u32,
     ) -> Result<Self, BpfmanError> {
         let db_tree = ROOT_DB
+            .get()
+            .expect("unable to open database")
             .open_tree(format!(
                 "{}_{}_{}_{}",
                 TC_DISPATCHER_PREFIX, if_index, direction, revision
@@ -401,15 +403,19 @@ impl TcDispatcher {
             if_index, revision
         );
 
-        ROOT_DB.drop_tree(self.db_tree.name()).map_err(|e| {
-            BpfmanError::DatabaseError(
-                format!(
-                    "unable to drop tc dispatcher tree {:?}",
-                    self.db_tree.name()
-                ),
-                e.to_string(),
-            )
-        })?;
+        ROOT_DB
+            .get()
+            .expect("unable to open database")
+            .drop_tree(self.db_tree.name())
+            .map_err(|e| {
+                BpfmanError::DatabaseError(
+                    format!(
+                        "unable to drop tc dispatcher tree {:?}",
+                        self.db_tree.name()
+                    ),
+                    e.to_string(),
+                )
+            })?;
 
         let base = match direction {
             Direction::Ingress => RTDIR_FS_TC_INGRESS,

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -51,6 +51,8 @@ impl XdpDispatcher {
         revision: u32,
     ) -> Result<Self, BpfmanError> {
         let db_tree = ROOT_DB
+            .get()
+            .expect("unable to open database")
             .open_tree(format!(
                 "{}_{}_{}",
                 XDP_DISPATCHER_PREFIX, if_index, revision
@@ -328,15 +330,19 @@ impl XdpDispatcher {
             "XdpDispatcher::delete() for if_index {}, revision {}, full {}",
             if_index, revision, full
         );
-        ROOT_DB.drop_tree(self.db_tree.name()).map_err(|e| {
-            BpfmanError::DatabaseError(
-                format!(
-                    "unable to drop xdp dispatcher tree {:?}",
-                    self.db_tree.name()
-                ),
-                e.to_string(),
-            )
-        })?;
+        ROOT_DB
+            .get()
+            .expect("unable to open database")
+            .drop_tree(self.db_tree.name())
+            .map_err(|e| {
+                BpfmanError::DatabaseError(
+                    format!(
+                        "unable to drop xdp dispatcher tree {:?}",
+                        self.db_tree.name()
+                    ),
+                    e.to_string(),
+                )
+            })?;
 
         let path = format!("{RTDIR_FS_XDP}/dispatcher_{}_{}", if_index, revision);
         fs::remove_dir_all(path)

--- a/bpfman/src/rpc.rs
+++ b/bpfman/src/rpc.rs
@@ -134,7 +134,10 @@ impl Bpfman for BpfmanLoader {
             responder: resp_tx,
         };
 
-        // Send the GET request
+        // Send the LOAD request
+        // TODO: This channel can be removed. It was in place because main bpfman thread
+        //       had the privileges and RPC thread did not. But now that we are unwinding
+        //       that, this can call bpfman directly.
         self.tx.send(Command::Load(load_args)).await.unwrap();
 
         // Await the response

--- a/bpfman/src/serve.rs
+++ b/bpfman/src/serve.rs
@@ -24,10 +24,10 @@ use tonic::transport::Server;
 use crate::{
     bpf::BpfManager,
     oci_utils::ImageManager,
+    root_db_init,
     rpc::BpfmanLoader,
     storage::StorageManager,
     utils::{set_file_permissions, SOCK_MODE},
-    ROOT_DB,
 };
 
 pub async fn serve(
@@ -52,7 +52,8 @@ pub async fn serve(
 
     let allow_unsigned = config.signing.as_ref().map_or(true, |s| s.allow_unsigned);
 
-    let mut image_manager = ImageManager::new(ROOT_DB.clone(), allow_unsigned, irx).await?;
+    let mut image_manager =
+        ImageManager::new(root_db_init(config).clone(), allow_unsigned, irx).await?;
     let image_manager_handle = tokio::spawn(async move {
         image_manager.run(shutdown_rx2).await;
     });

--- a/scripts/bpfman.toml
+++ b/scripts/bpfman.toml
@@ -1,3 +1,10 @@
 [interfaces]
 [interface.eth0]
 xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
+
+[signing]
+allow_unsigned = true
+
+[database]
+max_retries = 4
+millisec_delay = 500


### PR DESCRIPTION
To support removing RPC from the bpfman CLI, add a retry to the sled DB access so whien multiple simultaneous CLI calls are made, the additional calls won't panic immediately but will retry after a delay.