### PR TITLE
ci: Don't fail the build on codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: "^1.21"
 
       - name: cache go modules
         uses: actions/cache@v4
@@ -326,7 +326,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
           files: ./cover.out,./lcov.info
           verbose: true
 


### PR DESCRIPTION
If uploads still regularly fail we might wish to consider another service for code coverage.