### PR TITLE
chore: Fix yamllint/vscode-yaml formatting discrepencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,21 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+        dependency-type: development
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
     tags:
-      - "v*"
+      - v*
 
   pull_request:
     branches:
@@ -140,7 +140,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          # prettier-ignore
+          go-version: '1.21' # yamllint disable-line rule:quoted-strings
 
       - name: Go mod check
         working-directory: ${{ github.workspace }}
@@ -179,7 +180,7 @@ jobs:
 
   basic-integration-tests:
     runs-on: ubuntu-latest
-    needs: ["build", "build-go"]
+    needs: [build, build-go]
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -245,12 +246,12 @@ jobs:
         run: cargo xtask integration-test
 
   kubernetes-integration-tests:
-    needs: ["build", "build-go"]
+    needs: [build, build-go]
     runs-on: ubuntu-latest
     env:
-      BPFMAN_IMG: "quay.io/bpfman/bpfman:int-test"
-      BPFMAN_AGENT_IMG: "quay.io/bpfman/bpfman-agent:int-test"
-      BPFMAN_OPERATOR_IMG: "quay.io/bpfman/bpfman-operator:int-test"
+      BPFMAN_IMG: quay.io/bpfman/bpfman:int-test
+      BPFMAN_AGENT_IMG: quay.io/bpfman/bpfman-agent:int-test
+      BPFMAN_OPERATOR_IMG: quay.io/bpfman/bpfman-operator:int-test
       XDP_PASS_PRIVATE_IMAGE_CREDS: ${{ secrets.XDP_PASS_PRIVATE_IMAGE_CREDS }}
     steps:
       - name: Install dependencies
@@ -266,7 +267,8 @@ jobs:
       - name: setup golang
         uses: actions/setup-go@v5
         with:
-          go-version: "^1.21"
+          # prettier-ignore
+          go-version: '1.21' # yamllint disable-line rule:quoted-strings
 
       - name: cache go modules
         uses: actions/cache@v4
@@ -308,7 +310,7 @@ jobs:
           if-no-files-found: ignore
 
   coverage:
-    needs: ["build", "build-go"]
+    needs: [build, build-go]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -334,7 +336,7 @@ jobs:
   # Publish's bpfman and bpfman-api crates to crates.io
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: ["build"]
+    needs: [build]
     environment: crates.io
     runs-on: ubuntu-latest
     steps:
@@ -365,12 +367,12 @@ jobs:
   build-workflow-complete:
     needs:
       [
-        "check-license",
-        "build",
-        "build-go",
-        "coverage",
-        "basic-integration-tests",
-        "kubernetes-integration-tests",
+        check-license,
+        build,
+        build-go,
+        coverage,
+        basic-integration-tests,
+        kubernetes-integration-tests,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -4,7 +4,7 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
     tags:
-      - "v*"
+      - v*
 
 jobs:
   build-docs:
@@ -20,7 +20,8 @@ jobs:
           python-version: 3.8
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          # prettier-ignore
+          go-version: '1.21' # yamllint disable-line rule:quoted-strings
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -4,10 +4,10 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
     tags:
-      - "v*"
+      - v*
 
   pull_request:
-    paths: [".github/workflows/image-build.yaml"]
+    paths: [.github/workflows/image-build.yaml]
 
 jobs:
   build-and-push-images:
@@ -379,7 +379,8 @@ jobs:
       - uses: actions/setup-go@v5
         if: ${{ matrix.image.build_language == 'go' }}
         with:
-          go-version: "1.21"
+          # prettier-ignore
+          go-version: '1.21' # yamllint disable-line rule:quoted-strings
 
       - uses: sigstore/cosign-installer@v3.4.0
 

--- a/.packit.yml
+++ b/.packit.yml
@@ -10,7 +10,7 @@ srpm_build_deps:
   - openssl-devel
 actions:
   fix-spec-file:
-    - "bash .packit.sh"
+    - bash .packit.sh
   get-current-version:
     - bash -c 'cargo metadata --format-version 1 | jq -r ".packages[] | select(.name == \"bpfman\") | .version"'
   post-upstream-clone:
@@ -26,7 +26,7 @@ jobs:
     branch: main
     specfile_path: bpfman.spec
     owner: "@ebpf-sig"
-    project: "bpfman-next"
+    project: bpfman-next
     targets:
       - fedora-all
   - job: tests
@@ -39,7 +39,7 @@ jobs:
     branch: main
     specfile_path: bpfman.spec
     owner: "@ebpf-sig"
-    project: "bpfman"
+    project: bpfman
     targets:
       - fedora-all
   - job: tests

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,9 @@ rules:
   document-start: disable
   comments:
     min-spaces-from-content: 1
+  quoted-strings:
+    required: only-when-needed
+    quote-type: double
 ignore:
   - libbpf/*
   - vendor/*

--- a/bpfman-operator/config/bpfman-deployment/config.yaml
+++ b/bpfman-operator/config/bpfman-deployment/config.yaml
@@ -8,8 +8,8 @@ data:
   bpfman.agent.image: quay.io/bpfman/bpfman-agent:latest
   bpfman.image: quay.io/bpfman/bpfman:latest
   ## Can be set to "info", "debug", or "trace"
-  bpfman.agent.log.level: "info"
+  bpfman.agent.log.level: info
   ## See https://docs.rs/env_logger/latest/env_logger/ for configuration options
-  bpfman.log.level: "info"
-  bpfman.agent.healthprobe.addr: ":8175"
-  bpfman.agent.metric.addr: "127.0.0.1:8174"
+  bpfman.log.level: info
+  bpfman.agent.healthprobe.addr: :8175
+  bpfman.agent.metric.addr: 127.0.0.1:8174

--- a/bpfman-operator/config/bpfman-deployment/daemonset.yaml
+++ b/bpfman-operator/config/bpfman-deployment/daemonset.yaml
@@ -103,8 +103,8 @@ spec:
         - name: bpfman-agent
           command: [/bpfman-agent]
           args:
-            - "--health-probe-bind-address=:8175"
-            - "--metrics-bind-address=127.0.0.1:8174"
+            - --health-probe-bind-address=:8175
+            - --metrics-bind-address=127.0.0.1:8174
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true

--- a/bpfman-operator/config/bpfman-operator-deployment/deployment.yaml
+++ b/bpfman-operator/config/bpfman-operator-deployment/deployment.yaml
@@ -74,13 +74,13 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: GO_LOG
-              value: "debug"
+              value: debug
           name: bpfman-operator
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - "ALL"
+                - ALL
           livenessProbe:
             httpGet:
               path: /healthz

--- a/bpfman-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/default/manager_auth_proxy_patch.yaml
@@ -30,13 +30,13 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - "ALL"
+                - ALL
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
-            - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8174/"
-            - "--logtostderr=true"
-            - "--v=0"
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8174/
+            - --logtostderr=true
+            - --v=0
           ports:
             - containerPort: 8443
               protocol: TCP
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8175"
-            - "--metrics-bind-address=127.0.0.1:8174"
-            - "--leader-elect"
+            - --health-probe-bind-address=:8175
+            - --metrics-bind-address=127.0.0.1:8174
+            - --leader-elect

--- a/bpfman-operator/config/openshift/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/openshift/manager_auth_proxy_patch.yaml
@@ -30,13 +30,13 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - "ALL"
+                - ALL
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
-            - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8174/"
-            - "--logtostderr=true"
-            - "--v=0"
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8174/
+            - --logtostderr=true
+            - --v=0
           ports:
             - containerPort: 8443
               protocol: TCP
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8175"
-            - "--metrics-bind-address=127.0.0.1:8174"
-            - "--leader-elect"
+            - --health-probe-bind-address=:8175
+            - --metrics-bind-address=127.0.0.1:8174
+            - --leader-elect

--- a/bpfman-operator/config/openshift/patch.yaml
+++ b/bpfman-operator/config/openshift/patch.yaml
@@ -8,8 +8,8 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
   annotations:
     openshift.io/node-selector: ""
-    openshift.io/description: "Openshift bpfman components"
-    workload.openshift.io/allowed: "management"
+    openshift.io/description: Openshift bpfman components
+    workload.openshift.io/allowed: management
   name: system
 ---
 apiVersion: v1
@@ -19,5 +19,5 @@ metadata:
   namespace: kube-system
 data:
   ## Can be configured at runtime
-  bpfman.log.level: "info"
-  bpfman.agent.log.level: "info"
+  bpfman.log.level: info
+  bpfman.agent.log.level: info

--- a/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram_containers.yaml
+++ b/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram_containers.yaml
@@ -25,7 +25,7 @@ spec:
       - 0x0B
       - 0x0A
   containers:
-    namespace: "bpfman"
+    namespace: bpfman
     pods:
       matchLabels:
         name: bpfman-daemon

--- a/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram_nginx.yaml
+++ b/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram_nginx.yaml
@@ -26,7 +26,7 @@ spec:
       - 0x0B
       - 0x0A
   containers:
-    namespace: "default"
+    namespace: default
     pods:
       matchLabels: {}
     containernames:

--- a/bpfman-operator/config/test/manager_auth_proxy_patch.yaml
+++ b/bpfman-operator/config/test/manager_auth_proxy_patch.yaml
@@ -30,13 +30,13 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - "ALL"
+                - ALL
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:
-            - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8174/"
-            - "--logtostderr=true"
-            - "--v=0"
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8174/
+            - --logtostderr=true
+            - --v=0
           ports:
             - containerPort: 8443
               protocol: TCP
@@ -50,6 +50,6 @@ spec:
               memory: 64Mi
         - name: bpfman-operator
           args:
-            - "--health-probe-bind-address=:8175"
-            - "--metrics-bind-address=127.0.0.1:8174"
-            - "--leader-elect"
+            - --health-probe-bind-address=:8175
+            - --metrics-bind-address=127.0.0.1:8174
+            - --leader-elect

--- a/examples/config/v0.2.0/go-tc-counter/kustomization.yaml
+++ b/examples/config/v0.2.0/go-tc-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: TcProgram
-      name: "go-tc-counter-example"
+      name: go-tc-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.2.0/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/v0.2.0/go-tracepoint-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: TracepointProgram
-      name: "go-tracepoint-counter-example"
+      name: go-tracepoint-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.2.0/go-xdp-counter/kustomization.yaml
+++ b/examples/config/v0.2.0/go-xdp-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: XdpProgram
-      name: "go-xdp-counter-example"
+      name: go-xdp-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.3.0/go-tc-counter/kustomization.yaml
+++ b/examples/config/v0.3.0/go-tc-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: TcProgram
-      name: "go-tc-counter-example"
+      name: go-tc-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.3.0/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/v0.3.0/go-tracepoint-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: TracepointProgram
-      name: "go-tracepoint-counter-example"
+      name: go-tracepoint-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.3.0/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/v0.3.0/go-xdp-counter-sharing-map/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: XdpProgram
-      name: "go-xdp-counter-example"
+      name: go-xdp-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.3.0/go-xdp-counter/kustomization.yaml
+++ b/examples/config/v0.3.0/go-xdp-counter/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 patches:
   - target:
       kind: XdpProgram
-      name: "go-xdp-counter-example"
+      name: go-xdp-counter-example
     patch: |-
       - op: replace
         path: "/spec/bytecode/image/url"

--- a/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml
+++ b/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml
@@ -1,5 +1,5 @@
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/packaging/vm-deployment/provision.yaml
+++ b/packaging/vm-deployment/provision.yaml
@@ -6,7 +6,7 @@
   tasks:
     - name: Set Variables
       set_fact:
-        vagrant_user: "vagrant"
+        vagrant_user: vagrant
 
     - name: Make directories for bpfman binaries and scripts
       shell: |
@@ -37,7 +37,7 @@
 
     - name: Install packages
       package:
-        name: ["openssl", "acl"]
+        name: [openssl, acl]
 
     - name: Change the working directory to bpfman/scripts and run
       become: true


### PR DESCRIPTION
Tell yamllint to prefer double quotes + nag on unnecessary quotes. Tell prettier (used in vscode-yaml) to ignore the golang versions, that are in single quotes due to "1.20" being shortened to 1.2, which has strange results.