### PR TITLE
speed up bpfman image build

### DIFF
--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -2,13 +2,7 @@
 ## builds, dramatically speeding up the local development process.
 FROM rust:1 as bpfman-build
 
-RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfman/libbpf
-
 RUN apt-get update && apt-get install -y\
-    git\
-    clang\
-    protobuf-compiler\
-    libelf-dev\
     gcc-multilib\
     musl-tools
 
@@ -16,11 +10,6 @@ WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
 
 RUN rustup target add x86_64-unknown-linux-musl
-
-# Compile only the C ebpf bytecode
-RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo xtask build-ebpf --release --libbpf-dir /usr/src/bpfman/libbpf
 
 # Compile only bpfman
 RUN --mount=type=cache,target=/usr/src/bpfman/target/ \


### PR DESCRIPTION
Stop building ebpf bytecode as part of the core
bpfman image build process, since now the dispatcher bytecode is pulled from OCI images.

Super small change, but I'm seeing a dramatic decrease in build time by removing some dependencies! 

BEFORE 221.0 seconds fresh build

```bash
[astoycos@nfvsdn-02-oot bpfman]$ DOCKER_BUILDKIT=1 docker build -f Containerfile.bpfman.local  .
[+] Building 221.0s (21/21) FINISHED                                                                                                                                                          
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 65B                                                                                                                                                         0.0s
 => [internal] load build definition from Containerfile.bpfman.local                                                                                                                     0.0s
 => => transferring dockerfile: 1.53kB                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/fedora:38                                                                                                                             0.2s
 => [internal] load metadata for docker.io/library/rust:1                                                                                                                                0.2s
 => [auth] library/fedora:pull token for registry-1.docker.io                                                                                                                            0.0s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                                                              0.0s
 => CACHED [stage-1 1/3] FROM docker.io/library/fedora:38@sha256:3f01c8f79691df76331cb4bb0944794a60850475e859c15e49513fcbe0a3d88a                                                        0.0s
 => [internal] load build context                                                                                                                                                        0.1s
 => => transferring context: 49.31kB                                                                                                                                                     0.0s
 => [bpfman-build  1/10] FROM docker.io/library/rust:1@sha256:fd260ac37e010eb35e8e1bf6ce6c714a51d760a421690883ed77c637951d331c                                                          28.3s
 => => resolve docker.io/library/rust:1@sha256:fd260ac37e010eb35e8e1bf6ce6c714a51d760a421690883ed77c637951d331c                                                                          0.0s
 => => sha256:fd260ac37e010eb35e8e1bf6ce6c714a51d760a421690883ed77c637951d331c 6.17kB / 6.17kB                                                                                           0.0s
 => => sha256:9bf8062398ef8c2cad01b29624dce55c90cfaba824682b093b88e2128aba7916 1.94kB / 1.94kB                                                                                           0.0s
 => => sha256:e4ca6875abb0d32622c96de43aa2c5d3b55c4a235256e716bb2dbcee0cfa95e1 3.99kB / 3.99kB                                                                                           0.0s
 => => sha256:6a299ae9cfd996c1149a699d36cdaa76fa332c8e9d66d6678fa9a231d9ead04c 49.58MB / 49.58MB                                                                                         1.4s
 => => sha256:e08e8703b2fb5e50153f792f3192087d26970d262806b397049d61b9a14b3af5 24.05MB / 24.05MB                                                                                         0.7s
 => => sha256:68e92d11b04ec0fe48e60d59964704aca234084f87af5d1a068c49456b37fe3d 64.14MB / 64.14MB                                                                                         2.1s
 => => sha256:5b9fe7fef9befda786bc8e1dd1ae42ffd8b9c37a4cce3c433e65ebb890cb1672 211.11MB / 211.11MB                                                                                       6.3s
 => => extracting sha256:6a299ae9cfd996c1149a699d36cdaa76fa332c8e9d66d6678fa9a231d9ead04c                                                                                                3.3s
 => => sha256:d069ab9fbbda8d665751dae3953a8a28248db49aca5d8085ab60b35823b9e344 179.48MB / 179.48MB                                                                                       4.7s
 => => extracting sha256:e08e8703b2fb5e50153f792f3192087d26970d262806b397049d61b9a14b3af5                                                                                                1.0s
 => => extracting sha256:68e92d11b04ec0fe48e60d59964704aca234084f87af5d1a068c49456b37fe3d                                                                                                4.0s
 => => extracting sha256:5b9fe7fef9befda786bc8e1dd1ae42ffd8b9c37a4cce3c433e65ebb890cb1672                                                                                               10.9s
 => => extracting sha256:d069ab9fbbda8d665751dae3953a8a28248db49aca5d8085ab60b35823b9e344                                                                                                6.6s
 => [stage-1 2/3] RUN dnf makecache --refresh && dnf -y install bpftool tcpdump                                                                                                        115.4s
 => [bpfman-build  2/10] RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfman/libbpf                                                                          16.9s
 => [bpfman-build  3/10] RUN apt-get update && apt-get install -y    git    clang    protobuf-compiler    libelf-dev    gcc-multilib    musl-tools                                      24.4s
 => [bpfman-build  4/10] WORKDIR /usr/src/bpfman                                                                                                                                         0.2s
 => [bpfman-build  5/10] COPY ./ /usr/src/bpfman                                                                                                                                         5.7s
 => [bpfman-build  6/10] RUN rustup target add x86_64-unknown-linux-musl                                                                                                                 5.6s
 => [bpfman-build  7/10] RUN --mount=type=cache,target=/usr/src/bpfman/target/     --mount=type=cache,target=/usr/local/cargo/registry     cargo xtask build-ebpf --release --libbpf-d  41.2s
 => [bpfman-build  8/10] RUN --mount=type=cache,target=/usr/src/bpfman/target/     --mount=type=cache,target=/usr/local/cargo/registry     cargo build --release --target x86_64-unkno  94.2s
 => [bpfman-build  9/10] RUN --mount=type=cache,target=/usr/src/bpfman/target/     cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman ./bpfman/                          0.4s
 => [bpfman-build 10/10] RUN --mount=type=cache,target=/usr/src/bpfman/target/     cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman-ns ./bpfman/                       0.4s
 => [stage-1 3/3] COPY --from=bpfman-build  ./usr/src/bpfman/bpfman .                                                                                                                    0.0s
 => exporting to image                                                                                                                                                                   3.3s
 => => exporting layers                                                                                                                                                                  3.3s
 => => writing image sha256:90dceef7b68390558ecf02e2f6bf08b7fc07bae7696d38f4a4aaa451c02b359c  
```

AFTER 34.1 seconds fresh build

```bash
[astoycos@nfvsdn-02-oot bpfman]$ DOCKER_BUILDKIT=1 docker build -f Containerfile.bpfman.local.no.ebpf  .
[+] Building 34.1s (17/17) FINISHED                                                                                                                                                           
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 65B                                                                                                                                                         0.0s
 => [internal] load build definition from Containerfile.bpfman.local.no.ebpf                                                                                                             0.0s
 => => transferring dockerfile: 1.69kB                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/fedora:38                                                                                                                             0.2s
 => [internal] load metadata for docker.io/library/rust:1                                                                                                                                0.1s
 => [stage-1 1/3] FROM docker.io/library/fedora:38@sha256:3f01c8f79691df76331cb4bb0944794a60850475e859c15e49513fcbe0a3d88a                                                               0.0s
 => [internal] load build context                                                                                                                                                        0.1s
 => => transferring context: 100.29kB                                                                                                                                                    0.1s
 => [bpfman-build 1/8] FROM docker.io/library/rust:1@sha256:fd260ac37e010eb35e8e1bf6ce6c714a51d760a421690883ed77c637951d331c                                                             0.0s
 => CACHED [bpfman-build 2/8] RUN apt-get update && apt-get install -y    gcc-multilib    musl-tools                                                                                     0.0s
 => CACHED [bpfman-build 3/8] WORKDIR /usr/src/bpfman                                                                                                                                    0.0s
 => [bpfman-build 4/8] COPY ./ /usr/src/bpfman                                                                                                                                           2.8s
 => [bpfman-build 5/8] RUN rustup target add x86_64-unknown-linux-musl                                                                                                                   5.6s
 => [bpfman-build 6/8] RUN --mount=type=cache,target=/usr/src/bpfman/target/     --mount=type=cache,target=/usr/local/cargo/registry     cargo build --release --target x86_64-unknown  24.1s
 => [bpfman-build 7/8] RUN --mount=type=cache,target=/usr/src/bpfman/target/     cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman ./bpfman/                            0.2s 
 => [bpfman-build 8/8] RUN --mount=type=cache,target=/usr/src/bpfman/target/     cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman-ns ./bpfman/                         0.4s
 => CACHED [stage-1 2/3] RUN dnf makecache --refresh && dnf -y install bpftool tcpdump                                                                                                   0.0s
 => [stage-1 3/3] COPY --from=bpfman-build  ./usr/src/bpfman/bpfman .                                                                                                                    0.0s
 => exporting to image                                                                                                                                                                   0.4s
 => => exporting layers                                                                                                                                                                  0.4s
 => => writing image sha256:8133311995ced083d9dff8a712de82c264305ab6d9d7cd0a54583162130b0ac4   
```