### PR TITLE
remove to-string clippy failures

### DIFF
--- a/bpfman-api/src/config.rs
+++ b/bpfman-api/src/config.rs
@@ -82,12 +82,12 @@ impl TryFrom<u32> for XdpMode {
     }
 }
 
-impl ToString for XdpMode {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for XdpMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            XdpMode::Skb => "skb".to_string(),
-            XdpMode::Drv => "drv".to_string(),
-            XdpMode::Hw => "hw".to_string(),
+            XdpMode::Skb => write!(f, "skb"),
+            XdpMode::Drv => write!(f, "drv"),
+            XdpMode::Hw => write!(f, "hw"),
         }
     }
 }

--- a/bpfman-api/src/lib.rs
+++ b/bpfman-api/src/lib.rs
@@ -637,16 +637,17 @@ impl From<ImagePullPolicy> for i32 {
     }
 }
 
-impl ToString for Location {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             // Cast imagePullPolicy into it's concrete type so we can easily print.
-            Location::Image(i) => format!(
+            Location::Image(i) => write!(
+                f,
                 "image: {{ url: {}, pullpolicy: {} }}",
                 i.url,
                 TryInto::<ImagePullPolicy>::try_into(i.image_pull_policy).unwrap()
             ),
-            Location::File(p) => format!("file: {{ path: {p} }}"),
+            Location::File(p) => write!(f, "file: {{ path: {p} }}"),
         }
     }
 }


### PR DESCRIPTION
Implement std::fmt::Display rather than to_string
for Location and XDPMode to fix clippy failures.