### PR TITLE
fix startup race

### DIFF
--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -231,10 +231,12 @@ impl BpfManager {
                 dispatchers.push(name.clone());
                 continue;
             } else if name.contains(PROGRAM_PRE_LOAD_PREFIX) {
+                debug!("Removing temporary tree on rebuild: {name}");
                 // Drop temporary DB trees, as it means bpfman crashed mid load
                 ROOT_DB
                     .drop_tree(name)
                     .expect("unable to remove temporary program tree");
+                continue;
             }
         }
 

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -12,7 +12,7 @@ use nix::{
 use sled::Tree;
 use tokio::{fs, io::AsyncReadExt};
 
-use crate::{errors::BpfmanError, ROOT_DB};
+use crate::errors::BpfmanError;
 
 // The bpfman socket should always allow the same users and members of the same group
 // to Read/Write to it.
@@ -159,14 +159,8 @@ pub(crate) fn sled_get_option(db_tree: &Tree, key: &str) -> Result<Option<Vec<u8
         .map_err(|e| {
             BpfmanError::DatabaseError(
                 format!(
-                    "Unable to get database entry {key} from tree {} {}",
+                    "Unable to get database entry {key} from tree {}",
                     bytes_to_string(&db_tree.name()),
-                    ROOT_DB
-                        .tree_names()
-                        .iter()
-                        .map(|n| bytes_to_string(n))
-                        .collect::<Vec<_>>()
-                        .join(", "),
                 ),
                 e.to_string(),
             )


### PR DESCRIPTION
Make sure bpfman state is rebuilt before starting
the unix server, since data is intially written
in rpc.rs it could race with the rebuilding state
in bpfmanager::rebuild_state().

In this particular scenario, when running with
systemd, a `ProgramData` temporary pre-load
database tree would get created before the rebuild_state() was called, and then the rebuild logic would
delete the `ProgramData` tree mid load causing
all of the loading errors.