### PR TITLE
Convert the rest of the cli to not use GRPC

### DIFF
--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -54,7 +54,7 @@ const MAPS_USED_BY_PREFIX: &str = "map_used_by_";
 pub(crate) struct BpfManager {
     config: Config,
     commands: Option<Receiver<Command>>,
-    image_manager: Option<Sender<ImageManagerCommand>>,
+    pub(crate) image_manager: Option<Sender<ImageManagerCommand>>,
 }
 
 impl BpfManager {
@@ -913,7 +913,7 @@ impl BpfManager {
         }
     }
 
-    async fn pull_bytecode(&self, args: PullBytecodeArgs) -> anyhow::Result<()> {
+    pub(crate) async fn pull_bytecode(&self, args: PullBytecodeArgs) -> anyhow::Result<()> {
         let res;
         let (tx, rx) = oneshot::channel();
         if let Some(image_manager) = self.image_manager.clone() {

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -19,7 +19,7 @@ use bpfman_api::{
     ProbeType::{self, *},
     ProgramType,
 };
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use tokio::{
     fs::{create_dir_all, remove_dir_all},
     select,
@@ -32,8 +32,8 @@ use tokio::{
 
 use crate::{
     command::{
-        Command, Direction, Program, ProgramData, PullBytecodeArgs, UnloadArgs, PROGRAM_PREFIX,
-        PROGRAM_PRE_LOAD_PREFIX,
+        Command, Direction, ListFilter, Program, ProgramData, PullBytecodeArgs, UnloadArgs,
+        PROGRAM_PREFIX, PROGRAM_PRE_LOAD_PREFIX,
     },
     errors::BpfmanError,
     multiprog::{
@@ -851,7 +851,7 @@ impl BpfManager {
         Ok(())
     }
 
-    pub(crate) fn list_programs(&mut self) -> Result<Vec<Program>, BpfmanError> {
+    pub(crate) fn list_programs(&mut self, filter: ListFilter) -> Vec<Program> {
         debug!("BpfManager::list_programs()");
 
         // Get an iterator for the bpfman load programs, a hash map indexed by program id.
@@ -866,19 +866,22 @@ impl BpfManager {
                 // If the program was loaded by bpfman (check the hash map), then use it.
                 // Otherwise, convert the data returned from Aya into an Unsupported Program Object.
                 match bpfman_progs.remove(&prog_id) {
-                    Some(p) => Ok(p.to_owned()),
+                    Some(p) => p.to_owned(),
                     None => {
                         let db_tree = ROOT_DB
                             .open_tree(prog_id.to_string())
                             .expect("Unable to open program database tree for listing programs");
 
                         let mut data = ProgramData::new(db_tree);
-                        data.set_kernel_info(&prog)?;
+                        if let Err(e) = data.set_kernel_info(&prog) {
+                            warn!("Unable to set kernal info for prog {prog_id}, error: {e}");
+                        };
 
-                        Ok(Program::Unsupported(data))
+                        Program::Unsupported(data)
                     }
                 }
             })
+            .filter(|p| filter.matches(p))
             .collect()
     }
 
@@ -963,8 +966,8 @@ impl BpfManager {
                                 let _ = args.responder.send(prog);
                             },
                             Command::Unload(args) => self.unload_command(args).await.unwrap(),
-                            Command::List { responder } => {
-                                let progs = self.list_programs();
+                            Command::List { responder, filter } => {
+                                let progs = self.list_programs(filter);
                                 // Ignore errors as they'll be propagated to caller in the RPC status
                                 let _ = responder.send(progs);
                             }

--- a/bpfman/src/cli/get.rs
+++ b/bpfman/src/cli/get.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use bpfman_api::{
-    config::Config,
-    v1::{KernelProgramInfo, ProgramInfo},
-};
+use bpfman_api::v1::{KernelProgramInfo, ProgramInfo};
 use log::warn;
 
 use crate::{
@@ -14,9 +11,10 @@ use crate::{
     errors::BpfmanError,
 };
 
-pub(crate) async fn execute_get(config: &Config, args: &GetArgs) -> Result<(), BpfmanError> {
-    let mut bpf_manager = BpfManager::new(config.clone(), None, None);
-
+pub(crate) async fn execute_get(
+    bpf_manager: &mut BpfManager,
+    args: &GetArgs,
+) -> Result<(), BpfmanError> {
     match bpf_manager.get_program(args.id) {
         Ok(program) => {
             let info: Option<ProgramInfo> = if let Program::Unsupported(_) = program {
@@ -27,7 +25,7 @@ pub(crate) async fn execute_get(config: &Config, args: &GetArgs) -> Result<(), B
             let kernel_info: Option<KernelProgramInfo> = match (&program).try_into() {
                 Ok(i) => {
                     if let Program::Unsupported(_) = program {
-                        program.delete()?;
+                        program.delete()?
                     };
                     Some(i)
                 }

--- a/bpfman/src/cli/image.rs
+++ b/bpfman/src/cli/image.rs
@@ -25,22 +25,22 @@ impl TryFrom<&PullBytecodeArgs> for BytecodeImage {
     type Error = anyhow::Error;
 
     fn try_from(value: &PullBytecodeArgs) -> Result<Self, Self::Error> {
-        let pull_policy: ImagePullPolicy = value.pull_policy.as_str().try_into()?;
+        let image_pull_policy: ImagePullPolicy = value.pull_policy.as_str().try_into()?;
         let (username, password) = match &value.registry_auth {
             Some(a) => {
                 let auth_raw = general_purpose::STANDARD.decode(a)?;
                 let auth_string = String::from_utf8(auth_raw)?;
                 let (username, password) = auth_string.split_once(':').unwrap();
-                (username.to_owned(), password.to_owned())
+                (Some(username.to_owned()), Some(password.to_owned()))
             }
-            None => ("".to_owned(), "".to_owned()),
+            None => (None, None),
         };
 
         Ok(BytecodeImage {
             image_url: value.image_url.clone(),
-            image_pull_policy: pull_policy,
-            username: Some(username),
-            password: Some(password),
+            image_pull_policy,
+            username,
+            password,
         })
     }
 }

--- a/bpfman/src/cli/image.rs
+++ b/bpfman/src/cli/image.rs
@@ -2,20 +2,21 @@
 // Copyright Authors of bpfman
 
 use base64::{engine::general_purpose, Engine};
-use bpfman_api::{
-    v1::{bpfman_client::BpfmanClient, BytecodeImage, PullBytecodeRequest},
-    ImagePullPolicy,
-};
+use bpfman_api::ImagePullPolicy;
+use log::info;
+use tokio::sync::oneshot;
 
-use crate::cli::{
-    args::{ImageSubCommand, PullBytecodeArgs},
-    select_channel,
+use crate::{
+    bpf::BpfManager,
+    cli::args::{ImageSubCommand, PullBytecodeArgs},
+    errors::BpfmanError,
+    oci_utils::image_manager::{BytecodeImage, Command as ImageManagerCommand},
 };
 
 impl ImageSubCommand {
-    pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+    pub(crate) async fn execute(&self, bpf_manager: &mut BpfManager) -> anyhow::Result<()> {
         match self {
-            ImageSubCommand::Pull(args) => execute_pull(args).await,
+            ImageSubCommand::Pull(args) => execute_pull(bpf_manager, args).await,
         }
     }
 }
@@ -36,19 +37,45 @@ impl TryFrom<&PullBytecodeArgs> for BytecodeImage {
         };
 
         Ok(BytecodeImage {
-            url: value.image_url.clone(),
-            image_pull_policy: pull_policy.into(),
+            image_url: value.image_url.clone(),
+            image_pull_policy: pull_policy,
             username: Some(username),
             password: Some(password),
         })
     }
 }
 
-pub(crate) async fn execute_pull(args: &PullBytecodeArgs) -> anyhow::Result<()> {
-    let channel = select_channel().expect("failed to select channel");
-    let mut client = BpfmanClient::new(channel);
+pub(crate) async fn execute_pull(
+    bpf_manager: &mut BpfManager,
+    args: &PullBytecodeArgs,
+) -> anyhow::Result<()> {
     let image: BytecodeImage = args.try_into()?;
-    let request = tonic::Request::new(PullBytecodeRequest { image: Some(image) });
-    let _response = client.pull_bytecode(request).await?;
+    let (tx, rx) = oneshot::channel();
+    let res;
+    if let Some(image_manager) = bpf_manager.image_manager.clone() {
+        image_manager
+            .send(ImageManagerCommand::Pull {
+                image: image.image_url,
+                pull_policy: image.image_pull_policy.clone(),
+                username: image.username.clone(),
+                password: image.password.clone(),
+                resp: tx,
+            })
+            .await?;
+        res = match rx.await? {
+            Ok(_) => {
+                info!("Successfully pulled bytecode");
+                Ok(())
+            }
+            Err(e) => Err(BpfmanError::BpfBytecodeError(e)),
+        };
+    } else {
+        res = Err(BpfmanError::InternalError(
+            "ImageManager not set.".to_string(),
+        ));
+    }
+
+    res?;
+
     Ok(())
 }

--- a/bpfman/src/cli/list.rs
+++ b/bpfman/src/cli/list.rs
@@ -2,32 +2,52 @@
 // Copyright Authors of bpfman
 
 use anyhow::bail;
-use bpfman_api::v1::{bpfman_client::BpfmanClient, ListRequest};
+use bpfman_api::v1::list_response::ListResult;
 
-use crate::cli::{args::ListArgs, select_channel, table::ProgTable};
+use crate::{
+    bpf::BpfManager,
+    cli::{args::ListArgs, table::ProgTable},
+    command::{ListFilter, Program},
+};
 
-pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
-    let channel = select_channel().unwrap();
-    let mut client = BpfmanClient::new(channel);
+pub(crate) async fn execute_list(
+    bpf_manager: &mut BpfManager,
+    args: &ListArgs,
+) -> anyhow::Result<()> {
     let prog_type_filter = args.program_type.map(|p| p as u32);
 
-    let request = tonic::Request::new(ListRequest {
-        program_type: prog_type_filter,
-        // Transform metadata from a vec of tuples to an owned map.
-        match_metadata: args
-            .metadata_selector
+    let filter = ListFilter::new(
+        prog_type_filter,
+        args.metadata_selector
             .clone()
             .unwrap_or_default()
             .iter()
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect(),
-        bpfman_programs_only: Some(!args.all),
-    });
-    let response = client.list(request).await?.into_inner();
+        !args.all,
+    );
+
     let mut table = ProgTable::new_list();
 
-    for r in response.results {
-        if let Err(e) = table.add_response_prog(r) {
+    // TODO(astoycos) cleanup all table printing to accept core types not bpfman_api types.
+    for r in bpf_manager.list_programs(filter) {
+        let list_entry = ListResult {
+            info: if let Program::Unsupported(_) = r {
+                None
+            } else {
+                Some((&r).try_into()?)
+            },
+            kernel_info: match (&r).try_into() {
+                Ok(i) => {
+                    if let Program::Unsupported(_) = r {
+                        r.delete()?;
+                    };
+                    Ok(Some(i))
+                }
+                Err(e) => Err(e),
+            }?,
+        };
+        if let Err(e) = table.add_response_prog(list_entry) {
             bail!(e)
         }
     }

--- a/bpfman/src/cli/mod.rs
+++ b/bpfman/src/cli/mod.rs
@@ -31,7 +31,7 @@ impl Commands {
         match self {
             Commands::Load(l) => l.execute(&mut bpf_manager).await,
             Commands::Unload(args) => execute_unload(args).await,
-            Commands::List(args) => execute_list(args).await,
+            Commands::List(args) => execute_list(&mut bpf_manager, args).await,
             Commands::Get(args) => {
                 initialize_bpfman().await?;
                 execute_get(&mut bpf_manager, args)

--- a/bpfman/src/cli/mod.rs
+++ b/bpfman/src/cli/mod.rs
@@ -14,27 +14,44 @@ use anyhow::anyhow;
 use args::Commands;
 use get::execute_get;
 use list::execute_list;
+use tokio::sync::{broadcast, mpsc};
 use unload::execute_unload;
 
-use crate::{bpf::BpfManager, cli::system::initialize_bpfman, utils::open_config_file};
+use crate::{
+    bpf::BpfManager, cli::system::initialize_bpfman, oci_utils::ImageManager,
+    utils::open_config_file,
+};
 
 impl Commands {
     pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
+        initialize_bpfman().await?;
+
         let config = open_config_file();
-        let mut bpf_manager = BpfManager::new(config.clone(), None, None);
+        let (shutdown_tx, shutdown_rx1) = broadcast::channel(32);
+        let allow_unsigned: bool = config.signing.as_ref().map_or(true, |s| s.allow_unsigned);
+        let (itx, irx) = mpsc::channel(32);
+
+        let mut image_manager = ImageManager::new(allow_unsigned, irx).await?;
+        let image_manager_handle = tokio::spawn(async move {
+            image_manager.run(shutdown_rx1).await;
+        });
+        let mut bpf_manager = BpfManager::new(config.clone(), None, Some(itx));
 
         match self {
             Commands::Load(l) => l.execute(&mut bpf_manager).await,
             Commands::Unload(args) => execute_unload(&mut bpf_manager, args).await,
             Commands::List(args) => execute_list(&mut bpf_manager, args).await,
-            Commands::Get(args) => {
-                initialize_bpfman().await?;
-                execute_get(&mut bpf_manager, args)
-                    .await
-                    .map_err(|e| anyhow!("get error: {e}"))
-            }
+            Commands::Get(args) => execute_get(&mut bpf_manager, args)
+                .await
+                .map_err(|e| anyhow!("get error: {e}")),
             Commands::Image(i) => i.execute(&mut bpf_manager).await,
             Commands::System(s) => s.execute(&config).await,
-        }
+        }?;
+
+        // Shutdown the image_manager thread and wait for it to finish
+        shutdown_tx.send(()).unwrap();
+        image_manager_handle.await?;
+
+        Ok(())
     }
 }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -33,8 +33,6 @@ impl SystemSubcommand {
 }
 
 pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyhow::Result<()> {
-    initialize_bpfman().await?;
-
     //TODO https://github.com/bpfman/bpfman/issues/881
     serve(config, args.csi_support, args.timeout, &args.socket_path).await?;
     Ok(())

--- a/bpfman/src/cli/unload.rs
+++ b/bpfman/src/cli/unload.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use bpfman_api::v1::{bpfman_client::BpfmanClient, UnloadRequest};
+use crate::{bpf::BpfManager, cli::args::UnloadArgs};
 
-use crate::cli::{args::UnloadArgs, select_channel};
-
-pub(crate) async fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
-    let channel = select_channel().expect("failed to select channel");
-    let mut client = BpfmanClient::new(channel);
-    let request = tonic::Request::new(UnloadRequest { id: args.id });
-    let _response = client.unload(request).await?.into_inner();
+pub(crate) async fn execute_unload(
+    bpf_manager: &mut BpfManager,
+    args: &UnloadArgs,
+) -> Result<(), anyhow::Error> {
+    bpf_manager.remove_program(args.id).await?;
     Ok(())
 }

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -25,7 +25,7 @@ fn test_bpfmanhelptext() {
 fn test_load_unload_xdp() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
+    //let bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -68,8 +68,8 @@ fn test_load_unload_xdp() {
     assert!(bpffs_has_entries(RTDIR_FS_XDP));
 
     // Verify rule persistence between restarts
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
+    // drop(bpfman_guard);
+    // let _bpfman_guard = start_bpfman().unwrap();
 
     verify_and_delete_programs(loaded_ids);
 
@@ -80,7 +80,7 @@ fn test_load_unload_xdp() {
 fn test_map_sharing_load_unload_xdp() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
+    //let bpfman_guard = start_bpfman().unwrap();
     let load_type = LoadType::Image;
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
@@ -163,13 +163,13 @@ fn test_map_sharing_load_unload_xdp() {
     // Unload the Map Owner Program
     bpfman_del_program(&(map_owner_id.unwrap()));
 
-    drop(bpfman_guard);
+    //drop(bpfman_guard);
 
     // Retrive the Program sharing the map
     let stdout_3 = bpfman_get(shared_owner_id.as_ref().unwrap());
     let binding_3 = stdout_3.unwrap();
 
-    let _bpfman_guard = start_bpfman().unwrap();
+    //let _bpfman_guard = start_bpfman().unwrap();
 
     // Verify "Map Used By:" field is set to only the
     // 2nd loaded program (one sharing the map).
@@ -185,7 +185,7 @@ fn test_map_sharing_load_unload_xdp() {
 fn test_load_unload_tc() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
+    //let _bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -246,8 +246,6 @@ fn test_load_unload_tc() {
 
 #[integration_test]
 fn test_load_unload_tracepoint() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Installing tracepoint programs");
 
     let globals = vec!["GLOBAL_u8=61", "GLOBAL_u32=0D0C0B0A"];
@@ -269,8 +267,6 @@ fn test_load_unload_tracepoint() {
 
 #[integration_test]
 fn test_load_unload_uprobe() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Installing uprobe program");
 
     let globals = vec!["GLOBAL_u8=63", "GLOBAL_u32=0D0C0B0A"];
@@ -294,8 +290,6 @@ fn test_load_unload_uprobe() {
 
 #[integration_test]
 fn test_load_unload_uretprobe() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Installing uretprobe program");
 
     let globals = vec!["GLOBAL_u8=63", "GLOBAL_u32=0D0C0B0A"];
@@ -318,8 +312,6 @@ fn test_load_unload_uretprobe() {
 
 #[integration_test]
 fn test_load_unload_kprobe() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Installing kprobe program");
 
     let globals = vec!["GLOBAL_u8=63", "GLOBAL_u32=0D0C0B0A"];
@@ -337,8 +329,6 @@ fn test_load_unload_kprobe() {
 
 #[integration_test]
 fn test_load_unload_kretprobe() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Installing kretprobe program");
 
     let globals = vec!["GLOBAL_u8=63", "GLOBAL_u32=0D0C0B0A"];
@@ -362,8 +352,6 @@ fn test_load_unload_kretprobe() {
 
 #[integration_test]
 fn test_pull_bytecode() {
-    let _bpfman_guard = start_bpfman().unwrap();
-
     debug!("Pull bytecode image");
 
     // Just ensure this doesn't panic
@@ -373,7 +361,6 @@ fn test_pull_bytecode() {
 #[integration_test]
 fn test_list_with_metadata() {
     let _namespace_guard = create_namespace().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -438,10 +425,6 @@ fn test_list_with_metadata() {
     assert_eq!(loaded_ids.len(), 5);
 
     assert!(bpffs_has_entries(RTDIR_FS_XDP));
-
-    // Verify rule persistence between restarts
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
 
     verify_and_delete_programs(loaded_ids);
 

--- a/tests/integration-test/src/tests/e2e.rs
+++ b/tests/integration-test/src/tests/e2e.rs
@@ -33,7 +33,6 @@ fn test_proceed_on_xdp() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
     let trace_guard = start_trace_pipe().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -141,7 +140,6 @@ fn test_unload_xdp() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
     let trace_guard = start_trace_pipe().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -238,7 +236,6 @@ fn test_proceed_on_tc() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
     let trace_guard = start_trace_pipe().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -377,10 +374,6 @@ fn test_proceed_on_tc() {
     assert!(trace_pipe_log.contains(TC_EG_GLOBAL_6_LOG));
     debug!("Successfully completed tc egress proceed-on test");
 
-    // Verify that the programs still work after we stop and restart bpfman
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
-
     // Make sure it still works like it did before we stopped and restarted bpfman
     debug!("Clear the trace_pipe_log");
     drop(trace_guard);
@@ -415,7 +408,6 @@ fn test_unload_tc() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
     let trace_guard = start_trace_pipe().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -554,7 +546,6 @@ fn test_program_execution_with_global_variables() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
     let _trace_guard = start_trace_pipe().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -698,7 +689,6 @@ fn test_program_execution_with_global_variables() {
 fn test_load_unload_xdp_maps() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -725,10 +715,6 @@ fn test_load_unload_xdp_maps() {
     let map_pin_path = bpfman_output_map_pin_path(&binding);
     assert!(PathBuf::from(map_pin_path).join("xdp_stats_map").exists());
 
-    // Verify rule persistence between restarts
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
-
     verify_and_delete_programs(vec![prog_id.unwrap()]);
 
     assert!(!bpffs_has_entries(RTDIR_FS_XDP));
@@ -738,7 +724,6 @@ fn test_load_unload_xdp_maps() {
 fn test_load_unload_tc_maps() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
 
     assert!(iface_exists(DEFAULT_BPFMAN_IFACE));
 
@@ -764,10 +749,6 @@ fn test_load_unload_tc_maps() {
     let map_pin_path = bpfman_output_map_pin_path(&binding);
     assert!(PathBuf::from(map_pin_path).join("tc_stats_map").exists());
 
-    // Verify rule persistence between restarts
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
-
     verify_and_delete_programs(vec![prog_id.unwrap()]);
 
     assert!(!bpffs_has_entries(RTDIR_FS_TC_INGRESS));
@@ -777,7 +758,6 @@ fn test_load_unload_tc_maps() {
 fn test_load_unload_tracepoint_maps() {
     let _namespace_guard = create_namespace().unwrap();
     let _ping_guard = start_ping().unwrap();
-    let bpfman_guard = start_bpfman().unwrap();
 
     debug!("Installing tracepoint_counter program");
 
@@ -792,10 +772,6 @@ fn test_load_unload_tracepoint_maps() {
         .join("tracepoint_stats_map")
         .exists());
 
-    // Verify rule persistence between restarts
-    drop(bpfman_guard);
-    let _bpfman_guard = start_bpfman().unwrap();
-
     verify_and_delete_programs(vec![prog_id.unwrap()]);
 }
 
@@ -805,7 +781,6 @@ fn test_uprobe_container() {
 
     let container = start_container().unwrap();
     let _trace_guard = start_trace_pipe().unwrap();
-    let _bpfman_guard = start_bpfman().unwrap();
 
     let mut loaded_ids = vec![];
 

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -72,36 +72,36 @@ impl Drop for ChildGuard {
 }
 
 /// Spawn a bpfman process
-pub fn start_bpfman() -> Result<ChildGuard> {
-    debug!("Starting bpfman");
+// pub fn start_bpfman() -> Result<ChildGuard> {
+//     debug!("Starting bpfman");
 
-    let bpfman_process = Command::cargo_bin("bpfman")?
-        .args(["system", "service", "--timeout=0"])
-        .env("RUST_LOG", "bpfman=debug")
-        .spawn()
-        .map(|c| ChildGuard {
-            name: "bpfman",
-            child: c,
-        })?;
+//     let bpfman_process = Command::cargo_bin("bpfman")?
+//         .args(["system", "service", "--timeout=0"])
+//         .env("RUST_LOG", "bpfman=debug")
+//         .spawn()
+//         .map(|c| ChildGuard {
+//             name: "bpfman",
+//             child: c,
+//         })?;
 
-    debug!("started process");
-    // Wait for up to 5 seconds for bpfman to be ready
-    sleep(Duration::from_millis(100));
-    for i in 1..51 {
-        if let Err(e) = Command::cargo_bin("bpfman")?.args(["list"]).ok() {
-            if i == 50 {
-                panic!("bpfman not ready after {} ms. Error:\n{}", i * 100, e);
-            } else {
-                sleep(Duration::from_millis(100));
-            }
-        } else {
-            break;
-        }
-    }
-    debug!("Successfully Started bpfman");
+//     debug!("started process");
+//     // Wait for up to 5 seconds for bpfman to be ready
+//     sleep(Duration::from_millis(100));
+//     for i in 1..51 {
+//         if let Err(e) = Command::cargo_bin("bpfman")?.args(["list"]).ok() {
+//             if i == 50 {
+//                 panic!("bpfman not ready after {} ms. Error:\n{}", i * 100, e);
+//             } else {
+//                 sleep(Duration::from_millis(100));
+//             }
+//         } else {
+//             break;
+//         }
+//     }
+//     debug!("Successfully Started bpfman");
 
-    Ok(bpfman_process)
-}
+//     Ok(bpfman_process)
+// }
 
 /// Install an xdp program with bpfman
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
I decided to tackle this in one PR to not have a ton of intermediary hacks in the integration tests, and it really shouldn't be too big of a PR. (load will be the most difficult)

- [X] load
- [x] unload
- [x] list
- [X] pull-bytecode
- [x] fixup integration tests to use bpfman only as a library, while the k8s integration tests will still use the GRPC api


Fixes #936 #937 #938 #939 #940 #941 #942 #943 #944 #945 #946 #947 #948 #949 #950 #952