### PR TITLE
bpfman: Cache TUF Metadata

### DIFF
--- a/bpfman-api/src/util.rs
+++ b/bpfman-api/src/util.rs
@@ -39,6 +39,8 @@ pub mod directories {
     pub const RTDIR_BPFMAN_CSI: &str = "/run/bpfman/csi";
     pub const RTPATH_BPFMAN_CSI_SOCKET: &str = "/run/bpfman/csi/csi.sock";
     pub const RTDIR_BPFMAN_CSI_FS: &str = "/run/bpfman/csi/fs";
+    // The TUF repository is used to store Rekor and Fulcio public keys.
+    pub const RTDIR_TUF: &str = "/run/bpfman/tuf";
 
     // StateDirectory: /var/lib/bpfman/
     pub const STDIR_MODE: u32 = 0o6770;

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -81,6 +81,7 @@ pub(crate) async fn initialize_bpfman() -> anyhow::Result<()> {
     create_dir_all(RTDIR_BPFMAN_CSI).context("unable to create CSI directory")?;
     create_dir_all(RTDIR_BPFMAN_CSI_FS).context("unable to create CSI socket directory")?;
     create_dir_all(RTDIR_SOCK).context("unable to create socket directory")?;
+    create_dir_all(RTDIR_TUF).context("unable to create TUF directory")?;
 
     create_dir_all(STDIR).context("unable to create state directory")?;
 


### PR DESCRIPTION
This writes the TUF metadata to disk instead of caching in-memory. This should allow for multiple invocations of bpfman to be faster.