### PR TITLE
docs: Use the include-markdown plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ cargo +nightly clippy --all -- --deny warnings
 * Verify that Yaml files have been formatted (see
   [Install Yaml Formatter](https://bpfman.io/main/getting-started/building-bpfman/#install-yaml-formatter))
 * Verify that unit tests are passing locally (see
-  [Unit Testing](https://bpfman.io/main/developer-guide/testing/#unit-testing)):
+  [Unit Testing](./docs/developer-guide/testing.md#unit-testing)):
 
 ```console
 cd src/bpfman/
@@ -199,7 +199,7 @@ cargo test
 ```
 
 * Verify that integration tests are passing locally (see
-  [Basic Integration Tests](https://bpfman.io/main/developer-guide/testing/#basic-integration-tests)):
+  [Basic Integration Tests](./docs/developer-guide/testing.md#basic-integration-tests)):
 
 ```console
 cd src/bpfman/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,7 @@
 # Maintainers
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
-See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
+See [Contributing Guide](./CONTRIBUTING.md) for general contribution guidelines.
+See [bpfman Project Governance](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
 See [CODEOWNERS](https://github.com/bpfman/bpfman/blob/main/CODEOWNERS) for a detailed list of owners for the various source directories.
 
 | Name | Employer | Responsibilities |

--- a/docs/governance/CODE_OF_CONDUCT.md
+++ b/docs/governance/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
---8<-- "CODE_OF_CONDUCT.md"
+{% include "../../CODE_OF_CONDUCT.md" %}

--- a/docs/governance/CONTRIBUTING.md
+++ b/docs/governance/CONTRIBUTING.md
@@ -1,1 +1,1 @@
---8<-- "CONTRIBUTING.md"
+{% include "../../CONTRIBUTING.md" %}

--- a/docs/governance/GOVERNANCE.md
+++ b/docs/governance/GOVERNANCE.md
@@ -1,1 +1,1 @@
---8<-- "GOVERNANCE.md"
+{% include "../../GOVERNANCE.md" %}

--- a/docs/governance/MAINTAINERS.md
+++ b/docs/governance/MAINTAINERS.md
@@ -1,1 +1,1 @@
---8<-- "MAINTAINERS.md"
+{% include "../../MAINTAINERS.md" %}

--- a/docs/governance/MEETINGS.md
+++ b/docs/governance/MEETINGS.md
@@ -1,1 +1,2 @@
---8<-- "MEETINGS.md"
+{% include "../../MEETINGS.md" %}
+

--- a/docs/governance/REVIEWING.md
+++ b/docs/governance/REVIEWING.md
@@ -1,1 +1,1 @@
---8<-- "REVIEWING.md"
+{% include "../../REVIEWING.md" %}

--- a/docs/governance/SECURITY.md
+++ b/docs/governance/SECURITY.md
@@ -1,1 +1,1 @@
---8<-- "SECURITY.md"
+{% include "../../SECURITY.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,16 @@ extra:
   version:
     provider: mike
 
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 markdown_extensions:
   - admonition
   - pymdownx.highlight:
@@ -99,5 +109,6 @@ plugins:
         - "2024"
   - search
   - mike
+  - include-markdown
 
 copyright: Copyright &copy; 2021-2023 The bpfman contributors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.13.1
 beautifulsoup4==4.12.2
+bracex==2.4
 certifi==2023.11.17
 charset-normalizer==3.3.2
 click==8.1.3
@@ -16,6 +17,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 mike==1.1.2
 mkdocs==1.5.3
+mkdocs-include-markdown-plugin==6.0.4
 mkdocs-material==9.4.11
 mkdocs-material-extensions==1.3.1
 packaging==21.3
@@ -37,4 +39,5 @@ soupsieve==2.5
 urllib3==2.1.0
 verspec==0.1.0
 watchdog==2.1.9
+wcmatch==8.5.1
 zipp==3.8.0


### PR DESCRIPTION
This plugin includes markdown files and by default rewrites relative links. This allows us to preserve the governance docs in the repository root (and for them to use relative links) while also allowing those same docs to appear on the website.