### PR TITLE
bpfman-agent: list filters not working

### DIFF
--- a/bpfman-operator/controllers/bpfman-agent/internal/bpfman-core.go
+++ b/bpfman-operator/controllers/bpfman-agent/internal/bpfman-core.go
@@ -165,8 +165,10 @@ func GetBpfmanProgram(ctx context.Context, bpfmanClient gobpfman.BpfmanClient, u
 		return nil, err
 	}
 
-	if len(listResponse.Results) != 1 {
-		return nil, fmt.Errorf("multiple programs found for uuid: %+v ", uuid)
+	if len(listResponse.Results) == 0 {
+		return nil, fmt.Errorf("unable to find program for uuid: %+v ", uuid)
+	} else if len(listResponse.Results) != 1 {
+		return nil, fmt.Errorf("multiple programs found for uuid: %+v instances: %d", uuid, len(listResponse.Results))
 	}
 
 	return listResponse.Results[0], nil

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -153,6 +153,11 @@ impl ListFilter {
                     }
                 }
             }
+
+            // If a selector was provided, skip over non-bpfman loaded programs.
+            if !self.metadata_selector.is_empty() {
+                return false;
+            }
         } else {
             // Program type filtering has to be done differently for bpfman owned
             // programs since XDP and TC programs have a type EXT when loaded by


### PR DESCRIPTION
The XDP map-sharing example stopped working. The main XDP program loads fine but the program using the main XDP programs maps was not loading. After some investigation, the request to retrieve a list of programs filtered by a given UUID was returning multiple programs, not just the program that matched the UUID filter. All the non-bpfman loaded programs were being returned as well as the bpfman loaded program that matched the filter.