### PR TITLE
bpfman-operator: Add status to kubectl get commands

### DIFF
--- a/bpfman-operator/apis/v1alpha1/bpfprogram_types.go
+++ b/bpfman-operator/apis/v1alpha1/bpfprogram_types.go
@@ -29,6 +29,9 @@ import (
 //+kubebuilder:resource:scope=Cluster
 
 // BpfProgram is the Schema for the Bpfprograms API
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type BpfProgram struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bpfman-operator/apis/v1alpha1/kprobeProgram_types.go
+++ b/bpfman-operator/apis/v1alpha1/kprobeProgram_types.go
@@ -31,6 +31,7 @@ import (
 // KprobeProgram is the Schema for the KprobePrograms API
 // +kubebuilder:printcolumn:name="BpfFunctionName",type=string,JSONPath=`.spec.bpffunctionname`
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="FunctionName",type=string,JSONPath=`.spec.func_name`,priority=1
 // +kubebuilder:printcolumn:name="Offset",type=integer,JSONPath=`.spec.offset`,priority=1
 // +kubebuilder:printcolumn:name="RetProbe",type=boolean,JSONPath=`.spec.retprobe`,priority=1

--- a/bpfman-operator/apis/v1alpha1/tcProgram_types.go
+++ b/bpfman-operator/apis/v1alpha1/tcProgram_types.go
@@ -31,6 +31,7 @@ import (
 // TcProgram is the Schema for the TcProgram API
 // +kubebuilder:printcolumn:name="BpfFunctionName",type=string,JSONPath=`.spec.bpffunctionname`
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Priority",type=string,JSONPath=`.spec.priority`,priority=1
 // +kubebuilder:printcolumn:name="Direction",type=string,JSONPath=`.spec.direction`,priority=1
 // +kubebuilder:printcolumn:name="InterfaceSelector",type=string,JSONPath=`.spec.interfaceselector`,priority=1

--- a/bpfman-operator/apis/v1alpha1/tracepointProgram_types.go
+++ b/bpfman-operator/apis/v1alpha1/tracepointProgram_types.go
@@ -31,6 +31,7 @@ import (
 // TracepointProgram is the Schema for the TracepointPrograms API
 // +kubebuilder:printcolumn:name="BpfFunctionName",type=string,JSONPath=`.spec.bpffunctionname`
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="TracePoint",type=string,JSONPath=`.spec.name`,priority=1
 type TracepointProgram struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bpfman-operator/apis/v1alpha1/uprobeProgram_types.go
+++ b/bpfman-operator/apis/v1alpha1/uprobeProgram_types.go
@@ -31,6 +31,7 @@ import (
 // UprobeProgram is the Schema for the UprobePrograms API
 // +kubebuilder:printcolumn:name="BpfFunctionName",type=string,JSONPath=`.spec.bpffunctionname`
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="FunctionName",type=string,JSONPath=`.spec.func_name`,priority=1
 // +kubebuilder:printcolumn:name="Offset",type=integer,JSONPath=`.spec.offset`,priority=1
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target`,priority=1

--- a/bpfman-operator/apis/v1alpha1/xdpProgram_types.go
+++ b/bpfman-operator/apis/v1alpha1/xdpProgram_types.go
@@ -31,6 +31,7 @@ import (
 // XdpProgram is the Schema for the XdpPrograms API
 // +kubebuilder:printcolumn:name="BpfFunctionName",type=string,JSONPath=`.spec.bpffunctionname`
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Priority",type=string,JSONPath=`.spec.priority`,priority=1
 // +kubebuilder:printcolumn:name="InterfaceSelector",type=string,JSONPath=`.spec.interfaceselector`,priority=1
 // +kubebuilder:printcolumn:name="ProceedOn",type=string,JSONPath=`.spec.proceedon`,priority=1

--- a/bpfman-operator/config/crd/bases/bpfman.io_bpfprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_bpfprograms.yaml
@@ -15,7 +15,17 @@ spec:
     singular: bpfprogram
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BpfProgram is the Schema for the Bpfprograms API

--- a/bpfman-operator/config/crd/bases/bpfman.io_kprobeprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_kprobeprograms.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.nodeselector
       name: NodeSelector
       type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
     - jsonPath: .spec.func_name
       name: FunctionName
       priority: 1

--- a/bpfman-operator/config/crd/bases/bpfman.io_tcprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_tcprograms.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.nodeselector
       name: NodeSelector
       type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
     - jsonPath: .spec.priority
       name: Priority
       priority: 1

--- a/bpfman-operator/config/crd/bases/bpfman.io_tracepointprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_tracepointprograms.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.nodeselector
       name: NodeSelector
       type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
     - jsonPath: .spec.name
       name: TracePoint
       priority: 1

--- a/bpfman-operator/config/crd/bases/bpfman.io_uprobeprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_uprobeprograms.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.nodeselector
       name: NodeSelector
       type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
     - jsonPath: .spec.func_name
       name: FunctionName
       priority: 1

--- a/bpfman-operator/config/crd/bases/bpfman.io_xdpprograms.yaml
+++ b/bpfman-operator/config/crd/bases/bpfman.io_xdpprograms.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.nodeselector
       name: NodeSelector
       type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      type: string
     - jsonPath: .spec.priority
       name: Priority
       priority: 1

--- a/bpfman-operator/hack/kubectl-bpfprogramconfigs
+++ b/bpfman-operator/hack/kubectl-bpfprogramconfigs
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-kubectl get bpfprogramconfigs -o custom-columns="NAME":.metadata.name,"TYPE":.spec.type,"SECNAME":.spec.name,"STATUS":.status.conditions[-1:].type,"INTERFACE":.spec.attachpoint.networkmultiattach.interfaceselector.interface,"PRIORITY":.spec.attachpoint.networkmultiattach.priority,"DIRECTION":.spec.attachpoint.networkmultiattach.direction,"TRACEPOINT":.spec.attachpoint.singleattach.name

--- a/bpfman-operator/hack/kubectl-bpfprograms
+++ b/bpfman-operator/hack/kubectl-bpfprograms
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-kubectl get bpfprograms -o jsonpath='{"\n"}{"STATUS\tREASON\t\tNAME\n   IFACE\tPRI\tDIR\tTRACEPOINT\n\n"}{range .items[*]}{range .status.conditions[-1:]}{.type}{"\t"}{.reason}{end}{"\t"}{.metadata.name}{"\n"}{range .spec.programs.*}{"   "}{.attachpoint.networkmultiattach.interfaceselector.interface}{"\t"}{.attachpoint.networkmultiattach.priority}{"\t"}{.attachpoint.networkmultiattach.direction}{"\t"}{.attachpoint.singleattach.name}{end}{"\n"}{"\n"}{end}'


### PR DESCRIPTION
The `kubectl-bpfprogramconfigs` and `kubectl-bpfprograms` files located in `bpfman-operator\hack\` were used to customize the `kubectl get` output for the bpfman CRD objects. A while back, the code moved to use kubebuilder to autogenerate similar output, making these files outdated. So remove these files.

Now that each of the status slices in the bpfman CRD objects only contains one instance, add the status.reason to the `kubectl get` output for each of the bpfman CRD objects. For `kubectl get bpfprograms`, also add `Type`.

```
$ kubectl get tcprograms
NAME                    BPFFUNCTIONNAME   NODESELECTOR   STATUS
go-tc-counter-example   stats             {}             ReconcileSuccess

$ kubectl get tracepointprograms
NAME                            BPFFUNCTIONNAME            NODESELECTOR   STATUS
go-tracepoint-counter-example   tracepoint_kill_recorder   {}             ReconcileSuccess

$ kubectl get xdpprograms
NAME                                 BPFFUNCTIONNAME   NODESELECTOR   STATUS
go-xdp-counter-example               xdp_stats         {}             ReconcileSuccess
go-xdp-counter-sharing-map-example   xdp_stats         {}             ProgramsNotYetLoaded

$ kubectl get bpfprograms
NAME                                                                                    TYPE            STATUS         AGE
1073-bpfman-deployment-control-plane                                                    cgroup_device                  47s
1085-bpfman-deployment-control-plane                                                    cgroup_device                  47s
:
go-tc-counter-example-bpfman-deployment-control-plane-eth0                              tc              bpfmanLoaded   10s
go-tracepoint-counter-example-bpfman-deployment-control-plane-syscalls-sys-enter-kill   tracepoint      bpfmanLoaded   6s
go-xdp-counter-example-bpfman-deployment-control-plane-eth0                             xdp             bpfmanLoaded   6s
:
```

Resolves: #631