### PR TITLE
Image manager refactor

### DIFF
--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::HashMap,
+    fs::{create_dir_all, remove_dir_all},
     path::{Path, PathBuf},
 };
 
@@ -21,29 +22,24 @@ use bpfman_api::{
 };
 use log::{debug, error, info, warn};
 use tokio::{
-    fs::{create_dir_all, remove_dir_all},
     select,
-    sync::{
-        broadcast,
-        mpsc::{Receiver, Sender},
-        oneshot,
-    },
+    sync::{broadcast, mpsc::Receiver},
 };
 
 use crate::{
     command::{
-        Command, Direction, ListFilter, Program, ProgramData, PullBytecodeArgs, UnloadArgs,
-        PROGRAM_PREFIX, PROGRAM_PRE_LOAD_PREFIX,
+        Command, Direction, ListFilter, Program, ProgramData, UnloadArgs, PROGRAM_PREFIX,
+        PROGRAM_PRE_LOAD_PREFIX,
     },
     errors::BpfmanError,
     multiprog::{
         Dispatcher, DispatcherId, DispatcherInfo, TcDispatcher, XdpDispatcher,
         TC_DISPATCHER_PREFIX, XDP_DISPATCHER_PREFIX,
     },
-    oci_utils::image_manager::Command as ImageManagerCommand,
+    oci_utils::{image_manager::BytecodeImage, ImageManager},
     utils::{
-        bytes_to_string, bytes_to_u32, get_error_msg_from_stderr, get_ifindex, set_dir_permissions,
-        should_map_be_pinned, sled_insert,
+        bytes_to_string, bytes_to_u32, get_error_msg_from_stderr, get_ifindex, open_config_file,
+        set_dir_permissions, should_map_be_pinned, sled_insert,
     },
     ROOT_DB,
 };
@@ -54,19 +50,32 @@ const MAPS_USED_BY_PREFIX: &str = "map_used_by_";
 pub(crate) struct BpfManager {
     config: Config,
     commands: Option<Receiver<Command>>,
-    pub(crate) image_manager: Option<Sender<ImageManagerCommand>>,
+    pub(crate) image_manager: Option<ImageManager>,
 }
 
 impl BpfManager {
-    pub(crate) fn new(
-        config: Config,
-        commands: Option<Receiver<Command>>,
-        image_manager: Option<Sender<ImageManagerCommand>>,
-    ) -> Self {
+    pub(crate) fn new(config: Config, commands: Option<Receiver<Command>>) -> Self {
         Self {
             config,
             commands,
-            image_manager,
+            image_manager: None,
+        }
+    }
+
+    // Make sure to call init_image_manger if the command requires interation with
+    // an OCI based container registry. It should ONLY be used where needed, to
+    // explicitly control when bpfman blocks for network calls to both sigstore's
+    // cosign tuf registries and container registries.
+    pub(crate) async fn init_image_manager(&mut self) {
+        if self.image_manager.is_none() {
+            let config = open_config_file();
+            self.image_manager = Some(
+                ImageManager::new(config.signing.as_ref().map_or(true, |s| s.allow_unsigned))
+                    .await
+                    .expect("failed to initialize image manager"),
+            );
+        } else {
+            warn!("Image manager already initialized");
         }
     }
 
@@ -217,6 +226,7 @@ impl BpfManager {
 
     pub(crate) async fn rebuild_state(&mut self) -> Result<(), anyhow::Error> {
         debug!("BpfManager::rebuild_state()");
+        self.init_image_manager().await;
 
         // Rebuild dispatchers after rebuilding programs.
         let mut dispatchers = Vec::new();
@@ -276,6 +286,8 @@ impl BpfManager {
         &mut self,
         mut program: Program,
     ) -> Result<Program, BpfmanError> {
+        self.init_image_manager().await;
+
         let map_owner_id = program.get_data().get_map_owner_id()?;
         // Set map_pin_path if we're using another program's maps
         if let Some(map_owner_id) = map_owner_id {
@@ -283,16 +295,10 @@ impl BpfManager {
             program.get_data_mut().set_map_pin_path(&map_pin_path)?;
         }
 
-        if let Some(image_manager) = self.image_manager.clone() {
-            program
-                .get_data_mut()
-                .set_program_bytes(image_manager)
-                .await?;
-        } else {
-            return Err(BpfmanError::InternalError(
-                "ImageManager not set.".to_string(),
-            ));
-        }
+        program
+            .get_data_mut()
+            .set_program_bytes(self.image_manager.as_mut().expect("image manager not set"))
+            .await?;
 
         let result = match program {
             Program::Xdp(_) | Program::Tc(_) => {
@@ -301,7 +307,7 @@ impl BpfManager {
                 self.add_multi_attach_program(&mut program).await
             }
             Program::Tracepoint(_) | Program::Kprobe(_) | Program::Uprobe(_) => {
-                self.add_single_attach_program(&mut program).await
+                self.add_single_attach_program(&mut program)
             }
             Program::Unsupported(_) => panic!("Cannot add unsupported program"),
         };
@@ -316,7 +322,7 @@ impl BpfManager {
 
                 // Now that program is successfully loaded, update the id, maps hash table,
                 // and allow access to all maps by bpfman group members.
-                self.save_map(&mut program, id, map_owner_id).await?;
+                self.save_map(&mut program, id, map_owner_id)?;
 
                 // Swap the db tree to be persisted with the unique program ID generated
                 // by the kernel.
@@ -329,7 +335,7 @@ impl BpfManager {
                 // map_pin_path may or may not exist depending on where the original
                 // error occured, so don't error if not there and preserve original error.
                 if let Some(pin_path) = program.get_data().get_map_pin_path()? {
-                    let _ = self.cleanup_map_pin_path(&pin_path, map_owner_id).await;
+                    let _ = self.cleanup_map_pin_path(&pin_path, map_owner_id);
                 }
                 Err(e)
             }
@@ -391,29 +397,23 @@ impl BpfManager {
             1
         };
 
-        if let Some(image_manager) = self.image_manager.clone() {
-            Dispatcher::new(
-                if_config,
-                &mut programs,
-                next_revision,
-                old_dispatcher,
-                image_manager.clone(),
-            )
-            .await
-            .or_else(|e| {
-                // If kernel ID was never set there's no pins to cleanup here so just continue
-                if program.get_data().get_id().is_ok() {
-                    program
-                        .delete()
-                        .map_err(BpfmanError::BpfmanProgramDeleteError)?;
-                }
-                Err(e)
-            })?;
-        } else {
-            return Err(BpfmanError::InternalError(
-                "ImageManager not set.".to_string(),
-            ));
-        }
+        Dispatcher::new(
+            if_config,
+            &mut programs,
+            next_revision,
+            old_dispatcher,
+            self.image_manager.as_mut().expect("image manager not set"),
+        )
+        .await
+        .or_else(|e| {
+            // If kernel ID was never set there's no pins to cleanup here so just continue
+            if program.get_data().get_id().is_ok() {
+                program
+                    .delete()
+                    .map_err(BpfmanError::BpfmanProgramDeleteError)?;
+            }
+            Err(e)
+        })?;
 
         let id = program.get_data().get_id()?;
         program.set_attached();
@@ -421,7 +421,7 @@ impl BpfManager {
         Ok(id)
     }
 
-    pub(crate) async fn add_single_attach_program(
+    pub(crate) fn add_single_attach_program(
         &mut self,
         p: &mut Program,
     ) -> Result<u32, BpfmanError> {
@@ -667,7 +667,7 @@ impl BpfManager {
                 if p.get_data().get_map_pin_path()?.is_none() {
                     let map_pin_path = calc_map_pin_path(id);
                     p.get_data_mut().set_map_pin_path(&map_pin_path)?;
-                    create_map_pin_path(&map_pin_path).await?;
+                    create_map_pin_path(&map_pin_path)?;
 
                     for (name, map) in loader.maps_mut() {
                         if !should_map_be_pinned(name) {
@@ -732,7 +732,7 @@ impl BpfManager {
             }
         }
 
-        self.delete_map(id, map_owner_id).await?;
+        self.delete_map(id, map_owner_id)?;
 
         Ok(())
     }
@@ -746,6 +746,7 @@ impl BpfManager {
         direction: Option<Direction>,
     ) -> Result<(), BpfmanError> {
         debug!("BpfManager::remove_multi_attach_program()");
+        self.init_image_manager().await;
 
         let next_available_id = self.attached_programs(&did) - 1;
         debug!("next_available_id = {next_available_id}");
@@ -775,21 +776,17 @@ impl BpfManager {
             1
         };
         debug!("next_revision = {next_revision}");
-        if let Some(image_manager) = self.image_manager.clone() {
-            Dispatcher::new(
-                if_config,
-                &mut programs,
-                next_revision,
-                old_dispatcher,
-                image_manager.clone(),
-            )
-            .await?;
-            Ok(())
-        } else {
-            Err(BpfmanError::InternalError(
-                "ImageManager not set.".to_string(),
-            ))
-        }
+
+        Dispatcher::new(
+            if_config,
+            &mut programs,
+            next_revision,
+            old_dispatcher,
+            self.image_manager.as_mut().expect("image manager not set"),
+        )
+        .await?;
+
+        Ok(())
     }
 
     pub(crate) async fn rebuild_multiattach_dispatcher(
@@ -831,20 +828,14 @@ impl BpfManager {
                 1
             };
 
-            if let Some(image_manager) = self.image_manager.clone() {
-                Dispatcher::new(
-                    if_config,
-                    &mut programs,
-                    next_revision,
-                    old_dispatcher,
-                    image_manager.clone(),
-                )
-                .await?;
-            } else {
-                return Err(BpfmanError::InternalError(
-                    "ImageManager not set.".to_string(),
-                ));
-            }
+            Dispatcher::new(
+                if_config,
+                &mut programs,
+                next_revision,
+                old_dispatcher,
+                self.image_manager.as_mut().expect("image manager not set"),
+            )
+            .await?;
         } else {
             debug!("No dispatcher found in rebuild_multiattach_dispatcher() for {did:?}");
         }
@@ -916,32 +907,19 @@ impl BpfManager {
         }
     }
 
-    pub(crate) async fn pull_bytecode(&self, args: PullBytecodeArgs) -> anyhow::Result<()> {
-        let res;
-        let (tx, rx) = oneshot::channel();
-        if let Some(image_manager) = self.image_manager.clone() {
-            image_manager
-                .send(ImageManagerCommand::Pull {
-                    image: args.image.image_url,
-                    pull_policy: args.image.image_pull_policy.clone(),
-                    username: args.image.username.clone(),
-                    password: args.image.password.clone(),
-                    resp: tx,
-                })
-                .await?;
-            res = match rx.await? {
-                Ok(_) => {
-                    info!("Successfully pulled bytecode");
-                    Ok(())
-                }
-                Err(e) => Err(BpfmanError::BpfBytecodeError(e)),
-            };
-        } else {
-            res = Err(BpfmanError::InternalError(
-                "ImageManager not set.".to_string(),
-            ));
-        }
-        let _ = args.responder.send(res);
+    pub(crate) async fn pull_bytecode(&mut self, image: BytecodeImage) -> anyhow::Result<()> {
+        self.init_image_manager().await;
+
+        self.image_manager
+            .as_mut()
+            .expect("image manager not set")
+            .get_image(
+                &image.image_url,
+                image.image_pull_policy.clone(),
+                image.username.clone(),
+                image.password.clone(),
+            )
+            .await?;
         Ok(())
     }
 
@@ -976,7 +954,11 @@ impl BpfManager {
                                 // Ignore errors as they'll be propagated to caller in the RPC status
                                 let _ = args.responder.send(prog);
                             },
-                            Command::PullBytecode (args) => self.pull_bytecode(args).await.unwrap(),
+                            Command::PullBytecode(args) => {
+                                let res = self.pull_bytecode(args.image).await;
+                                // Ignore errors as they'll be propagated to caller in the RPC status
+                                let _ = args.responder.send(res.map_err(|e| e.into()));
+                            }
                         }
                     }
                 }
@@ -1013,14 +995,13 @@ impl BpfManager {
     // then map the directory is still in use and there is nothing to do.
     // Otherwise, the map directory was created so it must
     // deleted.
-    async fn cleanup_map_pin_path(
+    fn cleanup_map_pin_path(
         &mut self,
         map_pin_path: &Path,
         map_owner_id: Option<u32>,
     ) -> Result<(), BpfmanError> {
         if map_owner_id.is_none() && map_pin_path.exists() {
             let _ = remove_dir_all(map_pin_path)
-                .await
                 .map_err(|e| BpfmanError::Error(format!("can't delete map dir: {e}")));
             Ok(())
         } else {
@@ -1036,7 +1017,7 @@ impl BpfManager {
     // the Used-By array.
 
     // TODO this should probably be program.save_map not bpfmanager.save_map
-    async fn save_map(
+    fn save_map(
         &mut self,
         program: &mut Program,
         id: u32,
@@ -1106,7 +1087,7 @@ impl BpfManager {
     // directory is removed. If this eBPF program is referencing a
     // map from another eBPF program, then this eBPF programs ID
     // is removed from the UsedBy array.
-    async fn delete_map(&mut self, id: u32, map_owner_id: Option<u32>) -> Result<(), BpfmanError> {
+    fn delete_map(&mut self, id: u32, map_owner_id: Option<u32>) -> Result<(), BpfmanError> {
         let index = match map_owner_id {
             Some(i) => i,
             None => id,
@@ -1129,7 +1110,6 @@ impl BpfManager {
                     .drop_tree(MAP_PREFIX.to_string() + &index.to_string())
                     .expect("unable to drop maps tree");
                 remove_dir_all(path)
-                    .await
                     .map_err(|e| BpfmanError::Error(format!("can't delete map dir: {e}")))?;
             } else {
                 // Update all the programs still using the same map with the updated map_used_by.
@@ -1158,10 +1138,8 @@ pub fn calc_map_pin_path(id: u32) -> PathBuf {
 }
 
 // Create the map_pin_path for a given program.
-pub async fn create_map_pin_path(p: &Path) -> Result<(), BpfmanError> {
-    create_dir_all(p)
-        .await
-        .map_err(|e| BpfmanError::Error(format!("can't create map dir: {e}")))
+pub fn create_map_pin_path(p: &Path) -> Result<(), BpfmanError> {
+    create_dir_all(p).map_err(|e| BpfmanError::Error(format!("can't create map dir: {e}")))
 }
 
 // set_maps_used_by differs from other setters in that it's explicitly idempotent.

--- a/bpfman/src/bpf.rs
+++ b/bpfman/src/bpf.rs
@@ -1080,7 +1080,7 @@ impl BpfManager {
                 if let Some(map_pin_path) = data.get_map_pin_path()? {
                     if let Some(path) = map_pin_path.to_str() {
                         debug!("bpf set dir permissions for {}", path);
-                        set_dir_permissions(path, MAPS_MODE).await;
+                        set_dir_permissions(path, MAPS_MODE);
                     } else {
                         return Err(BpfmanError::Error(format!(
                             "invalid map_pin_path {} for {}",

--- a/bpfman/src/cli/mod.rs
+++ b/bpfman/src/cli/mod.rs
@@ -14,28 +14,15 @@ use anyhow::anyhow;
 use args::Commands;
 use get::execute_get;
 use list::execute_list;
-use tokio::sync::{broadcast, mpsc};
 use unload::execute_unload;
 
-use crate::{
-    bpf::BpfManager, cli::system::initialize_bpfman, oci_utils::ImageManager,
-    utils::open_config_file,
-};
+use crate::{bpf::BpfManager, utils::open_config_file};
 
 impl Commands {
     pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
-        initialize_bpfman()?;
-
         let config = open_config_file();
-        let (shutdown_tx, shutdown_rx1) = broadcast::channel(32);
-        let allow_unsigned: bool = config.signing.as_ref().map_or(true, |s| s.allow_unsigned);
-        let (itx, irx) = mpsc::channel(32);
 
-        let mut image_manager = ImageManager::new(allow_unsigned, irx).await?;
-        let image_manager_handle = tokio::spawn(async move {
-            image_manager.run(shutdown_rx1).await;
-        });
-        let mut bpf_manager = BpfManager::new(config.clone(), None, Some(itx));
+        let mut bpf_manager = BpfManager::new(config.clone(), None);
 
         match self {
             Commands::Load(l) => l.execute(&mut bpf_manager).await,
@@ -47,10 +34,6 @@ impl Commands {
             Commands::Image(i) => i.execute(&mut bpf_manager).await,
             Commands::System(s) => s.execute(&config).await,
         }?;
-
-        // Shutdown the image_manager thread and wait for it to finish
-        shutdown_tx.send(()).unwrap();
-        image_manager_handle.await?;
 
         Ok(())
     }

--- a/bpfman/src/cli/mod.rs
+++ b/bpfman/src/cli/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 
 impl Commands {
     pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
-        initialize_bpfman().await?;
+        initialize_bpfman()?;
 
         let config = open_config_file();
         let (shutdown_tx, shutdown_rx1) = broadcast::channel(32);

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -38,7 +38,7 @@ pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyh
     Ok(())
 }
 
-pub(crate) async fn initialize_bpfman() -> anyhow::Result<()> {
+pub(crate) fn initialize_bpfman() -> anyhow::Result<()> {
     if connected_to_journal() {
         // If bpfman is running as a service, log to journald.
         JournalLog::new()?
@@ -85,9 +85,9 @@ pub(crate) async fn initialize_bpfman() -> anyhow::Result<()> {
 
     create_dir_all(CFGDIR_STATIC_PROGRAMS).context("unable to create static programs directory")?;
 
-    set_dir_permissions(CFGDIR, CFGDIR_MODE).await;
-    set_dir_permissions(RTDIR, RTDIR_MODE).await;
-    set_dir_permissions(STDIR, STDIR_MODE).await;
+    set_dir_permissions(CFGDIR, CFGDIR_MODE);
+    set_dir_permissions(RTDIR, RTDIR_MODE);
+    set_dir_permissions(STDIR, STDIR_MODE);
 
     Ok(())
 }

--- a/bpfman/src/cli/system.rs
+++ b/bpfman/src/cli/system.rs
@@ -1,27 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use std::{
-    env,
-    fs::{create_dir_all, File},
-    io::{BufRead, BufReader},
-    str::FromStr,
-};
-
-use anyhow::{bail, Context};
 use bpfman_api::config::Config;
-use log::info;
-use nix::{
-    libc::RLIM_INFINITY,
-    sys::resource::{setrlimit, Resource},
-};
-use systemd_journal_logger::{connected_to_journal, JournalLog};
 
 use crate::{
     cli::args::{ServiceArgs, SystemSubcommand},
     serve::serve,
-    utils::{create_bpffs, set_dir_permissions},
-    BPFMAN_ENV_LOG_LEVEL,
 };
 
 impl SystemSubcommand {
@@ -36,95 +20,4 @@ pub(crate) async fn execute_service(args: &ServiceArgs, config: &Config) -> anyh
     //TODO https://github.com/bpfman/bpfman/issues/881
     serve(config, args.csi_support, args.timeout, &args.socket_path).await?;
     Ok(())
-}
-
-pub(crate) fn initialize_bpfman() -> anyhow::Result<()> {
-    if connected_to_journal() {
-        // If bpfman is running as a service, log to journald.
-        JournalLog::new()?
-            .with_extra_fields(vec![("VERSION", env!("CARGO_PKG_VERSION"))])
-            .install()
-            .unwrap();
-        manage_journal_log_level();
-        log::info!("Log using journald");
-    } else {
-        // Otherwise fall back to logging to standard error.
-        env_logger::init();
-        log::info!("Log using env_logger");
-    }
-
-    has_cap(caps::CapSet::Effective, caps::Capability::CAP_BPF);
-    has_cap(caps::CapSet::Effective, caps::Capability::CAP_SYS_ADMIN);
-
-    setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY).unwrap();
-
-    // Create directories associated with bpfman
-    use bpfman_api::util::directories::*;
-    create_dir_all(RTDIR).context("unable to create runtime directory")?;
-    create_dir_all(RTDIR_FS).context("unable to create mountpoint")?;
-    create_dir_all(RTDIR_TC_INGRESS_DISPATCHER).context("unable to create dispatcher directory")?;
-    create_dir_all(RTDIR_TC_EGRESS_DISPATCHER).context("unable to create dispatcher directory")?;
-    create_dir_all(RTDIR_XDP_DISPATCHER).context("unable to create dispatcher directory")?;
-    create_dir_all(RTDIR_PROGRAMS).context("unable to create programs directory")?;
-
-    if !is_bpffs_mounted()? {
-        create_bpffs(RTDIR_FS)?;
-    }
-    create_dir_all(RTDIR_FS_XDP).context("unable to create xdp dispatcher directory")?;
-    create_dir_all(RTDIR_FS_TC_INGRESS)
-        .context("unable to create tc ingress dispatcher directory")?;
-    create_dir_all(RTDIR_FS_TC_EGRESS)
-        .context("unable to create tc egress dispatcher directory")?;
-    create_dir_all(RTDIR_FS_MAPS).context("unable to create maps directory")?;
-    create_dir_all(RTDIR_BPFMAN_CSI).context("unable to create CSI directory")?;
-    create_dir_all(RTDIR_BPFMAN_CSI_FS).context("unable to create CSI socket directory")?;
-    create_dir_all(RTDIR_SOCK).context("unable to create socket directory")?;
-    create_dir_all(RTDIR_TUF).context("unable to create TUF directory")?;
-
-    create_dir_all(STDIR).context("unable to create state directory")?;
-
-    create_dir_all(CFGDIR_STATIC_PROGRAMS).context("unable to create static programs directory")?;
-
-    set_dir_permissions(CFGDIR, CFGDIR_MODE);
-    set_dir_permissions(RTDIR, RTDIR_MODE);
-    set_dir_permissions(STDIR, STDIR_MODE);
-
-    Ok(())
-}
-
-fn manage_journal_log_level() {
-    // env_logger uses the environment variable RUST_LOG to set the log
-    // level. Parse RUST_LOG to set the log level for journald.
-    log::set_max_level(log::LevelFilter::Error);
-    if env::var(BPFMAN_ENV_LOG_LEVEL).is_ok() {
-        let rust_log = log::LevelFilter::from_str(&env::var(BPFMAN_ENV_LOG_LEVEL).unwrap());
-        match rust_log {
-            Ok(value) => log::set_max_level(value),
-            Err(e) => log::error!("Invalid Log Level: {}", e),
-        }
-    }
-}
-
-fn has_cap(cset: caps::CapSet, cap: caps::Capability) {
-    info!("Has {}: {}", cap, caps::has_cap(None, cset, cap).unwrap());
-}
-
-fn is_bpffs_mounted() -> Result<bool, anyhow::Error> {
-    let file = File::open("/proc/mounts").context("Failed to open /proc/mounts")?;
-    let reader = BufReader::new(file);
-    for l in reader.lines() {
-        match l {
-            Ok(line) => {
-                let parts: Vec<&str> = line.split(' ').collect();
-                if parts.len() != 6 {
-                    bail!("expected 6 parts in proc mount")
-                }
-                if parts[0] == "none" && parts[1].contains("bpfman") && parts[2] == "bpf" {
-                    return Ok(true);
-                }
-            }
-            Err(e) => bail!("problem reading lines {}", e),
-        }
-    }
-    Ok(false)
 }

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -23,12 +23,12 @@ use chrono::{prelude::DateTime, Local};
 use log::{info, warn};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::oneshot;
 
 use crate::{
     errors::BpfmanError,
     multiprog::{DispatcherId, DispatcherInfo},
-    oci_utils::image_manager::{BytecodeImage, Command as ImageManagerCommand},
+    oci_utils::{image_manager::BytecodeImage, ImageManager},
     utils::{
         bytes_to_bool, bytes_to_i32, bytes_to_string, bytes_to_u32, bytes_to_u64, bytes_to_usize,
         sled_get, sled_get_option, sled_insert,
@@ -234,37 +234,20 @@ pub(crate) enum Location {
 impl Location {
     async fn get_program_bytes(
         &self,
-        image_manager: Sender<ImageManagerCommand>,
+        image_manager: &mut ImageManager,
     ) -> Result<(Vec<u8>, String), BpfmanError> {
         match self {
             Location::File(l) => Ok((crate::utils::read(l)?, "".to_owned())),
             Location::Image(l) => {
-                let (tx, rx) = oneshot::channel();
-                image_manager
-                    .send(ImageManagerCommand::Pull {
-                        image: l.image_url.clone(),
-                        pull_policy: l.image_pull_policy.clone(),
-                        username: l.username.clone(),
-                        password: l.password.clone(),
-                        resp: tx,
-                    })
-                    .await
-                    .map_err(|e| BpfmanError::RpcSendError(e.into()))?;
-                let (path, bpf_function_name) = rx
-                    .await
-                    .map_err(BpfmanError::RpcRecvError)?
-                    .map_err(BpfmanError::BpfBytecodeError)?;
-
-                let (tx, rx) = oneshot::channel();
-                image_manager
-                    .send(ImageManagerCommand::GetBytecode { path, resp: tx })
-                    .await
-                    .map_err(|e| BpfmanError::RpcSendError(e.into()))?;
-
-                let bytecode = rx
-                    .await
-                    .map_err(BpfmanError::RpcRecvError)?
-                    .map_err(BpfmanError::BpfBytecodeError)?;
+                let (path, bpf_function_name) = image_manager
+                    .get_image(
+                        &l.image_url,
+                        l.image_pull_policy.clone(),
+                        l.username.clone(),
+                        l.password.clone(),
+                    )
+                    .await?;
+                let bytecode = image_manager.get_bytecode_from_image_store(path)?;
 
                 Ok((bytecode, bpf_function_name))
             }
@@ -713,7 +696,7 @@ impl ProgramData {
 
     pub(crate) async fn set_program_bytes(
         &mut self,
-        image_manager: Sender<ImageManagerCommand>,
+        image_manager: &mut ImageManager,
     ) -> Result<(), BpfmanError> {
         let loc = self.get_location()?;
         match loc.get_program_bytes(image_manager).await {

--- a/bpfman/src/command.rs
+++ b/bpfman/src/command.rs
@@ -237,7 +237,7 @@ impl Location {
         image_manager: Sender<ImageManagerCommand>,
     ) -> Result<(Vec<u8>, String), BpfmanError> {
         match self {
-            Location::File(l) => Ok((crate::utils::read(l).await?, "".to_owned())),
+            Location::File(l) => Ok((crate::utils::read(l)?, "".to_owned())),
             Location::Image(l) => {
                 let (tx, rx) = oneshot::channel();
                 image_manager

--- a/bpfman/src/main.rs
+++ b/bpfman/src/main.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use log::info;
 use sled::{Config as SledConfig, Db};
 
-use crate::utils::open_config_file;
+use crate::utils::{initialize_bpfman, open_config_file};
 
 mod bpf;
 mod cli;
@@ -62,5 +62,7 @@ lazy_static! {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = cli::args::Cli::parse();
+    initialize_bpfman()?;
+
     cli.command.execute().await
 }

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -10,13 +10,12 @@ use bpfman_api::{
 };
 use log::debug;
 pub use tc::TcDispatcher;
-use tokio::sync::mpsc::Sender;
 pub use xdp::XdpDispatcher;
 
 use crate::{
     command::{Direction, Program},
     errors::BpfmanError,
-    oci_utils::image_manager::Command as ImageManagerCommand,
+    oci_utils::ImageManager,
     utils::bytes_to_string,
 };
 
@@ -35,7 +34,7 @@ impl Dispatcher {
         programs: &mut [Program],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
-        image_manager: Sender<ImageManagerCommand>,
+        image_manager: &mut ImageManager,
     ) -> Result<Dispatcher, BpfmanError> {
         debug!("Dispatcher::new()");
         let p = programs

--- a/bpfman/src/rpc.rs
+++ b/bpfman/src/rpc.rs
@@ -356,9 +356,7 @@ impl Bpfman for BpfmanLoader {
 mod test {
     use std::{collections::HashMap, time::SystemTime};
 
-    use bpfman_api::v1::{
-        bytecode_location::Location, AttachInfo, BytecodeLocation, LoadRequest, XdpAttachInfo,
-    };
+    use bpfman_api::v1::{AttachInfo, BytecodeLocation};
     use tokio::sync::mpsc::Receiver;
 
     use super::*;

--- a/bpfman/src/serve.rs
+++ b/bpfman/src/serve.rs
@@ -207,7 +207,7 @@ async fn std_unix_stream(path: &Path) -> anyhow::Result<UnixListenerStream> {
     let uds = UnixListener::bind(path)?;
     let stream = UnixListenerStream::new(uds);
     // Always set the file permissions of our listening socket.
-    set_file_permissions(path, SOCK_MODE).await;
+    set_file_permissions(path, SOCK_MODE);
 
     info!("Using default Unix socket");
     Ok(stream)

--- a/bpfman/src/storage.rs
+++ b/bpfman/src/storage.rs
@@ -188,7 +188,7 @@ impl Node for CsiNode {
                             format!("failed creating target path {target_path:?}: {e}"),
                         )
                     })?;
-                    set_dir_permissions(target_path, OWNER_READ_WRITE).await;
+                    set_dir_permissions(target_path, OWNER_READ_WRITE);
                 }
 
                 // Make a new bpf fs specifically for the pod.
@@ -372,7 +372,7 @@ impl StorageManager {
         let uds = UnixListener::bind(path)
             .unwrap_or_else(|_| panic!("failed to bind {RTPATH_BPFMAN_CSI_SOCKET}"));
         let uds_stream = UnixListenerStream::new(uds);
-        set_file_permissions(Path::new(RTPATH_BPFMAN_CSI_SOCKET), SOCK_MODE).await;
+        set_file_permissions(Path::new(RTPATH_BPFMAN_CSI_SOCKET), SOCK_MODE);
 
         let node_service = NodeServer::new(self.csi_node);
         let identity_service = IdentityServer::new(self.csi_identity);


### PR DESCRIPTION
Refactor the image manager
- Remove all channels and commands
- only initialize image_manager when needed and do this in the core codepath (bpf.rs)
- Cleanup a bunch of extra async functions which don't need to be async any longer
