### PR TITLE
chore(bpfman): Use native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,20 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1496,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1862,6 +1876,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2127,50 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -2664,15 +2740,15 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2680,7 +2756,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "trust-dns-resolver",
@@ -2689,7 +2765,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -2816,18 +2891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2841,16 +2904,6 @@ name = "rustls-pki-types"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2894,6 +2947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,16 +2974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2985,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3104,7 +3179,7 @@ dependencies = [
  "regex",
  "rsa",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki",
  "scrypt",
  "serde",
  "serde_json",
@@ -3459,12 +3534,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
 ]
 
@@ -3972,12 +4047,6 @@ dependencies = [
  "url",
  "web-sys",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"

--- a/Containerfile.bpfman
+++ b/Containerfile.bpfman
@@ -8,23 +8,21 @@ RUN apt-get update && apt-get install -y\
  protobuf-compiler\
  libelf-dev\
  gcc-multilib\
- musl-tools
+ libssl-dev
 
 WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
 
-RUN rustup target add x86_64-unknown-linux-musl
-
 # Compile only the C ebpf bytecode
 RUN cargo xtask build-ebpf --release --libbpf-dir /usr/src/bpfman/libbpf
-# Compile bpfman 
-RUN cargo build --release -p bpfman --target x86_64-unknown-linux-musl
-# Compile bpfman-ns 
-RUN cargo build --release -p bpfman-ns --target x86_64-unknown-linux-musl
+# Compile bpfman
+RUN cargo build --release -p bpfman
+# Compile bpfman-ns
+RUN cargo build --release -p bpfman-ns
 
-FROM scratch
+FROM redhat/ubi9-minimal
 
-COPY --from=bpfman-build  /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman .
-COPY --from=bpfman-build  /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman-ns .
+COPY --from=bpfman-build  /usr/src/bpfman/target/release/bpfman .
+COPY --from=bpfman-build  /usr/src/bpfman/target/release/bpfman-ns .
 
 ENTRYPOINT ["./bpfman", "system", "service", "--timeout=0"]

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -4,26 +4,24 @@ FROM rust:1 as bpfman-build
 
 RUN apt-get update && apt-get install -y\
     gcc-multilib\
-    musl-tools
+    libssl-dev
 
 WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
 
-RUN rustup target add x86_64-unknown-linux-musl
-
 # Compile only bpfman
 RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
     --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --target x86_64-unknown-linux-musl
+    cargo build --release
 
 RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
-    cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman ./bpfman/
+    cp /usr/src/bpfman/target/release/bpfman ./bpfman/
 
 RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
-    cp /usr/src/bpfman/target/x86_64-unknown-linux-musl/release/bpfman-ns ./bpfman/
+    cp /usr/src/bpfman/target/release/bpfman-ns ./bpfman/
 
 ## Image for Local testing is much more of a debug image, give it bpftool and tcpdump
-FROM fedora:38
+FROM fedora:39
 
 RUN dnf makecache --refresh && dnf -y install bpftool tcpdump
 

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -47,6 +47,7 @@ Source1:         bpfman-bpfman-vendor.tar.gz
 
 BuildRequires:  cargo-rpm-macros >= 25
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  openssl-devel
 
 # TODO: Generate Provides for all of the vendored dependencies
 

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -46,7 +46,7 @@ nix = { workspace = true, features = [
     "user",
 ] }
 oci-distribution = { workspace = true, default-features = false, features = [
-    "rustls-tls",
+    "native-tls",
     "trust-dns",
 ] }
 rand = { workspace = true }
@@ -56,7 +56,7 @@ serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }
 sigstore = { workspace = true, features = [
     "cached-client",
-    "cosign-rustls-tls",
+    "cosign-native-tls",
     "tuf",
 ] }
 sled = { workspace = true }


### PR DESCRIPTION
In order to be more easily packaged by Linux distros, we'll opt to use native-tls over rust-tls. This puts a compile-time dependency on having openssl libraries/headers available. This requires changes to the Dockerfile and Specfile.

This also drops support for musl libc - given that figuring out how to cross-compile OpenSSL for musl is a pain.

Therefore, we move away from using a `scratch` image to a RHEL UBI image, which does include libc. Given this image includes microdnf we can drop the bpfman.local image and install debugging tools on demand.