### PR TITLE
add public-api checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,9 @@ jobs:
         run: |
           cargo +nightly clippy --all -- --deny warnings
 
+      - name: Check public API
+        run: cargo xtask public-api
+
       - name: Build
         run: cargo build --verbose
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,13 @@ cargo +nightly clippy --all -- --deny warnings
 * Verify that unit tests are passing locally (see
   [Unit Testing](https://bpfman.io/main/developer-guide/testing/#unit-testing)):
 
+* Verify any changes to the bpfman api have been "blessed"
+
+```console
+cd /src/bpfman/
+cargo +nightly xtask public-api --bless
+```
+
 ```console
 cd src/bpfman/
 cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,12 +547,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo-manifest"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ff49a028a52bf61913e19f5ba3b9bd34145cc97eb1649865576c8f06b408d"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -700,6 +743,19 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -965,6 +1021,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1132,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1387,6 +1466,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f494b2060b2a8f5e63379e1e487258e014cee1b1725a735816c0107a2e9d93"
 
 [[package]]
 name = "hashbrown"
@@ -2703,6 +2788,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "public-api"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b759eeee807ac96096fce568abeb9ef8d23db7be771a65252b1e5093fe7938c4"
+dependencies = [
+ "hashbag",
+ "rustdoc-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3055,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-json"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21e727474edad247ba206da91e5d3f76c0ff4a4ddac1fb7bba508df49101388"
+dependencies = [
+ "cargo-manifest",
+ "cargo_metadata",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "rustdoc-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3135,15 @@ dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustup-toolchain"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64406f60467f189c326fc2e7f74ee643c28d1ff500068e0fa0f5e56a04e2cc95"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -3126,6 +3255,9 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -3239,6 +3371,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3695,6 +3833,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4460,11 +4599,17 @@ dependencies = [
  "anyhow",
  "bpfman",
  "bpfman-api",
+ "cargo_metadata",
  "clap",
  "clap_complete",
  "clap_mangen",
+ "dialoguer",
+ "diff",
  "hex",
  "lazy_static",
+ "public-api",
+ "rustdoc-json",
+ "rustup-toolchain",
  "serde_json",
  "tonic-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,14 @@ bpfman = { version = "0.4.0-dev", path = "./bpfman" }
 bpfman-api = { version = "0.4.0-dev", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
 caps = { version = "0.5.4", default-features = false }
+cargo_metadata = { version = "0.18.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false }
 clap = { version = "4", default-features = false }
 clap_complete = { version = "4.5.1", default-features = false }
 clap_mangen = { version = "0.2.20", default-features = false }
 comfy-table = { version = "7.1.0", default-features = false }
+dialoguer = { version = "0.11", default-features = false }
+diff = { version = "0.1.13", default-features = false }
 env_logger = { version = "0.11.3", default-features = false }
 flate2 = { version = "1.0", default-features = false }
 futures = { version = "0.3.30", default-features = false }
@@ -59,10 +62,13 @@ opentelemetry_sdk = { version = "0.22.1", default-features = false }
 predicates = { version = "3.0.4", default-features = false }
 prost = { version = "0.12.3", default-features = false }
 prost-types = { version = "0.12.3", default-features = false }
+public-api = { version = "0.33.1", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 regex = { version = "1.9.6", default-features = false }
 rtnetlink = { version = "0.14", default-features = false }
+rustdoc-json = { version = "0.8.9", default-features = false }
+rustup-toolchain = { version = "0.1.6", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
@@ -82,6 +88,7 @@ tonic-build = { version = "0.11.0", default-features = false }
 tower = { version = "0.4.13", default-features = false }
 url = { version = "2.5.0", default-features = false }
 users = { version = "0.11.0", default-features = false }
+
 
 [workspace.metadata.vendor-filter]
 platforms = [

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 anyhow = { workspace = true, features = ["std"] }
 bpfman = { workspace = true }
 bpfman-api = { workspace = true }
+cargo_metadata = { workspace = true }
 clap = { workspace = true, features = [
     "derive",
     "help",
@@ -17,7 +18,12 @@ clap = { workspace = true, features = [
 ] }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
+dialoguer = { workspace = true }
+diff = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
+public-api = { workspace = true }
+rustdoc-json = { workspace = true }
+rustup-toolchain = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tonic-build = { workspace = true, features = ["prost"] }

--- a/xtask/public-api/bpfman-api.txt
+++ b/xtask/public-api/bpfman-api.txt
@@ -1,0 +1,1703 @@
+pub mod bpfman_api
+pub mod bpfman_api::v1
+pub mod bpfman_api::v1::attach_info
+pub enum bpfman_api::v1::attach_info::Info
+pub bpfman_api::v1::attach_info::Info::FentryAttachInfo(bpfman_api::v1::FentryAttachInfo)
+pub bpfman_api::v1::attach_info::Info::FexitAttachInfo(bpfman_api::v1::FexitAttachInfo)
+pub bpfman_api::v1::attach_info::Info::KprobeAttachInfo(bpfman_api::v1::KprobeAttachInfo)
+pub bpfman_api::v1::attach_info::Info::TcAttachInfo(bpfman_api::v1::TcAttachInfo)
+pub bpfman_api::v1::attach_info::Info::TracepointAttachInfo(bpfman_api::v1::TracepointAttachInfo)
+pub bpfman_api::v1::attach_info::Info::UprobeAttachInfo(bpfman_api::v1::UprobeAttachInfo)
+pub bpfman_api::v1::attach_info::Info::XdpAttachInfo(bpfman_api::v1::XdpAttachInfo)
+impl bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_api::v1::attach_info::Info::encoded_len(&self) -> usize
+pub fn bpfman_api::v1::attach_info::Info::merge<B>(field: &mut core::option::Option<bpfman_api::v1::attach_info::Info>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::clone(&self) -> bpfman_api::v1::attach_info::Info
+impl core::cmp::PartialEq for bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::eq(&self, other: &bpfman_api::v1::attach_info::Info) -> bool
+impl core::fmt::Debug for bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::attach_info::Info
+impl core::marker::Freeze for bpfman_api::v1::attach_info::Info
+impl core::marker::Send for bpfman_api::v1::attach_info::Info
+impl core::marker::Sync for bpfman_api::v1::attach_info::Info
+impl core::marker::Unpin for bpfman_api::v1::attach_info::Info
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::attach_info::Info
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::attach_info::Info
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::attach_info::Info where U: core::convert::From<T>
+pub fn bpfman_api::v1::attach_info::Info::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::attach_info::Info where U: core::convert::Into<T>
+pub type bpfman_api::v1::attach_info::Info::Error = core::convert::Infallible
+pub fn bpfman_api::v1::attach_info::Info::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::attach_info::Info where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::attach_info::Info::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::attach_info::Info::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::attach_info::Info where T: core::clone::Clone
+pub type bpfman_api::v1::attach_info::Info::Owned = T
+pub fn bpfman_api::v1::attach_info::Info::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::attach_info::Info::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::attach_info::Info where T: core::clone::Clone
+pub fn bpfman_api::v1::attach_info::Info::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::attach_info::Info where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::attach_info::Info::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::attach_info::Info where T: core::marker::Sized
+pub fn bpfman_api::v1::attach_info::Info::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::attach_info::Info where T: core::marker::Sized
+pub fn bpfman_api::v1::attach_info::Info::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::attach_info::Info
+pub type bpfman_api::v1::attach_info::Info::Init = T
+pub const bpfman_api::v1::attach_info::Info::ALIGN: usize
+pub unsafe fn bpfman_api::v1::attach_info::Info::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::attach_info::Info::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::attach_info::Info::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::attach_info::Info::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::attach_info::Info where T: core::clone::Clone
+pub fn bpfman_api::v1::attach_info::Info::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::attach_info::Info
+pub fn bpfman_api::v1::attach_info::Info::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::attach_info::Info
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::attach_info::Info
+impl<T> typenum::type_operators::Same for bpfman_api::v1::attach_info::Info
+pub type bpfman_api::v1::attach_info::Info::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::attach_info::Info where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::attach_info::Info::vzip(self) -> V
+pub mod bpfman_api::v1::bpfman_client
+pub struct bpfman_api::v1::bpfman_client::BpfmanClient<T>
+impl<T> bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: tonic::client::service::GrpcService<tonic::body::BoxBody>, <T as tonic::client::service::GrpcService>::Error: core::convert::Into<tonic::codegen::StdError>, <T as tonic::client::service::GrpcService>::ResponseBody: http_body::Body<Data = bytes::bytes::Bytes> + core::marker::Send + 'static, <<T as tonic::client::service::GrpcService>::ResponseBody as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::get(&mut self, request: impl tonic::request::IntoRequest<bpfman_api::v1::GetRequest>) -> core::result::Result<tonic::response::Response<bpfman_api::v1::GetResponse>, tonic::status::Status>
+pub async fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::list(&mut self, request: impl tonic::request::IntoRequest<bpfman_api::v1::ListRequest>) -> core::result::Result<tonic::response::Response<bpfman_api::v1::ListResponse>, tonic::status::Status>
+pub async fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::load(&mut self, request: impl tonic::request::IntoRequest<bpfman_api::v1::LoadRequest>) -> core::result::Result<tonic::response::Response<bpfman_api::v1::LoadResponse>, tonic::status::Status>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::new(inner: T) -> Self
+pub async fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::pull_bytecode(&mut self, request: impl tonic::request::IntoRequest<bpfman_api::v1::PullBytecodeRequest>) -> core::result::Result<tonic::response::Response<bpfman_api::v1::PullBytecodeResponse>, tonic::status::Status>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::unload(&mut self, request: impl tonic::request::IntoRequest<bpfman_api::v1::UnloadRequest>) -> core::result::Result<tonic::response::Response<bpfman_api::v1::UnloadResponse>, tonic::status::Status>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::with_interceptor<F>(inner: T, interceptor: F) -> bpfman_api::v1::bpfman_client::BpfmanClient<tonic::service::interceptor::InterceptedService<T, F>> where F: tonic::service::interceptor::Interceptor, <T as tonic::client::service::GrpcService>::ResponseBody: core::default::Default, T: tower_service::Service<http::request::Request<tonic::body::BoxBody>, Response = http::response::Response<<T as tonic::client::service::GrpcService<tonic::body::BoxBody>>::ResponseBody>>, <T as tower_service::Service<http::request::Request<tonic::body::BoxBody>>>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + core::marker::Sync
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::with_origin(inner: T, origin: http::uri::Uri) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::clone(&self) -> bpfman_api::v1::bpfman_client::BpfmanClient<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> !core::marker::Freeze for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+impl<T> core::marker::Send for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where U: core::convert::From<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where U: core::convert::Into<T>
+pub type bpfman_api::v1::bpfman_client::BpfmanClient<T>::Error = core::convert::Infallible
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::bpfman_client::BpfmanClient<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::clone::Clone
+pub type bpfman_api::v1::bpfman_client::BpfmanClient<T>::Owned = T
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::clone::Clone
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::marker::Sized
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::marker::Sized
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub type bpfman_api::v1::bpfman_client::BpfmanClient<T>::Init = T
+pub const bpfman_api::v1::bpfman_client::BpfmanClient<T>::ALIGN: usize
+pub unsafe fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::bpfman_client::BpfmanClient<T> where T: core::clone::Clone
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+impl<T> typenum::type_operators::Same for bpfman_api::v1::bpfman_client::BpfmanClient<T>
+pub type bpfman_api::v1::bpfman_client::BpfmanClient<T>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::bpfman_client::BpfmanClient<T> where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::bpfman_client::BpfmanClient<T>::vzip(self) -> V
+pub mod bpfman_api::v1::bpfman_server
+pub struct bpfman_api::v1::bpfman_server::BpfmanServer<T: bpfman_api::v1::bpfman_server::Bpfman>
+impl<T: bpfman_api::v1::bpfman_server::Bpfman> bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::from_arc(inner: alloc::sync::Arc<T>) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::new(inner: T) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::with_interceptor<F>(inner: T, interceptor: F) -> tonic::service::interceptor::InterceptedService<Self, F> where F: tonic::service::interceptor::Interceptor
+impl<T, B> tower_service::Service<http::request::Request<B>> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: bpfman_api::v1::bpfman_server::Bpfman, B: http_body::Body + core::marker::Send + 'static, <B as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + 'static
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Error = core::convert::Infallible
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Future = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<<bpfman_api::v1::bpfman_server::BpfmanServer<T> as tower_service::Service<http::request::Request<B>>>::Response, <bpfman_api::v1::bpfman_server::BpfmanServer<T> as tower_service::Service<http::request::Request<B>>>::Error>> + core::marker::Send)>>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Response = http::response::Response<http_body::combinators::box_body::UnsyncBoxBody<bytes::bytes::Bytes, tonic::status::Status>>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::call(&mut self, req: http::request::Request<B>) -> Self::Future
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::poll_ready(&mut self, _cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), Self::Error>>
+impl<T: bpfman_api::v1::bpfman_server::Bpfman> core::clone::Clone for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::clone(&self) -> Self
+impl<T: bpfman_api::v1::bpfman_server::Bpfman> tonic::server::NamedService for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub const bpfman_api::v1::bpfman_server::BpfmanServer<T>::NAME: &'static str
+impl<T: core::fmt::Debug + bpfman_api::v1::bpfman_server::Bpfman> core::fmt::Debug for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> core::marker::Send for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> core::marker::Sync for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> core::marker::Unpin for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<S, R> axum::service_ext::ServiceExt<R> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where S: tower_service::Service<R>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::into_make_service(self) -> axum::routing::into_make_service::IntoMakeService<S>
+impl<T, ReqBody, ResBody> tonic::client::service::GrpcService<ReqBody> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: tower_service::Service<http::request::Request<ReqBody>, Response = http::response::Response<ResBody>>, <T as tower_service::Service<http::request::Request<ReqBody>>>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>, ResBody: http_body::Body, <ResBody as http_body::Body>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Error = <T as tower_service::Service<http::request::Request<ReqBody>>>::Error
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Future = <T as tower_service::Service<http::request::Request<ReqBody>>>::Future
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::ResponseBody = ResBody
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::call(&mut self, request: http::request::Request<ReqBody>) -> <T as tonic::client::service::GrpcService<ReqBody>>::Future
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::poll_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), <T as tonic::client::service::GrpcService<ReqBody>>::Error>>
+impl<T, Request> tower::util::ServiceExt<Request> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: tower_service::Service<Request> + core::marker::Sized
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where U: core::convert::From<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where U: core::convert::Into<T>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Error = core::convert::Infallible
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::clone::Clone
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Owned = T
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::clone::Clone
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::marker::Sized
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::marker::Sized
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Init = T
+pub const bpfman_api::v1::bpfman_server::BpfmanServer<T>::ALIGN: usize
+pub unsafe fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::bpfman_server::BpfmanServer<T> where T: core::clone::Clone
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+impl<T> typenum::type_operators::Same for bpfman_api::v1::bpfman_server::BpfmanServer<T>
+pub type bpfman_api::v1::bpfman_server::BpfmanServer<T>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::bpfman_server::BpfmanServer<T> where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::bpfman_server::BpfmanServer<T>::vzip(self) -> V
+pub trait bpfman_api::v1::bpfman_server::Bpfman: core::marker::Send + core::marker::Sync + 'static
+pub fn bpfman_api::v1::bpfman_server::Bpfman::get<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_api::v1::GetRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_api::v1::GetResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_api::v1::bpfman_server::Bpfman::list<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_api::v1::ListRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_api::v1::ListResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_api::v1::bpfman_server::Bpfman::load<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_api::v1::LoadRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_api::v1::LoadResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_api::v1::bpfman_server::Bpfman::pull_bytecode<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_api::v1::PullBytecodeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_api::v1::PullBytecodeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_api::v1::bpfman_server::Bpfman::unload<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_api::v1::UnloadRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_api::v1::UnloadResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub mod bpfman_api::v1::bytecode_location
+pub enum bpfman_api::v1::bytecode_location::Location
+pub bpfman_api::v1::bytecode_location::Location::File(alloc::string::String)
+pub bpfman_api::v1::bytecode_location::Location::Image(bpfman_api::v1::BytecodeImage)
+impl bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_api::v1::bytecode_location::Location::encoded_len(&self) -> usize
+pub fn bpfman_api::v1::bytecode_location::Location::merge<B>(field: &mut core::option::Option<bpfman_api::v1::bytecode_location::Location>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::clone(&self) -> bpfman_api::v1::bytecode_location::Location
+impl core::cmp::PartialEq for bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::eq(&self, other: &bpfman_api::v1::bytecode_location::Location) -> bool
+impl core::fmt::Debug for bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::bytecode_location::Location
+impl core::marker::Freeze for bpfman_api::v1::bytecode_location::Location
+impl core::marker::Send for bpfman_api::v1::bytecode_location::Location
+impl core::marker::Sync for bpfman_api::v1::bytecode_location::Location
+impl core::marker::Unpin for bpfman_api::v1::bytecode_location::Location
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::bytecode_location::Location
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::bytecode_location::Location
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::bytecode_location::Location where U: core::convert::From<T>
+pub fn bpfman_api::v1::bytecode_location::Location::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::bytecode_location::Location where U: core::convert::Into<T>
+pub type bpfman_api::v1::bytecode_location::Location::Error = core::convert::Infallible
+pub fn bpfman_api::v1::bytecode_location::Location::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::bytecode_location::Location where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::bytecode_location::Location::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::bytecode_location::Location::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::bytecode_location::Location where T: core::clone::Clone
+pub type bpfman_api::v1::bytecode_location::Location::Owned = T
+pub fn bpfman_api::v1::bytecode_location::Location::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::bytecode_location::Location::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::bytecode_location::Location where T: core::clone::Clone
+pub fn bpfman_api::v1::bytecode_location::Location::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::bytecode_location::Location where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::bytecode_location::Location::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::bytecode_location::Location where T: core::marker::Sized
+pub fn bpfman_api::v1::bytecode_location::Location::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::bytecode_location::Location where T: core::marker::Sized
+pub fn bpfman_api::v1::bytecode_location::Location::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::bytecode_location::Location
+pub type bpfman_api::v1::bytecode_location::Location::Init = T
+pub const bpfman_api::v1::bytecode_location::Location::ALIGN: usize
+pub unsafe fn bpfman_api::v1::bytecode_location::Location::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::bytecode_location::Location::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::bytecode_location::Location::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::bytecode_location::Location::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::bytecode_location::Location where T: core::clone::Clone
+pub fn bpfman_api::v1::bytecode_location::Location::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::bytecode_location::Location
+pub fn bpfman_api::v1::bytecode_location::Location::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::bytecode_location::Location
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::bytecode_location::Location
+impl<T> typenum::type_operators::Same for bpfman_api::v1::bytecode_location::Location
+pub type bpfman_api::v1::bytecode_location::Location::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::bytecode_location::Location where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::bytecode_location::Location::vzip(self) -> V
+pub mod bpfman_api::v1::list_response
+pub struct bpfman_api::v1::list_response::ListResult
+pub bpfman_api::v1::list_response::ListResult::info: core::option::Option<bpfman_api::v1::ProgramInfo>
+pub bpfman_api::v1::list_response::ListResult::kernel_info: core::option::Option<bpfman_api::v1::KernelProgramInfo>
+impl core::clone::Clone for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::clone(&self) -> bpfman_api::v1::list_response::ListResult
+impl core::cmp::PartialEq for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::eq(&self, other: &bpfman_api::v1::list_response::ListResult) -> bool
+impl core::default::Default for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::list_response::ListResult
+impl prost::message::Message for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::clear(&mut self)
+pub fn bpfman_api::v1::list_response::ListResult::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::list_response::ListResult
+impl core::marker::Send for bpfman_api::v1::list_response::ListResult
+impl core::marker::Sync for bpfman_api::v1::list_response::ListResult
+impl core::marker::Unpin for bpfman_api::v1::list_response::ListResult
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::list_response::ListResult
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::list_response::ListResult
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::list_response::ListResult where U: core::convert::From<T>
+pub fn bpfman_api::v1::list_response::ListResult::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::list_response::ListResult where U: core::convert::Into<T>
+pub type bpfman_api::v1::list_response::ListResult::Error = core::convert::Infallible
+pub fn bpfman_api::v1::list_response::ListResult::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::list_response::ListResult where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::list_response::ListResult::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::list_response::ListResult::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::list_response::ListResult where T: core::clone::Clone
+pub type bpfman_api::v1::list_response::ListResult::Owned = T
+pub fn bpfman_api::v1::list_response::ListResult::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::list_response::ListResult::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::list_response::ListResult where T: core::clone::Clone
+pub fn bpfman_api::v1::list_response::ListResult::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::list_response::ListResult where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::list_response::ListResult::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::list_response::ListResult where T: core::marker::Sized
+pub fn bpfman_api::v1::list_response::ListResult::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::list_response::ListResult where T: core::marker::Sized
+pub fn bpfman_api::v1::list_response::ListResult::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::list_response::ListResult
+pub type bpfman_api::v1::list_response::ListResult::Init = T
+pub const bpfman_api::v1::list_response::ListResult::ALIGN: usize
+pub unsafe fn bpfman_api::v1::list_response::ListResult::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::list_response::ListResult::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::list_response::ListResult::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::list_response::ListResult::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::list_response::ListResult where T: core::clone::Clone
+pub fn bpfman_api::v1::list_response::ListResult::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::list_response::ListResult
+pub fn bpfman_api::v1::list_response::ListResult::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::list_response::ListResult
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::list_response::ListResult
+impl<T> typenum::type_operators::Same for bpfman_api::v1::list_response::ListResult
+pub type bpfman_api::v1::list_response::ListResult::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::list_response::ListResult where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::list_response::ListResult::vzip(self) -> V
+pub struct bpfman_api::v1::AttachInfo
+pub bpfman_api::v1::AttachInfo::info: core::option::Option<bpfman_api::v1::attach_info::Info>
+impl core::clone::Clone for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::clone(&self) -> bpfman_api::v1::AttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::eq(&self, other: &bpfman_api::v1::AttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::AttachInfo
+impl prost::message::Message for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::AttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::AttachInfo
+impl core::marker::Send for bpfman_api::v1::AttachInfo
+impl core::marker::Sync for bpfman_api::v1::AttachInfo
+impl core::marker::Unpin for bpfman_api::v1::AttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::AttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::AttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::AttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::AttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::AttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::AttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::AttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::AttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::AttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::AttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::AttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::AttachInfo::Owned = T
+pub fn bpfman_api::v1::AttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::AttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::AttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::AttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::AttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::AttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::AttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::AttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::AttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::AttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::AttachInfo
+pub type bpfman_api::v1::AttachInfo::Init = T
+pub const bpfman_api::v1::AttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::AttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::AttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::AttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::AttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::AttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::AttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::AttachInfo
+pub fn bpfman_api::v1::AttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::AttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::AttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::AttachInfo
+pub type bpfman_api::v1::AttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::AttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::AttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::BytecodeImage
+pub bpfman_api::v1::BytecodeImage::image_pull_policy: i32
+pub bpfman_api::v1::BytecodeImage::password: core::option::Option<alloc::string::String>
+pub bpfman_api::v1::BytecodeImage::url: alloc::string::String
+pub bpfman_api::v1::BytecodeImage::username: core::option::Option<alloc::string::String>
+impl bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::password(&self) -> &str
+pub fn bpfman_api::v1::BytecodeImage::username(&self) -> &str
+impl core::clone::Clone for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::clone(&self) -> bpfman_api::v1::BytecodeImage
+impl core::cmp::PartialEq for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::eq(&self, other: &bpfman_api::v1::BytecodeImage) -> bool
+impl core::convert::From<bpfman_api::v1::BytecodeImage> for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::from(value: bpfman_api::v1::BytecodeImage) -> Self
+impl core::default::Default for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::BytecodeImage
+impl prost::message::Message for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::clear(&mut self)
+pub fn bpfman_api::v1::BytecodeImage::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::BytecodeImage
+impl core::marker::Send for bpfman_api::v1::BytecodeImage
+impl core::marker::Sync for bpfman_api::v1::BytecodeImage
+impl core::marker::Unpin for bpfman_api::v1::BytecodeImage
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::BytecodeImage
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::BytecodeImage
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::BytecodeImage where U: core::convert::From<T>
+pub fn bpfman_api::v1::BytecodeImage::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::BytecodeImage where U: core::convert::Into<T>
+pub type bpfman_api::v1::BytecodeImage::Error = core::convert::Infallible
+pub fn bpfman_api::v1::BytecodeImage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::BytecodeImage where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::BytecodeImage::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::BytecodeImage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::BytecodeImage where T: core::clone::Clone
+pub type bpfman_api::v1::BytecodeImage::Owned = T
+pub fn bpfman_api::v1::BytecodeImage::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::BytecodeImage::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::BytecodeImage where T: core::clone::Clone
+pub fn bpfman_api::v1::BytecodeImage::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::BytecodeImage where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::BytecodeImage::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::BytecodeImage where T: core::marker::Sized
+pub fn bpfman_api::v1::BytecodeImage::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::BytecodeImage where T: core::marker::Sized
+pub fn bpfman_api::v1::BytecodeImage::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::BytecodeImage
+pub type bpfman_api::v1::BytecodeImage::Init = T
+pub const bpfman_api::v1::BytecodeImage::ALIGN: usize
+pub unsafe fn bpfman_api::v1::BytecodeImage::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::BytecodeImage::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::BytecodeImage::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::BytecodeImage::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::BytecodeImage where T: core::clone::Clone
+pub fn bpfman_api::v1::BytecodeImage::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::BytecodeImage
+pub fn bpfman_api::v1::BytecodeImage::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::BytecodeImage
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::BytecodeImage
+impl<T> typenum::type_operators::Same for bpfman_api::v1::BytecodeImage
+pub type bpfman_api::v1::BytecodeImage::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::BytecodeImage where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::BytecodeImage::vzip(self) -> V
+pub struct bpfman_api::v1::BytecodeLocation
+pub bpfman_api::v1::BytecodeLocation::location: core::option::Option<bpfman_api::v1::bytecode_location::Location>
+impl core::clone::Clone for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::clone(&self) -> bpfman_api::v1::BytecodeLocation
+impl core::cmp::PartialEq for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::eq(&self, other: &bpfman_api::v1::BytecodeLocation) -> bool
+impl core::default::Default for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::BytecodeLocation
+impl prost::message::Message for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::clear(&mut self)
+pub fn bpfman_api::v1::BytecodeLocation::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::BytecodeLocation
+impl core::marker::Send for bpfman_api::v1::BytecodeLocation
+impl core::marker::Sync for bpfman_api::v1::BytecodeLocation
+impl core::marker::Unpin for bpfman_api::v1::BytecodeLocation
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::BytecodeLocation
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::BytecodeLocation
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::BytecodeLocation where U: core::convert::From<T>
+pub fn bpfman_api::v1::BytecodeLocation::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::BytecodeLocation where U: core::convert::Into<T>
+pub type bpfman_api::v1::BytecodeLocation::Error = core::convert::Infallible
+pub fn bpfman_api::v1::BytecodeLocation::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::BytecodeLocation where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::BytecodeLocation::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::BytecodeLocation::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::BytecodeLocation where T: core::clone::Clone
+pub type bpfman_api::v1::BytecodeLocation::Owned = T
+pub fn bpfman_api::v1::BytecodeLocation::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::BytecodeLocation::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::BytecodeLocation where T: core::clone::Clone
+pub fn bpfman_api::v1::BytecodeLocation::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::BytecodeLocation where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::BytecodeLocation::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::BytecodeLocation where T: core::marker::Sized
+pub fn bpfman_api::v1::BytecodeLocation::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::BytecodeLocation where T: core::marker::Sized
+pub fn bpfman_api::v1::BytecodeLocation::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::BytecodeLocation
+pub type bpfman_api::v1::BytecodeLocation::Init = T
+pub const bpfman_api::v1::BytecodeLocation::ALIGN: usize
+pub unsafe fn bpfman_api::v1::BytecodeLocation::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::BytecodeLocation::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::BytecodeLocation::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::BytecodeLocation::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::BytecodeLocation where T: core::clone::Clone
+pub fn bpfman_api::v1::BytecodeLocation::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::BytecodeLocation
+pub fn bpfman_api::v1::BytecodeLocation::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::BytecodeLocation
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::BytecodeLocation
+impl<T> typenum::type_operators::Same for bpfman_api::v1::BytecodeLocation
+pub type bpfman_api::v1::BytecodeLocation::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::BytecodeLocation where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::BytecodeLocation::vzip(self) -> V
+pub struct bpfman_api::v1::FentryAttachInfo
+pub bpfman_api::v1::FentryAttachInfo::fn_name: alloc::string::String
+impl core::clone::Clone for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::clone(&self) -> bpfman_api::v1::FentryAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::eq(&self, other: &bpfman_api::v1::FentryAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::FentryAttachInfo
+impl prost::message::Message for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::FentryAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::FentryAttachInfo
+impl core::marker::Send for bpfman_api::v1::FentryAttachInfo
+impl core::marker::Sync for bpfman_api::v1::FentryAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::FentryAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::FentryAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::FentryAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::FentryAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::FentryAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::FentryAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::FentryAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::FentryAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::FentryAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::FentryAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::FentryAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::FentryAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::FentryAttachInfo::Owned = T
+pub fn bpfman_api::v1::FentryAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::FentryAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::FentryAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::FentryAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::FentryAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::FentryAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::FentryAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::FentryAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::FentryAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::FentryAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::FentryAttachInfo
+pub type bpfman_api::v1::FentryAttachInfo::Init = T
+pub const bpfman_api::v1::FentryAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::FentryAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::FentryAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::FentryAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::FentryAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::FentryAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::FentryAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::FentryAttachInfo
+pub fn bpfman_api::v1::FentryAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::FentryAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::FentryAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::FentryAttachInfo
+pub type bpfman_api::v1::FentryAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::FentryAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::FentryAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::FexitAttachInfo
+pub bpfman_api::v1::FexitAttachInfo::fn_name: alloc::string::String
+impl core::clone::Clone for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::clone(&self) -> bpfman_api::v1::FexitAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::eq(&self, other: &bpfman_api::v1::FexitAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::FexitAttachInfo
+impl prost::message::Message for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::FexitAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::FexitAttachInfo
+impl core::marker::Send for bpfman_api::v1::FexitAttachInfo
+impl core::marker::Sync for bpfman_api::v1::FexitAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::FexitAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::FexitAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::FexitAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::FexitAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::FexitAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::FexitAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::FexitAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::FexitAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::FexitAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::FexitAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::FexitAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::FexitAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::FexitAttachInfo::Owned = T
+pub fn bpfman_api::v1::FexitAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::FexitAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::FexitAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::FexitAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::FexitAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::FexitAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::FexitAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::FexitAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::FexitAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::FexitAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::FexitAttachInfo
+pub type bpfman_api::v1::FexitAttachInfo::Init = T
+pub const bpfman_api::v1::FexitAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::FexitAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::FexitAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::FexitAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::FexitAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::FexitAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::FexitAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::FexitAttachInfo
+pub fn bpfman_api::v1::FexitAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::FexitAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::FexitAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::FexitAttachInfo
+pub type bpfman_api::v1::FexitAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::FexitAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::FexitAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::GetRequest
+pub bpfman_api::v1::GetRequest::id: u32
+impl core::clone::Clone for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::clone(&self) -> bpfman_api::v1::GetRequest
+impl core::cmp::PartialEq for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::eq(&self, other: &bpfman_api::v1::GetRequest) -> bool
+impl core::default::Default for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::GetRequest
+impl prost::message::Message for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::clear(&mut self)
+pub fn bpfman_api::v1::GetRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::GetRequest
+impl core::marker::Send for bpfman_api::v1::GetRequest
+impl core::marker::Sync for bpfman_api::v1::GetRequest
+impl core::marker::Unpin for bpfman_api::v1::GetRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::GetRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::GetRequest
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::GetRequest where U: core::convert::From<T>
+pub fn bpfman_api::v1::GetRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::GetRequest where U: core::convert::Into<T>
+pub type bpfman_api::v1::GetRequest::Error = core::convert::Infallible
+pub fn bpfman_api::v1::GetRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::GetRequest where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::GetRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::GetRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::GetRequest where T: core::clone::Clone
+pub type bpfman_api::v1::GetRequest::Owned = T
+pub fn bpfman_api::v1::GetRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::GetRequest::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::GetRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::GetRequest::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::GetRequest where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::GetRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::GetRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::GetRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::GetRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::GetRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::GetRequest
+pub type bpfman_api::v1::GetRequest::Init = T
+pub const bpfman_api::v1::GetRequest::ALIGN: usize
+pub unsafe fn bpfman_api::v1::GetRequest::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::GetRequest::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::GetRequest::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::GetRequest::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::GetRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::GetRequest::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::GetRequest
+pub fn bpfman_api::v1::GetRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::GetRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::GetRequest
+impl<T> typenum::type_operators::Same for bpfman_api::v1::GetRequest
+pub type bpfman_api::v1::GetRequest::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::GetRequest where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::GetRequest::vzip(self) -> V
+pub struct bpfman_api::v1::GetResponse
+pub bpfman_api::v1::GetResponse::info: core::option::Option<bpfman_api::v1::ProgramInfo>
+pub bpfman_api::v1::GetResponse::kernel_info: core::option::Option<bpfman_api::v1::KernelProgramInfo>
+impl core::clone::Clone for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::clone(&self) -> bpfman_api::v1::GetResponse
+impl core::cmp::PartialEq for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::eq(&self, other: &bpfman_api::v1::GetResponse) -> bool
+impl core::default::Default for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::GetResponse
+impl prost::message::Message for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::clear(&mut self)
+pub fn bpfman_api::v1::GetResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::GetResponse
+impl core::marker::Send for bpfman_api::v1::GetResponse
+impl core::marker::Sync for bpfman_api::v1::GetResponse
+impl core::marker::Unpin for bpfman_api::v1::GetResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::GetResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::GetResponse
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::GetResponse where U: core::convert::From<T>
+pub fn bpfman_api::v1::GetResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::GetResponse where U: core::convert::Into<T>
+pub type bpfman_api::v1::GetResponse::Error = core::convert::Infallible
+pub fn bpfman_api::v1::GetResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::GetResponse where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::GetResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::GetResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::GetResponse where T: core::clone::Clone
+pub type bpfman_api::v1::GetResponse::Owned = T
+pub fn bpfman_api::v1::GetResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::GetResponse::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::GetResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::GetResponse::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::GetResponse where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::GetResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::GetResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::GetResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::GetResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::GetResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::GetResponse
+pub type bpfman_api::v1::GetResponse::Init = T
+pub const bpfman_api::v1::GetResponse::ALIGN: usize
+pub unsafe fn bpfman_api::v1::GetResponse::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::GetResponse::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::GetResponse::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::GetResponse::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::GetResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::GetResponse::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::GetResponse
+pub fn bpfman_api::v1::GetResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::GetResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::GetResponse
+impl<T> typenum::type_operators::Same for bpfman_api::v1::GetResponse
+pub type bpfman_api::v1::GetResponse::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::GetResponse where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::GetResponse::vzip(self) -> V
+pub struct bpfman_api::v1::KernelProgramInfo
+pub bpfman_api::v1::KernelProgramInfo::btf_id: u32
+pub bpfman_api::v1::KernelProgramInfo::bytes_jited: u32
+pub bpfman_api::v1::KernelProgramInfo::bytes_memlock: u32
+pub bpfman_api::v1::KernelProgramInfo::bytes_xlated: u32
+pub bpfman_api::v1::KernelProgramInfo::gpl_compatible: bool
+pub bpfman_api::v1::KernelProgramInfo::id: u32
+pub bpfman_api::v1::KernelProgramInfo::jited: bool
+pub bpfman_api::v1::KernelProgramInfo::loaded_at: alloc::string::String
+pub bpfman_api::v1::KernelProgramInfo::map_ids: alloc::vec::Vec<u32>
+pub bpfman_api::v1::KernelProgramInfo::name: alloc::string::String
+pub bpfman_api::v1::KernelProgramInfo::program_type: u32
+pub bpfman_api::v1::KernelProgramInfo::tag: alloc::string::String
+pub bpfman_api::v1::KernelProgramInfo::verified_insns: u32
+impl core::clone::Clone for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::clone(&self) -> bpfman_api::v1::KernelProgramInfo
+impl core::cmp::PartialEq for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::eq(&self, other: &bpfman_api::v1::KernelProgramInfo) -> bool
+impl core::convert::TryFrom<&bpfman::types::Program> for bpfman_api::v1::KernelProgramInfo
+pub type bpfman_api::v1::KernelProgramInfo::Error = bpfman::errors::BpfmanError
+pub fn bpfman_api::v1::KernelProgramInfo::try_from(program: &bpfman::types::Program) -> core::result::Result<Self, Self::Error>
+impl core::default::Default for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::KernelProgramInfo
+impl prost::message::Message for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::clear(&mut self)
+pub fn bpfman_api::v1::KernelProgramInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::KernelProgramInfo
+impl core::marker::Send for bpfman_api::v1::KernelProgramInfo
+impl core::marker::Sync for bpfman_api::v1::KernelProgramInfo
+impl core::marker::Unpin for bpfman_api::v1::KernelProgramInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::KernelProgramInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::KernelProgramInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::KernelProgramInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::KernelProgramInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::KernelProgramInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::KernelProgramInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::KernelProgramInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::KernelProgramInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::KernelProgramInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::KernelProgramInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::KernelProgramInfo where T: core::clone::Clone
+pub type bpfman_api::v1::KernelProgramInfo::Owned = T
+pub fn bpfman_api::v1::KernelProgramInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::KernelProgramInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::KernelProgramInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::KernelProgramInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::KernelProgramInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::KernelProgramInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::KernelProgramInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::KernelProgramInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::KernelProgramInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::KernelProgramInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::KernelProgramInfo
+pub type bpfman_api::v1::KernelProgramInfo::Init = T
+pub const bpfman_api::v1::KernelProgramInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::KernelProgramInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::KernelProgramInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::KernelProgramInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::KernelProgramInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::KernelProgramInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::KernelProgramInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::KernelProgramInfo
+pub fn bpfman_api::v1::KernelProgramInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::KernelProgramInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::KernelProgramInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::KernelProgramInfo
+pub type bpfman_api::v1::KernelProgramInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::KernelProgramInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::KernelProgramInfo::vzip(self) -> V
+pub struct bpfman_api::v1::KprobeAttachInfo
+pub bpfman_api::v1::KprobeAttachInfo::container_pid: core::option::Option<i32>
+pub bpfman_api::v1::KprobeAttachInfo::fn_name: alloc::string::String
+pub bpfman_api::v1::KprobeAttachInfo::offset: u64
+pub bpfman_api::v1::KprobeAttachInfo::retprobe: bool
+impl bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::container_pid(&self) -> i32
+impl core::clone::Clone for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::clone(&self) -> bpfman_api::v1::KprobeAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::eq(&self, other: &bpfman_api::v1::KprobeAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::KprobeAttachInfo
+impl prost::message::Message for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::KprobeAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::KprobeAttachInfo
+impl core::marker::Send for bpfman_api::v1::KprobeAttachInfo
+impl core::marker::Sync for bpfman_api::v1::KprobeAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::KprobeAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::KprobeAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::KprobeAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::KprobeAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::KprobeAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::KprobeAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::KprobeAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::KprobeAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::KprobeAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::KprobeAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::KprobeAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::KprobeAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::KprobeAttachInfo::Owned = T
+pub fn bpfman_api::v1::KprobeAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::KprobeAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::KprobeAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::KprobeAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::KprobeAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::KprobeAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::KprobeAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::KprobeAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::KprobeAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::KprobeAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::KprobeAttachInfo
+pub type bpfman_api::v1::KprobeAttachInfo::Init = T
+pub const bpfman_api::v1::KprobeAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::KprobeAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::KprobeAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::KprobeAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::KprobeAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::KprobeAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::KprobeAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::KprobeAttachInfo
+pub fn bpfman_api::v1::KprobeAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::KprobeAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::KprobeAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::KprobeAttachInfo
+pub type bpfman_api::v1::KprobeAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::KprobeAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::KprobeAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::ListRequest
+pub bpfman_api::v1::ListRequest::bpfman_programs_only: core::option::Option<bool>
+pub bpfman_api::v1::ListRequest::match_metadata: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_api::v1::ListRequest::program_type: core::option::Option<u32>
+impl bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::bpfman_programs_only(&self) -> bool
+pub fn bpfman_api::v1::ListRequest::program_type(&self) -> u32
+impl core::clone::Clone for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::clone(&self) -> bpfman_api::v1::ListRequest
+impl core::cmp::PartialEq for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::eq(&self, other: &bpfman_api::v1::ListRequest) -> bool
+impl core::default::Default for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::ListRequest
+impl prost::message::Message for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::clear(&mut self)
+pub fn bpfman_api::v1::ListRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::ListRequest
+impl core::marker::Send for bpfman_api::v1::ListRequest
+impl core::marker::Sync for bpfman_api::v1::ListRequest
+impl core::marker::Unpin for bpfman_api::v1::ListRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::ListRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::ListRequest
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::ListRequest where U: core::convert::From<T>
+pub fn bpfman_api::v1::ListRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::ListRequest where U: core::convert::Into<T>
+pub type bpfman_api::v1::ListRequest::Error = core::convert::Infallible
+pub fn bpfman_api::v1::ListRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::ListRequest where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::ListRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::ListRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::ListRequest where T: core::clone::Clone
+pub type bpfman_api::v1::ListRequest::Owned = T
+pub fn bpfman_api::v1::ListRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::ListRequest::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::ListRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::ListRequest::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::ListRequest where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::ListRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::ListRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::ListRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::ListRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::ListRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::ListRequest
+pub type bpfman_api::v1::ListRequest::Init = T
+pub const bpfman_api::v1::ListRequest::ALIGN: usize
+pub unsafe fn bpfman_api::v1::ListRequest::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::ListRequest::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::ListRequest::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::ListRequest::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::ListRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::ListRequest::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::ListRequest
+pub fn bpfman_api::v1::ListRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::ListRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::ListRequest
+impl<T> typenum::type_operators::Same for bpfman_api::v1::ListRequest
+pub type bpfman_api::v1::ListRequest::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::ListRequest where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::ListRequest::vzip(self) -> V
+pub struct bpfman_api::v1::ListResponse
+pub bpfman_api::v1::ListResponse::results: alloc::vec::Vec<bpfman_api::v1::list_response::ListResult>
+impl core::clone::Clone for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::clone(&self) -> bpfman_api::v1::ListResponse
+impl core::cmp::PartialEq for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::eq(&self, other: &bpfman_api::v1::ListResponse) -> bool
+impl core::default::Default for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::ListResponse
+impl prost::message::Message for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::clear(&mut self)
+pub fn bpfman_api::v1::ListResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::ListResponse
+impl core::marker::Send for bpfman_api::v1::ListResponse
+impl core::marker::Sync for bpfman_api::v1::ListResponse
+impl core::marker::Unpin for bpfman_api::v1::ListResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::ListResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::ListResponse
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::ListResponse where U: core::convert::From<T>
+pub fn bpfman_api::v1::ListResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::ListResponse where U: core::convert::Into<T>
+pub type bpfman_api::v1::ListResponse::Error = core::convert::Infallible
+pub fn bpfman_api::v1::ListResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::ListResponse where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::ListResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::ListResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::ListResponse where T: core::clone::Clone
+pub type bpfman_api::v1::ListResponse::Owned = T
+pub fn bpfman_api::v1::ListResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::ListResponse::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::ListResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::ListResponse::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::ListResponse where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::ListResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::ListResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::ListResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::ListResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::ListResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::ListResponse
+pub type bpfman_api::v1::ListResponse::Init = T
+pub const bpfman_api::v1::ListResponse::ALIGN: usize
+pub unsafe fn bpfman_api::v1::ListResponse::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::ListResponse::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::ListResponse::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::ListResponse::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::ListResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::ListResponse::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::ListResponse
+pub fn bpfman_api::v1::ListResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::ListResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::ListResponse
+impl<T> typenum::type_operators::Same for bpfman_api::v1::ListResponse
+pub type bpfman_api::v1::ListResponse::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::ListResponse where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::ListResponse::vzip(self) -> V
+pub struct bpfman_api::v1::LoadRequest
+pub bpfman_api::v1::LoadRequest::attach: core::option::Option<bpfman_api::v1::AttachInfo>
+pub bpfman_api::v1::LoadRequest::bytecode: core::option::Option<bpfman_api::v1::BytecodeLocation>
+pub bpfman_api::v1::LoadRequest::global_data: std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u8>>
+pub bpfman_api::v1::LoadRequest::map_owner_id: core::option::Option<u32>
+pub bpfman_api::v1::LoadRequest::metadata: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_api::v1::LoadRequest::name: alloc::string::String
+pub bpfman_api::v1::LoadRequest::program_type: u32
+pub bpfman_api::v1::LoadRequest::uuid: core::option::Option<alloc::string::String>
+impl bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::map_owner_id(&self) -> u32
+pub fn bpfman_api::v1::LoadRequest::uuid(&self) -> &str
+impl core::clone::Clone for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::clone(&self) -> bpfman_api::v1::LoadRequest
+impl core::cmp::PartialEq for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::eq(&self, other: &bpfman_api::v1::LoadRequest) -> bool
+impl core::default::Default for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::LoadRequest
+impl prost::message::Message for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::clear(&mut self)
+pub fn bpfman_api::v1::LoadRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::LoadRequest
+impl core::marker::Send for bpfman_api::v1::LoadRequest
+impl core::marker::Sync for bpfman_api::v1::LoadRequest
+impl core::marker::Unpin for bpfman_api::v1::LoadRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::LoadRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::LoadRequest
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::LoadRequest where U: core::convert::From<T>
+pub fn bpfman_api::v1::LoadRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::LoadRequest where U: core::convert::Into<T>
+pub type bpfman_api::v1::LoadRequest::Error = core::convert::Infallible
+pub fn bpfman_api::v1::LoadRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::LoadRequest where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::LoadRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::LoadRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::LoadRequest where T: core::clone::Clone
+pub type bpfman_api::v1::LoadRequest::Owned = T
+pub fn bpfman_api::v1::LoadRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::LoadRequest::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::LoadRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::LoadRequest::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::LoadRequest where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::LoadRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::LoadRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::LoadRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::LoadRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::LoadRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::LoadRequest
+pub type bpfman_api::v1::LoadRequest::Init = T
+pub const bpfman_api::v1::LoadRequest::ALIGN: usize
+pub unsafe fn bpfman_api::v1::LoadRequest::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::LoadRequest::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::LoadRequest::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::LoadRequest::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::LoadRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::LoadRequest::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::LoadRequest
+pub fn bpfman_api::v1::LoadRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::LoadRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::LoadRequest
+impl<T> typenum::type_operators::Same for bpfman_api::v1::LoadRequest
+pub type bpfman_api::v1::LoadRequest::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::LoadRequest where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::LoadRequest::vzip(self) -> V
+pub struct bpfman_api::v1::LoadResponse
+pub bpfman_api::v1::LoadResponse::info: core::option::Option<bpfman_api::v1::ProgramInfo>
+pub bpfman_api::v1::LoadResponse::kernel_info: core::option::Option<bpfman_api::v1::KernelProgramInfo>
+impl core::clone::Clone for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::clone(&self) -> bpfman_api::v1::LoadResponse
+impl core::cmp::PartialEq for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::eq(&self, other: &bpfman_api::v1::LoadResponse) -> bool
+impl core::default::Default for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::LoadResponse
+impl prost::message::Message for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::clear(&mut self)
+pub fn bpfman_api::v1::LoadResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::LoadResponse
+impl core::marker::Send for bpfman_api::v1::LoadResponse
+impl core::marker::Sync for bpfman_api::v1::LoadResponse
+impl core::marker::Unpin for bpfman_api::v1::LoadResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::LoadResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::LoadResponse
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::LoadResponse where U: core::convert::From<T>
+pub fn bpfman_api::v1::LoadResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::LoadResponse where U: core::convert::Into<T>
+pub type bpfman_api::v1::LoadResponse::Error = core::convert::Infallible
+pub fn bpfman_api::v1::LoadResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::LoadResponse where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::LoadResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::LoadResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::LoadResponse where T: core::clone::Clone
+pub type bpfman_api::v1::LoadResponse::Owned = T
+pub fn bpfman_api::v1::LoadResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::LoadResponse::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::LoadResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::LoadResponse::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::LoadResponse where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::LoadResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::LoadResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::LoadResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::LoadResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::LoadResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::LoadResponse
+pub type bpfman_api::v1::LoadResponse::Init = T
+pub const bpfman_api::v1::LoadResponse::ALIGN: usize
+pub unsafe fn bpfman_api::v1::LoadResponse::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::LoadResponse::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::LoadResponse::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::LoadResponse::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::LoadResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::LoadResponse::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::LoadResponse
+pub fn bpfman_api::v1::LoadResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::LoadResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::LoadResponse
+impl<T> typenum::type_operators::Same for bpfman_api::v1::LoadResponse
+pub type bpfman_api::v1::LoadResponse::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::LoadResponse where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::LoadResponse::vzip(self) -> V
+pub struct bpfman_api::v1::ProgramInfo
+pub bpfman_api::v1::ProgramInfo::attach: core::option::Option<bpfman_api::v1::AttachInfo>
+pub bpfman_api::v1::ProgramInfo::bytecode: core::option::Option<bpfman_api::v1::BytecodeLocation>
+pub bpfman_api::v1::ProgramInfo::global_data: std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u8>>
+pub bpfman_api::v1::ProgramInfo::map_owner_id: core::option::Option<u32>
+pub bpfman_api::v1::ProgramInfo::map_pin_path: alloc::string::String
+pub bpfman_api::v1::ProgramInfo::map_used_by: alloc::vec::Vec<alloc::string::String>
+pub bpfman_api::v1::ProgramInfo::metadata: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_api::v1::ProgramInfo::name: alloc::string::String
+impl bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::map_owner_id(&self) -> u32
+impl core::clone::Clone for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::clone(&self) -> bpfman_api::v1::ProgramInfo
+impl core::cmp::PartialEq for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::eq(&self, other: &bpfman_api::v1::ProgramInfo) -> bool
+impl core::convert::TryFrom<&bpfman::types::Program> for bpfman_api::v1::ProgramInfo
+pub type bpfman_api::v1::ProgramInfo::Error = bpfman::errors::BpfmanError
+pub fn bpfman_api::v1::ProgramInfo::try_from(program: &bpfman::types::Program) -> core::result::Result<Self, Self::Error>
+impl core::default::Default for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::ProgramInfo
+impl prost::message::Message for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::clear(&mut self)
+pub fn bpfman_api::v1::ProgramInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::ProgramInfo
+impl core::marker::Send for bpfman_api::v1::ProgramInfo
+impl core::marker::Sync for bpfman_api::v1::ProgramInfo
+impl core::marker::Unpin for bpfman_api::v1::ProgramInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::ProgramInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::ProgramInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::ProgramInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::ProgramInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::ProgramInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::ProgramInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::ProgramInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::ProgramInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::ProgramInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::ProgramInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::ProgramInfo where T: core::clone::Clone
+pub type bpfman_api::v1::ProgramInfo::Owned = T
+pub fn bpfman_api::v1::ProgramInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::ProgramInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::ProgramInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::ProgramInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::ProgramInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::ProgramInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::ProgramInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::ProgramInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::ProgramInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::ProgramInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::ProgramInfo
+pub type bpfman_api::v1::ProgramInfo::Init = T
+pub const bpfman_api::v1::ProgramInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::ProgramInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::ProgramInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::ProgramInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::ProgramInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::ProgramInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::ProgramInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::ProgramInfo
+pub fn bpfman_api::v1::ProgramInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::ProgramInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::ProgramInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::ProgramInfo
+pub type bpfman_api::v1::ProgramInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::ProgramInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::ProgramInfo::vzip(self) -> V
+pub struct bpfman_api::v1::PullBytecodeRequest
+pub bpfman_api::v1::PullBytecodeRequest::image: core::option::Option<bpfman_api::v1::BytecodeImage>
+impl core::clone::Clone for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::clone(&self) -> bpfman_api::v1::PullBytecodeRequest
+impl core::cmp::PartialEq for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::eq(&self, other: &bpfman_api::v1::PullBytecodeRequest) -> bool
+impl core::default::Default for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::PullBytecodeRequest
+impl prost::message::Message for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::clear(&mut self)
+pub fn bpfman_api::v1::PullBytecodeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::PullBytecodeRequest
+impl core::marker::Send for bpfman_api::v1::PullBytecodeRequest
+impl core::marker::Sync for bpfman_api::v1::PullBytecodeRequest
+impl core::marker::Unpin for bpfman_api::v1::PullBytecodeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::PullBytecodeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::PullBytecodeRequest
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::PullBytecodeRequest where U: core::convert::From<T>
+pub fn bpfman_api::v1::PullBytecodeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::PullBytecodeRequest where U: core::convert::Into<T>
+pub type bpfman_api::v1::PullBytecodeRequest::Error = core::convert::Infallible
+pub fn bpfman_api::v1::PullBytecodeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::PullBytecodeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::PullBytecodeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::PullBytecodeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::PullBytecodeRequest where T: core::clone::Clone
+pub type bpfman_api::v1::PullBytecodeRequest::Owned = T
+pub fn bpfman_api::v1::PullBytecodeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::PullBytecodeRequest::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::PullBytecodeRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::PullBytecodeRequest::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::PullBytecodeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::PullBytecodeRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::PullBytecodeRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::PullBytecodeRequest
+pub type bpfman_api::v1::PullBytecodeRequest::Init = T
+pub const bpfman_api::v1::PullBytecodeRequest::ALIGN: usize
+pub unsafe fn bpfman_api::v1::PullBytecodeRequest::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::PullBytecodeRequest::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::PullBytecodeRequest::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::PullBytecodeRequest::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::PullBytecodeRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::PullBytecodeRequest::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::PullBytecodeRequest
+pub fn bpfman_api::v1::PullBytecodeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::PullBytecodeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::PullBytecodeRequest
+impl<T> typenum::type_operators::Same for bpfman_api::v1::PullBytecodeRequest
+pub type bpfman_api::v1::PullBytecodeRequest::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::PullBytecodeRequest where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::PullBytecodeRequest::vzip(self) -> V
+pub struct bpfman_api::v1::PullBytecodeResponse
+impl core::clone::Clone for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::clone(&self) -> bpfman_api::v1::PullBytecodeResponse
+impl core::cmp::PartialEq for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::eq(&self, other: &bpfman_api::v1::PullBytecodeResponse) -> bool
+impl core::default::Default for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::PullBytecodeResponse
+impl prost::message::Message for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::clear(&mut self)
+pub fn bpfman_api::v1::PullBytecodeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::PullBytecodeResponse
+impl core::marker::Send for bpfman_api::v1::PullBytecodeResponse
+impl core::marker::Sync for bpfman_api::v1::PullBytecodeResponse
+impl core::marker::Unpin for bpfman_api::v1::PullBytecodeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::PullBytecodeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::PullBytecodeResponse
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::PullBytecodeResponse where U: core::convert::From<T>
+pub fn bpfman_api::v1::PullBytecodeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::PullBytecodeResponse where U: core::convert::Into<T>
+pub type bpfman_api::v1::PullBytecodeResponse::Error = core::convert::Infallible
+pub fn bpfman_api::v1::PullBytecodeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::PullBytecodeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::PullBytecodeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::PullBytecodeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::PullBytecodeResponse where T: core::clone::Clone
+pub type bpfman_api::v1::PullBytecodeResponse::Owned = T
+pub fn bpfman_api::v1::PullBytecodeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::PullBytecodeResponse::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::PullBytecodeResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::PullBytecodeResponse::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::PullBytecodeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::PullBytecodeResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::PullBytecodeResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::PullBytecodeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::PullBytecodeResponse
+pub type bpfman_api::v1::PullBytecodeResponse::Init = T
+pub const bpfman_api::v1::PullBytecodeResponse::ALIGN: usize
+pub unsafe fn bpfman_api::v1::PullBytecodeResponse::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::PullBytecodeResponse::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::PullBytecodeResponse::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::PullBytecodeResponse::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::PullBytecodeResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::PullBytecodeResponse::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::PullBytecodeResponse
+pub fn bpfman_api::v1::PullBytecodeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::PullBytecodeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::PullBytecodeResponse
+impl<T> typenum::type_operators::Same for bpfman_api::v1::PullBytecodeResponse
+pub type bpfman_api::v1::PullBytecodeResponse::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::PullBytecodeResponse where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::PullBytecodeResponse::vzip(self) -> V
+pub struct bpfman_api::v1::TcAttachInfo
+pub bpfman_api::v1::TcAttachInfo::direction: alloc::string::String
+pub bpfman_api::v1::TcAttachInfo::iface: alloc::string::String
+pub bpfman_api::v1::TcAttachInfo::position: i32
+pub bpfman_api::v1::TcAttachInfo::priority: i32
+pub bpfman_api::v1::TcAttachInfo::proceed_on: alloc::vec::Vec<i32>
+impl core::clone::Clone for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::clone(&self) -> bpfman_api::v1::TcAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::eq(&self, other: &bpfman_api::v1::TcAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::TcAttachInfo
+impl prost::message::Message for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::TcAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::TcAttachInfo
+impl core::marker::Send for bpfman_api::v1::TcAttachInfo
+impl core::marker::Sync for bpfman_api::v1::TcAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::TcAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::TcAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::TcAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::TcAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::TcAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::TcAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::TcAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::TcAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::TcAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::TcAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::TcAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::TcAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::TcAttachInfo::Owned = T
+pub fn bpfman_api::v1::TcAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::TcAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::TcAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::TcAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::TcAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::TcAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::TcAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::TcAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::TcAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::TcAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::TcAttachInfo
+pub type bpfman_api::v1::TcAttachInfo::Init = T
+pub const bpfman_api::v1::TcAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::TcAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::TcAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::TcAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::TcAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::TcAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::TcAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::TcAttachInfo
+pub fn bpfman_api::v1::TcAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::TcAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::TcAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::TcAttachInfo
+pub type bpfman_api::v1::TcAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::TcAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::TcAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::TracepointAttachInfo
+pub bpfman_api::v1::TracepointAttachInfo::tracepoint: alloc::string::String
+impl core::clone::Clone for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::clone(&self) -> bpfman_api::v1::TracepointAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::eq(&self, other: &bpfman_api::v1::TracepointAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::TracepointAttachInfo
+impl prost::message::Message for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::TracepointAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::TracepointAttachInfo
+impl core::marker::Send for bpfman_api::v1::TracepointAttachInfo
+impl core::marker::Sync for bpfman_api::v1::TracepointAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::TracepointAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::TracepointAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::TracepointAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::TracepointAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::TracepointAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::TracepointAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::TracepointAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::TracepointAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::TracepointAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::TracepointAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::TracepointAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::TracepointAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::TracepointAttachInfo::Owned = T
+pub fn bpfman_api::v1::TracepointAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::TracepointAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::TracepointAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::TracepointAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::TracepointAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::TracepointAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::TracepointAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::TracepointAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::TracepointAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::TracepointAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::TracepointAttachInfo
+pub type bpfman_api::v1::TracepointAttachInfo::Init = T
+pub const bpfman_api::v1::TracepointAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::TracepointAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::TracepointAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::TracepointAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::TracepointAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::TracepointAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::TracepointAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::TracepointAttachInfo
+pub fn bpfman_api::v1::TracepointAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::TracepointAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::TracepointAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::TracepointAttachInfo
+pub type bpfman_api::v1::TracepointAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::TracepointAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::TracepointAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::UnloadRequest
+pub bpfman_api::v1::UnloadRequest::id: u32
+impl core::clone::Clone for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::clone(&self) -> bpfman_api::v1::UnloadRequest
+impl core::cmp::PartialEq for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::eq(&self, other: &bpfman_api::v1::UnloadRequest) -> bool
+impl core::default::Default for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::UnloadRequest
+impl prost::message::Message for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::clear(&mut self)
+pub fn bpfman_api::v1::UnloadRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::UnloadRequest
+impl core::marker::Send for bpfman_api::v1::UnloadRequest
+impl core::marker::Sync for bpfman_api::v1::UnloadRequest
+impl core::marker::Unpin for bpfman_api::v1::UnloadRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::UnloadRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::UnloadRequest
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::UnloadRequest where U: core::convert::From<T>
+pub fn bpfman_api::v1::UnloadRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::UnloadRequest where U: core::convert::Into<T>
+pub type bpfman_api::v1::UnloadRequest::Error = core::convert::Infallible
+pub fn bpfman_api::v1::UnloadRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::UnloadRequest where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::UnloadRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::UnloadRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::UnloadRequest where T: core::clone::Clone
+pub type bpfman_api::v1::UnloadRequest::Owned = T
+pub fn bpfman_api::v1::UnloadRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::UnloadRequest::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::UnloadRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::UnloadRequest::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::UnloadRequest where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::UnloadRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::UnloadRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::UnloadRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::UnloadRequest where T: core::marker::Sized
+pub fn bpfman_api::v1::UnloadRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::UnloadRequest
+pub type bpfman_api::v1::UnloadRequest::Init = T
+pub const bpfman_api::v1::UnloadRequest::ALIGN: usize
+pub unsafe fn bpfman_api::v1::UnloadRequest::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::UnloadRequest::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::UnloadRequest::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::UnloadRequest::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::UnloadRequest where T: core::clone::Clone
+pub fn bpfman_api::v1::UnloadRequest::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::UnloadRequest
+pub fn bpfman_api::v1::UnloadRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::UnloadRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::UnloadRequest
+impl<T> typenum::type_operators::Same for bpfman_api::v1::UnloadRequest
+pub type bpfman_api::v1::UnloadRequest::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::UnloadRequest where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::UnloadRequest::vzip(self) -> V
+pub struct bpfman_api::v1::UnloadResponse
+impl core::clone::Clone for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::clone(&self) -> bpfman_api::v1::UnloadResponse
+impl core::cmp::PartialEq for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::eq(&self, other: &bpfman_api::v1::UnloadResponse) -> bool
+impl core::default::Default for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::UnloadResponse
+impl prost::message::Message for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::clear(&mut self)
+pub fn bpfman_api::v1::UnloadResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::UnloadResponse
+impl core::marker::Send for bpfman_api::v1::UnloadResponse
+impl core::marker::Sync for bpfman_api::v1::UnloadResponse
+impl core::marker::Unpin for bpfman_api::v1::UnloadResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::UnloadResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::UnloadResponse
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::UnloadResponse where U: core::convert::From<T>
+pub fn bpfman_api::v1::UnloadResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::UnloadResponse where U: core::convert::Into<T>
+pub type bpfman_api::v1::UnloadResponse::Error = core::convert::Infallible
+pub fn bpfman_api::v1::UnloadResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::UnloadResponse where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::UnloadResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::UnloadResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::UnloadResponse where T: core::clone::Clone
+pub type bpfman_api::v1::UnloadResponse::Owned = T
+pub fn bpfman_api::v1::UnloadResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::UnloadResponse::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::UnloadResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::UnloadResponse::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::UnloadResponse where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::UnloadResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::UnloadResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::UnloadResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::UnloadResponse where T: core::marker::Sized
+pub fn bpfman_api::v1::UnloadResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::UnloadResponse
+pub type bpfman_api::v1::UnloadResponse::Init = T
+pub const bpfman_api::v1::UnloadResponse::ALIGN: usize
+pub unsafe fn bpfman_api::v1::UnloadResponse::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::UnloadResponse::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::UnloadResponse::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::UnloadResponse::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::UnloadResponse where T: core::clone::Clone
+pub fn bpfman_api::v1::UnloadResponse::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::UnloadResponse
+pub fn bpfman_api::v1::UnloadResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::UnloadResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::UnloadResponse
+impl<T> typenum::type_operators::Same for bpfman_api::v1::UnloadResponse
+pub type bpfman_api::v1::UnloadResponse::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::UnloadResponse where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::UnloadResponse::vzip(self) -> V
+pub struct bpfman_api::v1::UprobeAttachInfo
+pub bpfman_api::v1::UprobeAttachInfo::container_pid: core::option::Option<i32>
+pub bpfman_api::v1::UprobeAttachInfo::fn_name: core::option::Option<alloc::string::String>
+pub bpfman_api::v1::UprobeAttachInfo::offset: u64
+pub bpfman_api::v1::UprobeAttachInfo::pid: core::option::Option<i32>
+pub bpfman_api::v1::UprobeAttachInfo::retprobe: bool
+pub bpfman_api::v1::UprobeAttachInfo::target: alloc::string::String
+impl bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::container_pid(&self) -> i32
+pub fn bpfman_api::v1::UprobeAttachInfo::fn_name(&self) -> &str
+pub fn bpfman_api::v1::UprobeAttachInfo::pid(&self) -> i32
+impl core::clone::Clone for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::clone(&self) -> bpfman_api::v1::UprobeAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::eq(&self, other: &bpfman_api::v1::UprobeAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::UprobeAttachInfo
+impl prost::message::Message for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::UprobeAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::UprobeAttachInfo
+impl core::marker::Send for bpfman_api::v1::UprobeAttachInfo
+impl core::marker::Sync for bpfman_api::v1::UprobeAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::UprobeAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::UprobeAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::UprobeAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::UprobeAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::UprobeAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::UprobeAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::UprobeAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::UprobeAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::UprobeAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::UprobeAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::UprobeAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::UprobeAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::UprobeAttachInfo::Owned = T
+pub fn bpfman_api::v1::UprobeAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::UprobeAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::UprobeAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::UprobeAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::UprobeAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::UprobeAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::UprobeAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::UprobeAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::UprobeAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::UprobeAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::UprobeAttachInfo
+pub type bpfman_api::v1::UprobeAttachInfo::Init = T
+pub const bpfman_api::v1::UprobeAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::UprobeAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::UprobeAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::UprobeAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::UprobeAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::UprobeAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::UprobeAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::UprobeAttachInfo
+pub fn bpfman_api::v1::UprobeAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::UprobeAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::UprobeAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::UprobeAttachInfo
+pub type bpfman_api::v1::UprobeAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::UprobeAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::UprobeAttachInfo::vzip(self) -> V
+pub struct bpfman_api::v1::XdpAttachInfo
+pub bpfman_api::v1::XdpAttachInfo::iface: alloc::string::String
+pub bpfman_api::v1::XdpAttachInfo::position: i32
+pub bpfman_api::v1::XdpAttachInfo::priority: i32
+pub bpfman_api::v1::XdpAttachInfo::proceed_on: alloc::vec::Vec<i32>
+impl core::clone::Clone for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::clone(&self) -> bpfman_api::v1::XdpAttachInfo
+impl core::cmp::PartialEq for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::eq(&self, other: &bpfman_api::v1::XdpAttachInfo) -> bool
+impl core::default::Default for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::default() -> Self
+impl core::fmt::Debug for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_api::v1::XdpAttachInfo
+impl prost::message::Message for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::clear(&mut self)
+pub fn bpfman_api::v1::XdpAttachInfo::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_api::v1::XdpAttachInfo
+impl core::marker::Send for bpfman_api::v1::XdpAttachInfo
+impl core::marker::Sync for bpfman_api::v1::XdpAttachInfo
+impl core::marker::Unpin for bpfman_api::v1::XdpAttachInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_api::v1::XdpAttachInfo
+impl core::panic::unwind_safe::UnwindSafe for bpfman_api::v1::XdpAttachInfo
+impl<T, U> core::convert::Into<U> for bpfman_api::v1::XdpAttachInfo where U: core::convert::From<T>
+pub fn bpfman_api::v1::XdpAttachInfo::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_api::v1::XdpAttachInfo where U: core::convert::Into<T>
+pub type bpfman_api::v1::XdpAttachInfo::Error = core::convert::Infallible
+pub fn bpfman_api::v1::XdpAttachInfo::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_api::v1::XdpAttachInfo where U: core::convert::TryFrom<T>
+pub type bpfman_api::v1::XdpAttachInfo::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_api::v1::XdpAttachInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_api::v1::XdpAttachInfo where T: core::clone::Clone
+pub type bpfman_api::v1::XdpAttachInfo::Owned = T
+pub fn bpfman_api::v1::XdpAttachInfo::clone_into(&self, target: &mut T)
+pub fn bpfman_api::v1::XdpAttachInfo::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman_api::v1::XdpAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::XdpAttachInfo::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman_api::v1::XdpAttachInfo where T: 'static + core::marker::Sized
+pub fn bpfman_api::v1::XdpAttachInfo::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_api::v1::XdpAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::XdpAttachInfo::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_api::v1::XdpAttachInfo where T: core::marker::Sized
+pub fn bpfman_api::v1::XdpAttachInfo::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman_api::v1::XdpAttachInfo
+pub type bpfman_api::v1::XdpAttachInfo::Init = T
+pub const bpfman_api::v1::XdpAttachInfo::ALIGN: usize
+pub unsafe fn bpfman_api::v1::XdpAttachInfo::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman_api::v1::XdpAttachInfo::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman_api::v1::XdpAttachInfo::drop(ptr: usize)
+pub unsafe fn bpfman_api::v1::XdpAttachInfo::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman_api::v1::XdpAttachInfo where T: core::clone::Clone
+pub fn bpfman_api::v1::XdpAttachInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman_api::v1::XdpAttachInfo
+pub fn bpfman_api::v1::XdpAttachInfo::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_api::v1::XdpAttachInfo
+impl<T> tracing::instrument::WithSubscriber for bpfman_api::v1::XdpAttachInfo
+impl<T> typenum::type_operators::Same for bpfman_api::v1::XdpAttachInfo
+pub type bpfman_api::v1::XdpAttachInfo::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman_api::v1::XdpAttachInfo where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman_api::v1::XdpAttachInfo::vzip(self) -> V

--- a/xtask/public-api/bpfman-csi.txt
+++ b/xtask/public-api/bpfman-csi.txt
@@ -1,0 +1,5140 @@
+pub mod bpfman_csi
+pub mod bpfman_csi::v1
+pub mod bpfman_csi::v1::controller_client
+pub struct bpfman_csi::v1::controller_client::ControllerClient<T>
+impl<T> bpfman_csi::v1::controller_client::ControllerClient<T> where T: tonic::client::service::GrpcService<tonic::body::BoxBody>, <T as tonic::client::service::GrpcService>::Error: core::convert::Into<tonic::codegen::StdError>, <T as tonic::client::service::GrpcService>::ResponseBody: http_body::Body<Data = bytes::bytes::Bytes> + core::marker::Send + 'static, <<T as tonic::client::service::GrpcService>::ResponseBody as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_expand_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerExpandVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerExpandVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_get_capabilities(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerGetCapabilitiesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerGetCapabilitiesResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_get_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerGetVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerGetVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_modify_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerModifyVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerModifyVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_publish_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerPublishVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerPublishVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::controller_unpublish_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ControllerUnpublishVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerUnpublishVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::create_snapshot(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::CreateSnapshotRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateSnapshotResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::create_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::CreateVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::delete_snapshot(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::DeleteSnapshotRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteSnapshotResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::delete_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::DeleteVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::get_capacity(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::GetCapacityRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::GetCapacityResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::list_snapshots(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ListSnapshotsRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ListSnapshotsResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::list_volumes(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ListVolumesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ListVolumesResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_csi::v1::controller_client::ControllerClient<T>::validate_volume_capabilities(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ValidateVolumeCapabilitiesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ValidateVolumeCapabilitiesResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::with_interceptor<F>(inner: T, interceptor: F) -> bpfman_csi::v1::controller_client::ControllerClient<tonic::service::interceptor::InterceptedService<T, F>> where F: tonic::service::interceptor::Interceptor, <T as tonic::client::service::GrpcService>::ResponseBody: core::default::Default, T: tower_service::Service<http::request::Request<tonic::body::BoxBody>, Response = http::response::Response<<T as tonic::client::service::GrpcService<tonic::body::BoxBody>>::ResponseBody>>, <T as tower_service::Service<http::request::Request<tonic::body::BoxBody>>>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + core::marker::Sync
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::with_origin(inner: T, origin: http::uri::Uri) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bpfman_csi::v1::controller_client::ControllerClient<T>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::clone(&self) -> bpfman_csi::v1::controller_client::ControllerClient<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bpfman_csi::v1::controller_client::ControllerClient<T>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> !core::marker::Freeze for bpfman_csi::v1::controller_client::ControllerClient<T>
+impl<T> core::marker::Send for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_client::ControllerClient<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_client::ControllerClient<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_client::ControllerClient<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_client::ControllerClient<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_client::ControllerClient<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_client::ControllerClient<T>::Owned = T
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_client::ControllerClient<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_client::ControllerClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_client::ControllerClient<T>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_client::ControllerClient<T>
+pub fn bpfman_csi::v1::controller_client::ControllerClient<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_client::ControllerClient<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_client::ControllerClient<T>
+pub mod bpfman_csi::v1::controller_get_volume_response
+pub struct bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub bpfman_csi::v1::controller_get_volume_response::VolumeStatus::published_node_ids: alloc::vec::Vec<alloc::string::String>
+pub bpfman_csi::v1::controller_get_volume_response::VolumeStatus::volume_condition: core::option::Option<bpfman_csi::v1::VolumeCondition>
+impl core::clone::Clone for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::clone(&self) -> bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::cmp::PartialEq for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::eq(&self, other: &bpfman_csi::v1::controller_get_volume_response::VolumeStatus) -> bool
+impl core::default::Default for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl prost::message::Message for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::clear(&mut self)
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::marker::Send for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::marker::Sync for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::marker::Unpin for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_get_volume_response::VolumeStatus::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_get_volume_response::VolumeStatus::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_get_volume_response::VolumeStatus::Owned = T
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub fn bpfman_csi::v1::controller_get_volume_response::VolumeStatus::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_get_volume_response::VolumeStatus
+pub mod bpfman_csi::v1::controller_server
+pub struct bpfman_csi::v1::controller_server::ControllerServer<T: bpfman_csi::v1::controller_server::Controller>
+impl<T: bpfman_csi::v1::controller_server::Controller> bpfman_csi::v1::controller_server::ControllerServer<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::from_arc(inner: alloc::sync::Arc<T>) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::with_interceptor<F>(inner: T, interceptor: F) -> tonic::service::interceptor::InterceptedService<Self, F> where F: tonic::service::interceptor::Interceptor
+impl<T, B> tower_service::Service<http::request::Request<B>> for bpfman_csi::v1::controller_server::ControllerServer<T> where T: bpfman_csi::v1::controller_server::Controller, B: http_body::Body + core::marker::Send + 'static, <B as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + 'static
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Error = core::convert::Infallible
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Future = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<<bpfman_csi::v1::controller_server::ControllerServer<T> as tower_service::Service<http::request::Request<B>>>::Response, <bpfman_csi::v1::controller_server::ControllerServer<T> as tower_service::Service<http::request::Request<B>>>::Error>> + core::marker::Send)>>
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Response = http::response::Response<http_body::combinators::box_body::UnsyncBoxBody<bytes::bytes::Bytes, tonic::status::Status>>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::call(&mut self, req: http::request::Request<B>) -> Self::Future
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::poll_ready(&mut self, _cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), Self::Error>>
+impl<T: bpfman_csi::v1::controller_server::Controller> core::clone::Clone for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::clone(&self) -> Self
+impl<T: bpfman_csi::v1::controller_server::Controller> tonic::server::NamedService for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub const bpfman_csi::v1::controller_server::ControllerServer<T>::NAME: &'static str
+impl<T: core::fmt::Debug + bpfman_csi::v1::controller_server::Controller> core::fmt::Debug for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for bpfman_csi::v1::controller_server::ControllerServer<T>
+impl<T> core::marker::Send for bpfman_csi::v1::controller_server::ControllerServer<T>
+impl<T> core::marker::Sync for bpfman_csi::v1::controller_server::ControllerServer<T>
+impl<T> core::marker::Unpin for bpfman_csi::v1::controller_server::ControllerServer<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_server::ControllerServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_server::ControllerServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, ReqBody, ResBody> tonic::client::service::GrpcService<ReqBody> for bpfman_csi::v1::controller_server::ControllerServer<T> where T: tower_service::Service<http::request::Request<ReqBody>, Response = http::response::Response<ResBody>>, <T as tower_service::Service<http::request::Request<ReqBody>>>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>, ResBody: http_body::Body, <ResBody as http_body::Body>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Error = <T as tower_service::Service<http::request::Request<ReqBody>>>::Error
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Future = <T as tower_service::Service<http::request::Request<ReqBody>>>::Future
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::ResponseBody = ResBody
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::call(&mut self, request: http::request::Request<ReqBody>) -> <T as tonic::client::service::GrpcService<ReqBody>>::Future
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::poll_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), <T as tonic::client::service::GrpcService<ReqBody>>::Error>>
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_server::ControllerServer<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_server::ControllerServer<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_server::ControllerServer<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_server::ControllerServer<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_server::ControllerServer<T>::Owned = T
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_server::ControllerServer<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_server::ControllerServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_server::ControllerServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub fn bpfman_csi::v1::controller_server::ControllerServer<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_server::ControllerServer<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_server::ControllerServer<T>
+pub trait bpfman_csi::v1::controller_server::Controller: core::marker::Send + core::marker::Sync + 'static
+pub fn bpfman_csi::v1::controller_server::Controller::controller_expand_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerExpandVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerExpandVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::controller_get_capabilities<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerGetCapabilitiesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerGetCapabilitiesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::controller_get_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerGetVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerGetVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::controller_modify_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerModifyVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerModifyVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::controller_publish_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerPublishVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerPublishVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::controller_unpublish_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ControllerUnpublishVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ControllerUnpublishVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::create_snapshot<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::CreateSnapshotRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateSnapshotResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::create_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::CreateVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::delete_snapshot<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::DeleteSnapshotRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteSnapshotResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::delete_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::DeleteVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::get_capacity<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::GetCapacityRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::GetCapacityResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::list_snapshots<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ListSnapshotsRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ListSnapshotsResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::list_volumes<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ListVolumesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ListVolumesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::controller_server::Controller::validate_volume_capabilities<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ValidateVolumeCapabilitiesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ValidateVolumeCapabilitiesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub mod bpfman_csi::v1::controller_service_capability
+pub mod bpfman_csi::v1::controller_service_capability::rpc
+#[repr(i32)] pub enum bpfman_csi::v1::controller_service_capability::rpc::Type
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::CloneVolume = 7
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::CreateDeleteSnapshot = 5
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::CreateDeleteVolume = 1
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::ExpandVolume = 9
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::GetCapacity = 4
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::GetVolume = 12
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::ListSnapshots = 6
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::ListVolumes = 3
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::ListVolumesPublishedNodes = 10
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::ModifyVolume = 14
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::PublishReadonly = 8
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::PublishUnpublishVolume = 2
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::SingleNodeMultiWriter = 13
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::Unknown = 0
+pub bpfman_csi::v1::controller_service_capability::rpc::Type::VolumeCondition = 11
+impl bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::controller_service_capability::rpc::Type>
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::clone(&self) -> bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::cmp::Eq for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::cmp::Ord for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::cmp(&self, other: &bpfman_csi::v1::controller_service_capability::rpc::Type) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::eq(&self, other: &bpfman_csi::v1::controller_service_capability::rpc::Type) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::partial_cmp(&self, other: &bpfman_csi::v1::controller_service_capability::rpc::Type) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::controller_service_capability::rpc::Type> for i32
+pub fn i32::from(value: bpfman_csi::v1::controller_service_capability::rpc::Type) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub type bpfman_csi::v1::controller_service_capability::rpc::Type::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::controller_service_capability::rpc::Type, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::default() -> bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::fmt::Debug for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::marker::Freeze for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::marker::Send for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::marker::Sync for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::marker::Unpin for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_service_capability::rpc::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_service_capability::rpc::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_service_capability::rpc::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_service_capability::rpc::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_service_capability::rpc::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_service_capability::rpc::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_service_capability::rpc::Type::Owned = T
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_service_capability::rpc::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::controller_service_capability::rpc::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_service_capability::rpc::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_service_capability::rpc::Type
+pub enum bpfman_csi::v1::controller_service_capability::Type
+pub bpfman_csi::v1::controller_service_capability::Type::Rpc(bpfman_csi::v1::controller_service_capability::Rpc)
+impl bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::controller_service_capability::Type::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::controller_service_capability::Type::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::controller_service_capability::Type>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::clone(&self) -> bpfman_csi::v1::controller_service_capability::Type
+impl core::cmp::PartialEq for bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::eq(&self, other: &bpfman_csi::v1::controller_service_capability::Type) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::controller_service_capability::Type
+impl core::marker::Freeze for bpfman_csi::v1::controller_service_capability::Type
+impl core::marker::Send for bpfman_csi::v1::controller_service_capability::Type
+impl core::marker::Sync for bpfman_csi::v1::controller_service_capability::Type
+impl core::marker::Unpin for bpfman_csi::v1::controller_service_capability::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_service_capability::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_service_capability::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_service_capability::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_service_capability::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_service_capability::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_service_capability::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_service_capability::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_service_capability::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_service_capability::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_service_capability::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_service_capability::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_service_capability::Type::Owned = T
+pub fn bpfman_csi::v1::controller_service_capability::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_service_capability::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_service_capability::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_service_capability::Type
+pub fn bpfman_csi::v1::controller_service_capability::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_service_capability::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_service_capability::Type
+pub struct bpfman_csi::v1::controller_service_capability::Rpc
+pub bpfman_csi::v1::controller_service_capability::Rpc::type: i32
+impl bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::set_type(&mut self, value: bpfman_csi::v1::controller_service_capability::rpc::Type)
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::type(&self) -> bpfman_csi::v1::controller_service_capability::rpc::Type
+impl core::clone::Clone for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::clone(&self) -> bpfman_csi::v1::controller_service_capability::Rpc
+impl core::cmp::PartialEq for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::eq(&self, other: &bpfman_csi::v1::controller_service_capability::Rpc) -> bool
+impl core::default::Default for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::controller_service_capability::Rpc
+impl prost::message::Message for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::clear(&mut self)
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::controller_service_capability::Rpc
+impl core::marker::Send for bpfman_csi::v1::controller_service_capability::Rpc
+impl core::marker::Sync for bpfman_csi::v1::controller_service_capability::Rpc
+impl core::marker::Unpin for bpfman_csi::v1::controller_service_capability::Rpc
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::controller_service_capability::Rpc
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::controller_service_capability::Rpc
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::controller_service_capability::Rpc where U: core::convert::From<T>
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::controller_service_capability::Rpc where U: core::convert::Into<T>
+pub type bpfman_csi::v1::controller_service_capability::Rpc::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::controller_service_capability::Rpc where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::controller_service_capability::Rpc::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::controller_service_capability::Rpc where T: core::clone::Clone
+pub type bpfman_csi::v1::controller_service_capability::Rpc::Owned = T
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::controller_service_capability::Rpc where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::controller_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::controller_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::controller_service_capability::Rpc
+pub fn bpfman_csi::v1::controller_service_capability::Rpc::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::controller_service_capability::Rpc
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::controller_service_capability::Rpc
+pub mod bpfman_csi::v1::group_controller_client
+pub struct bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+impl<T> bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: tonic::client::service::GrpcService<tonic::body::BoxBody>, <T as tonic::client::service::GrpcService>::Error: core::convert::Into<tonic::codegen::StdError>, <T as tonic::client::service::GrpcService>::ResponseBody: http_body::Body<Data = bytes::bytes::Bytes> + core::marker::Send + 'static, <<T as tonic::client::service::GrpcService>::ResponseBody as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::create_volume_group_snapshot(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::CreateVolumeGroupSnapshotRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateVolumeGroupSnapshotResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::delete_volume_group_snapshot(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::get_volume_group_snapshot(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::GetVolumeGroupSnapshotRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::GetVolumeGroupSnapshotResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::group_controller_get_capabilities(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::GroupControllerGetCapabilitiesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::GroupControllerGetCapabilitiesResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::with_interceptor<F>(inner: T, interceptor: F) -> bpfman_csi::v1::group_controller_client::GroupControllerClient<tonic::service::interceptor::InterceptedService<T, F>> where F: tonic::service::interceptor::Interceptor, <T as tonic::client::service::GrpcService>::ResponseBody: core::default::Default, T: tower_service::Service<http::request::Request<tonic::body::BoxBody>, Response = http::response::Response<<T as tonic::client::service::GrpcService<tonic::body::BoxBody>>::ResponseBody>>, <T as tower_service::Service<http::request::Request<tonic::body::BoxBody>>>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + core::marker::Sync
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::with_origin(inner: T, origin: http::uri::Uri) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::clone(&self) -> bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> !core::marker::Freeze for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+impl<T> core::marker::Send for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::Owned = T
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+pub fn bpfman_csi::v1::group_controller_client::GroupControllerClient<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::group_controller_client::GroupControllerClient<T>
+pub mod bpfman_csi::v1::group_controller_server
+pub struct bpfman_csi::v1::group_controller_server::GroupControllerServer<T: bpfman_csi::v1::group_controller_server::GroupController>
+impl<T: bpfman_csi::v1::group_controller_server::GroupController> bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::from_arc(inner: alloc::sync::Arc<T>) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::with_interceptor<F>(inner: T, interceptor: F) -> tonic::service::interceptor::InterceptedService<Self, F> where F: tonic::service::interceptor::Interceptor
+impl<T, B> tower_service::Service<http::request::Request<B>> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: bpfman_csi::v1::group_controller_server::GroupController, B: http_body::Body + core::marker::Send + 'static, <B as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + 'static
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Error = core::convert::Infallible
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Future = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<<bpfman_csi::v1::group_controller_server::GroupControllerServer<T> as tower_service::Service<http::request::Request<B>>>::Response, <bpfman_csi::v1::group_controller_server::GroupControllerServer<T> as tower_service::Service<http::request::Request<B>>>::Error>> + core::marker::Send)>>
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Response = http::response::Response<http_body::combinators::box_body::UnsyncBoxBody<bytes::bytes::Bytes, tonic::status::Status>>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::call(&mut self, req: http::request::Request<B>) -> Self::Future
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::poll_ready(&mut self, _cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), Self::Error>>
+impl<T: bpfman_csi::v1::group_controller_server::GroupController> core::clone::Clone for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::clone(&self) -> Self
+impl<T: bpfman_csi::v1::group_controller_server::GroupController> tonic::server::NamedService for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub const bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::NAME: &'static str
+impl<T: core::fmt::Debug + bpfman_csi::v1::group_controller_server::GroupController> core::fmt::Debug for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+impl<T> core::marker::Send for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+impl<T> core::marker::Sync for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+impl<T> core::marker::Unpin for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, ReqBody, ResBody> tonic::client::service::GrpcService<ReqBody> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: tower_service::Service<http::request::Request<ReqBody>, Response = http::response::Response<ResBody>>, <T as tower_service::Service<http::request::Request<ReqBody>>>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>, ResBody: http_body::Body, <ResBody as http_body::Body>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Error = <T as tower_service::Service<http::request::Request<ReqBody>>>::Error
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Future = <T as tower_service::Service<http::request::Request<ReqBody>>>::Future
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::ResponseBody = ResBody
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::call(&mut self, request: http::request::Request<ReqBody>) -> <T as tonic::client::service::GrpcService<ReqBody>>::Future
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::poll_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), <T as tonic::client::service::GrpcService<ReqBody>>::Error>>
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::Owned = T
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub fn bpfman_csi::v1::group_controller_server::GroupControllerServer<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::group_controller_server::GroupControllerServer<T>
+pub trait bpfman_csi::v1::group_controller_server::GroupController: core::marker::Send + core::marker::Sync + 'static
+pub fn bpfman_csi::v1::group_controller_server::GroupController::create_volume_group_snapshot<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::CreateVolumeGroupSnapshotRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::CreateVolumeGroupSnapshotResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::group_controller_server::GroupController::delete_volume_group_snapshot<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::group_controller_server::GroupController::get_volume_group_snapshot<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::GetVolumeGroupSnapshotRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::GetVolumeGroupSnapshotResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::group_controller_server::GroupController::group_controller_get_capabilities<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::GroupControllerGetCapabilitiesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::GroupControllerGetCapabilitiesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub mod bpfman_csi::v1::group_controller_service_capability
+pub mod bpfman_csi::v1::group_controller_service_capability::rpc
+#[repr(i32)] pub enum bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub bpfman_csi::v1::group_controller_service_capability::rpc::Type::CreateDeleteGetVolumeGroupSnapshot = 1
+pub bpfman_csi::v1::group_controller_service_capability::rpc::Type::Unknown = 0
+impl bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::group_controller_service_capability::rpc::Type>
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::clone(&self) -> bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::cmp::Eq for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::cmp::Ord for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::cmp(&self, other: &bpfman_csi::v1::group_controller_service_capability::rpc::Type) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::eq(&self, other: &bpfman_csi::v1::group_controller_service_capability::rpc::Type) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::partial_cmp(&self, other: &bpfman_csi::v1::group_controller_service_capability::rpc::Type) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::group_controller_service_capability::rpc::Type> for i32
+pub fn i32::from(value: bpfman_csi::v1::group_controller_service_capability::rpc::Type) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub type bpfman_csi::v1::group_controller_service_capability::rpc::Type::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::group_controller_service_capability::rpc::Type, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::default() -> bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::fmt::Debug for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::marker::Freeze for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::marker::Send for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::marker::Sync for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::marker::Unpin for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::group_controller_service_capability::rpc::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::group_controller_service_capability::rpc::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::group_controller_service_capability::rpc::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::group_controller_service_capability::rpc::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::group_controller_service_capability::rpc::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::group_controller_service_capability::rpc::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::group_controller_service_capability::rpc::Type::Owned = T
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::group_controller_service_capability::rpc::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::group_controller_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::group_controller_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::rpc::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::group_controller_service_capability::rpc::Type
+pub enum bpfman_csi::v1::group_controller_service_capability::Type
+pub bpfman_csi::v1::group_controller_service_capability::Type::Rpc(bpfman_csi::v1::group_controller_service_capability::Rpc)
+impl bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::group_controller_service_capability::Type>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::clone(&self) -> bpfman_csi::v1::group_controller_service_capability::Type
+impl core::cmp::PartialEq for bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::eq(&self, other: &bpfman_csi::v1::group_controller_service_capability::Type) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::marker::Freeze for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::marker::Send for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::marker::Sync for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::marker::Unpin for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::group_controller_service_capability::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::group_controller_service_capability::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::group_controller_service_capability::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::group_controller_service_capability::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::group_controller_service_capability::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::group_controller_service_capability::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::group_controller_service_capability::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::group_controller_service_capability::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::group_controller_service_capability::Type::Owned = T
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::group_controller_service_capability::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::group_controller_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::group_controller_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::group_controller_service_capability::Type
+pub fn bpfman_csi::v1::group_controller_service_capability::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::group_controller_service_capability::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::group_controller_service_capability::Type
+pub struct bpfman_csi::v1::group_controller_service_capability::Rpc
+pub bpfman_csi::v1::group_controller_service_capability::Rpc::type: i32
+impl bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::set_type(&mut self, value: bpfman_csi::v1::group_controller_service_capability::rpc::Type)
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::type(&self) -> bpfman_csi::v1::group_controller_service_capability::rpc::Type
+impl core::clone::Clone for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::clone(&self) -> bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::cmp::PartialEq for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::eq(&self, other: &bpfman_csi::v1::group_controller_service_capability::Rpc) -> bool
+impl core::default::Default for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl prost::message::Message for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::clear(&mut self)
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::marker::Send for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::marker::Sync for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::marker::Unpin for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::group_controller_service_capability::Rpc where U: core::convert::From<T>
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::group_controller_service_capability::Rpc where U: core::convert::Into<T>
+pub type bpfman_csi::v1::group_controller_service_capability::Rpc::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::group_controller_service_capability::Rpc where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::group_controller_service_capability::Rpc::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::group_controller_service_capability::Rpc where T: core::clone::Clone
+pub type bpfman_csi::v1::group_controller_service_capability::Rpc::Owned = T
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::group_controller_service_capability::Rpc where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::group_controller_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::group_controller_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub fn bpfman_csi::v1::group_controller_service_capability::Rpc::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::group_controller_service_capability::Rpc
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::group_controller_service_capability::Rpc
+pub mod bpfman_csi::v1::identity_client
+pub struct bpfman_csi::v1::identity_client::IdentityClient<T>
+impl<T> bpfman_csi::v1::identity_client::IdentityClient<T> where T: tonic::client::service::GrpcService<tonic::body::BoxBody>, <T as tonic::client::service::GrpcService>::Error: core::convert::Into<tonic::codegen::StdError>, <T as tonic::client::service::GrpcService>::ResponseBody: http_body::Body<Data = bytes::bytes::Bytes> + core::marker::Send + 'static, <<T as tonic::client::service::GrpcService>::ResponseBody as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub async fn bpfman_csi::v1::identity_client::IdentityClient<T>::get_plugin_capabilities(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::GetPluginCapabilitiesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::GetPluginCapabilitiesResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::identity_client::IdentityClient<T>::get_plugin_info(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::GetPluginInfoRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::GetPluginInfoResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::new(inner: T) -> Self
+pub async fn bpfman_csi::v1::identity_client::IdentityClient<T>::probe(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::ProbeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::ProbeResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::with_interceptor<F>(inner: T, interceptor: F) -> bpfman_csi::v1::identity_client::IdentityClient<tonic::service::interceptor::InterceptedService<T, F>> where F: tonic::service::interceptor::Interceptor, <T as tonic::client::service::GrpcService>::ResponseBody: core::default::Default, T: tower_service::Service<http::request::Request<tonic::body::BoxBody>, Response = http::response::Response<<T as tonic::client::service::GrpcService<tonic::body::BoxBody>>::ResponseBody>>, <T as tower_service::Service<http::request::Request<tonic::body::BoxBody>>>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + core::marker::Sync
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::with_origin(inner: T, origin: http::uri::Uri) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bpfman_csi::v1::identity_client::IdentityClient<T>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::clone(&self) -> bpfman_csi::v1::identity_client::IdentityClient<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bpfman_csi::v1::identity_client::IdentityClient<T>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> !core::marker::Freeze for bpfman_csi::v1::identity_client::IdentityClient<T>
+impl<T> core::marker::Send for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::identity_client::IdentityClient<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::identity_client::IdentityClient<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::identity_client::IdentityClient<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::identity_client::IdentityClient<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::identity_client::IdentityClient<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::identity_client::IdentityClient<T>::Owned = T
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::identity_client::IdentityClient<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::identity_client::IdentityClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::identity_client::IdentityClient<T>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::identity_client::IdentityClient<T>
+pub fn bpfman_csi::v1::identity_client::IdentityClient<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::identity_client::IdentityClient<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::identity_client::IdentityClient<T>
+pub mod bpfman_csi::v1::identity_server
+pub struct bpfman_csi::v1::identity_server::IdentityServer<T: bpfman_csi::v1::identity_server::Identity>
+impl<T: bpfman_csi::v1::identity_server::Identity> bpfman_csi::v1::identity_server::IdentityServer<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::from_arc(inner: alloc::sync::Arc<T>) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::with_interceptor<F>(inner: T, interceptor: F) -> tonic::service::interceptor::InterceptedService<Self, F> where F: tonic::service::interceptor::Interceptor
+impl<T, B> tower_service::Service<http::request::Request<B>> for bpfman_csi::v1::identity_server::IdentityServer<T> where T: bpfman_csi::v1::identity_server::Identity, B: http_body::Body + core::marker::Send + 'static, <B as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + 'static
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Error = core::convert::Infallible
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Future = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<<bpfman_csi::v1::identity_server::IdentityServer<T> as tower_service::Service<http::request::Request<B>>>::Response, <bpfman_csi::v1::identity_server::IdentityServer<T> as tower_service::Service<http::request::Request<B>>>::Error>> + core::marker::Send)>>
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Response = http::response::Response<http_body::combinators::box_body::UnsyncBoxBody<bytes::bytes::Bytes, tonic::status::Status>>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::call(&mut self, req: http::request::Request<B>) -> Self::Future
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::poll_ready(&mut self, _cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), Self::Error>>
+impl<T: bpfman_csi::v1::identity_server::Identity> core::clone::Clone for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::clone(&self) -> Self
+impl<T: bpfman_csi::v1::identity_server::Identity> tonic::server::NamedService for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub const bpfman_csi::v1::identity_server::IdentityServer<T>::NAME: &'static str
+impl<T: core::fmt::Debug + bpfman_csi::v1::identity_server::Identity> core::fmt::Debug for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for bpfman_csi::v1::identity_server::IdentityServer<T>
+impl<T> core::marker::Send for bpfman_csi::v1::identity_server::IdentityServer<T>
+impl<T> core::marker::Sync for bpfman_csi::v1::identity_server::IdentityServer<T>
+impl<T> core::marker::Unpin for bpfman_csi::v1::identity_server::IdentityServer<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::identity_server::IdentityServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::identity_server::IdentityServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, ReqBody, ResBody> tonic::client::service::GrpcService<ReqBody> for bpfman_csi::v1::identity_server::IdentityServer<T> where T: tower_service::Service<http::request::Request<ReqBody>, Response = http::response::Response<ResBody>>, <T as tower_service::Service<http::request::Request<ReqBody>>>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>, ResBody: http_body::Body, <ResBody as http_body::Body>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Error = <T as tower_service::Service<http::request::Request<ReqBody>>>::Error
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Future = <T as tower_service::Service<http::request::Request<ReqBody>>>::Future
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::ResponseBody = ResBody
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::call(&mut self, request: http::request::Request<ReqBody>) -> <T as tonic::client::service::GrpcService<ReqBody>>::Future
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::poll_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), <T as tonic::client::service::GrpcService<ReqBody>>::Error>>
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::identity_server::IdentityServer<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::identity_server::IdentityServer<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::identity_server::IdentityServer<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::identity_server::IdentityServer<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::identity_server::IdentityServer<T>::Owned = T
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::identity_server::IdentityServer<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::identity_server::IdentityServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::identity_server::IdentityServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub fn bpfman_csi::v1::identity_server::IdentityServer<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::identity_server::IdentityServer<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::identity_server::IdentityServer<T>
+pub trait bpfman_csi::v1::identity_server::Identity: core::marker::Send + core::marker::Sync + 'static
+pub fn bpfman_csi::v1::identity_server::Identity::get_plugin_capabilities<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::GetPluginCapabilitiesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::GetPluginCapabilitiesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::identity_server::Identity::get_plugin_info<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::GetPluginInfoRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::GetPluginInfoResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::identity_server::Identity::probe<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::ProbeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::ProbeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub mod bpfman_csi::v1::list_snapshots_response
+pub struct bpfman_csi::v1::list_snapshots_response::Entry
+pub bpfman_csi::v1::list_snapshots_response::Entry::snapshot: core::option::Option<bpfman_csi::v1::Snapshot>
+impl core::clone::Clone for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::clone(&self) -> bpfman_csi::v1::list_snapshots_response::Entry
+impl core::cmp::PartialEq for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::eq(&self, other: &bpfman_csi::v1::list_snapshots_response::Entry) -> bool
+impl core::default::Default for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::list_snapshots_response::Entry
+impl prost::message::Message for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::clear(&mut self)
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::list_snapshots_response::Entry
+impl core::marker::Send for bpfman_csi::v1::list_snapshots_response::Entry
+impl core::marker::Sync for bpfman_csi::v1::list_snapshots_response::Entry
+impl core::marker::Unpin for bpfman_csi::v1::list_snapshots_response::Entry
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::list_snapshots_response::Entry
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::list_snapshots_response::Entry
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::list_snapshots_response::Entry where U: core::convert::From<T>
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::list_snapshots_response::Entry where U: core::convert::Into<T>
+pub type bpfman_csi::v1::list_snapshots_response::Entry::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::list_snapshots_response::Entry where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::list_snapshots_response::Entry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::list_snapshots_response::Entry where T: core::clone::Clone
+pub type bpfman_csi::v1::list_snapshots_response::Entry::Owned = T
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::list_snapshots_response::Entry where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::list_snapshots_response::Entry where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::list_snapshots_response::Entry where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::list_snapshots_response::Entry
+pub fn bpfman_csi::v1::list_snapshots_response::Entry::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::list_snapshots_response::Entry
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::list_snapshots_response::Entry
+pub mod bpfman_csi::v1::list_volumes_response
+pub struct bpfman_csi::v1::list_volumes_response::Entry
+pub bpfman_csi::v1::list_volumes_response::Entry::status: core::option::Option<bpfman_csi::v1::list_volumes_response::VolumeStatus>
+pub bpfman_csi::v1::list_volumes_response::Entry::volume: core::option::Option<bpfman_csi::v1::Volume>
+impl core::clone::Clone for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::clone(&self) -> bpfman_csi::v1::list_volumes_response::Entry
+impl core::cmp::PartialEq for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::eq(&self, other: &bpfman_csi::v1::list_volumes_response::Entry) -> bool
+impl core::default::Default for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::list_volumes_response::Entry
+impl prost::message::Message for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::clear(&mut self)
+pub fn bpfman_csi::v1::list_volumes_response::Entry::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::list_volumes_response::Entry
+impl core::marker::Send for bpfman_csi::v1::list_volumes_response::Entry
+impl core::marker::Sync for bpfman_csi::v1::list_volumes_response::Entry
+impl core::marker::Unpin for bpfman_csi::v1::list_volumes_response::Entry
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::list_volumes_response::Entry
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::list_volumes_response::Entry
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::list_volumes_response::Entry where U: core::convert::From<T>
+pub fn bpfman_csi::v1::list_volumes_response::Entry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::list_volumes_response::Entry where U: core::convert::Into<T>
+pub type bpfman_csi::v1::list_volumes_response::Entry::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::list_volumes_response::Entry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::list_volumes_response::Entry where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::list_volumes_response::Entry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::list_volumes_response::Entry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::list_volumes_response::Entry where T: core::clone::Clone
+pub type bpfman_csi::v1::list_volumes_response::Entry::Owned = T
+pub fn bpfman_csi::v1::list_volumes_response::Entry::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::list_volumes_response::Entry::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::list_volumes_response::Entry where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::Entry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::list_volumes_response::Entry where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::Entry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::list_volumes_response::Entry where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::Entry::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::list_volumes_response::Entry
+pub fn bpfman_csi::v1::list_volumes_response::Entry::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::list_volumes_response::Entry
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::list_volumes_response::Entry
+pub struct bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub bpfman_csi::v1::list_volumes_response::VolumeStatus::published_node_ids: alloc::vec::Vec<alloc::string::String>
+pub bpfman_csi::v1::list_volumes_response::VolumeStatus::volume_condition: core::option::Option<bpfman_csi::v1::VolumeCondition>
+impl core::clone::Clone for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::clone(&self) -> bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::cmp::PartialEq for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::eq(&self, other: &bpfman_csi::v1::list_volumes_response::VolumeStatus) -> bool
+impl core::default::Default for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl prost::message::Message for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::clear(&mut self)
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::marker::Send for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::marker::Sync for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::marker::Unpin for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::list_volumes_response::VolumeStatus where U: core::convert::From<T>
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::list_volumes_response::VolumeStatus where U: core::convert::Into<T>
+pub type bpfman_csi::v1::list_volumes_response::VolumeStatus::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::list_volumes_response::VolumeStatus where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::list_volumes_response::VolumeStatus::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::list_volumes_response::VolumeStatus where T: core::clone::Clone
+pub type bpfman_csi::v1::list_volumes_response::VolumeStatus::Owned = T
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::list_volumes_response::VolumeStatus where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::list_volumes_response::VolumeStatus where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::list_volumes_response::VolumeStatus where T: core::marker::Sized
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub fn bpfman_csi::v1::list_volumes_response::VolumeStatus::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::list_volumes_response::VolumeStatus
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::list_volumes_response::VolumeStatus
+pub mod bpfman_csi::v1::node_client
+pub struct bpfman_csi::v1::node_client::NodeClient<T>
+impl<T> bpfman_csi::v1::node_client::NodeClient<T> where T: tonic::client::service::GrpcService<tonic::body::BoxBody>, <T as tonic::client::service::GrpcService>::Error: core::convert::Into<tonic::codegen::StdError>, <T as tonic::client::service::GrpcService>::ResponseBody: http_body::Body<Data = bytes::bytes::Bytes> + core::marker::Send + 'static, <<T as tonic::client::service::GrpcService>::ResponseBody as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::new(inner: T) -> Self
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_expand_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeExpandVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeExpandVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_get_capabilities(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeGetCapabilitiesRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetCapabilitiesResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_get_info(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeGetInfoRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetInfoResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_get_volume_stats(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeGetVolumeStatsRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetVolumeStatsResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_publish_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodePublishVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodePublishVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_stage_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeStageVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeStageVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_unpublish_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeUnpublishVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeUnpublishVolumeResponse>, tonic::status::Status>
+pub async fn bpfman_csi::v1::node_client::NodeClient<T>::node_unstage_volume(&mut self, request: impl tonic::request::IntoRequest<bpfman_csi::v1::NodeUnstageVolumeRequest>) -> core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeUnstageVolumeResponse>, tonic::status::Status>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::with_interceptor<F>(inner: T, interceptor: F) -> bpfman_csi::v1::node_client::NodeClient<tonic::service::interceptor::InterceptedService<T, F>> where F: tonic::service::interceptor::Interceptor, <T as tonic::client::service::GrpcService>::ResponseBody: core::default::Default, T: tower_service::Service<http::request::Request<tonic::body::BoxBody>, Response = http::response::Response<<T as tonic::client::service::GrpcService<tonic::body::BoxBody>>::ResponseBody>>, <T as tower_service::Service<http::request::Request<tonic::body::BoxBody>>>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + core::marker::Sync
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::with_origin(inner: T, origin: http::uri::Uri) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bpfman_csi::v1::node_client::NodeClient<T>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::clone(&self) -> bpfman_csi::v1::node_client::NodeClient<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bpfman_csi::v1::node_client::NodeClient<T>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> !core::marker::Freeze for bpfman_csi::v1::node_client::NodeClient<T>
+impl<T> core::marker::Send for bpfman_csi::v1::node_client::NodeClient<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bpfman_csi::v1::node_client::NodeClient<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bpfman_csi::v1::node_client::NodeClient<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::node_client::NodeClient<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::node_client::NodeClient<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::node_client::NodeClient<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::node_client::NodeClient<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::node_client::NodeClient<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::node_client::NodeClient<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::node_client::NodeClient<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::node_client::NodeClient<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::node_client::NodeClient<T>::Owned = T
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::node_client::NodeClient<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::node_client::NodeClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::node_client::NodeClient<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::node_client::NodeClient<T>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::node_client::NodeClient<T>
+pub fn bpfman_csi::v1::node_client::NodeClient<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::node_client::NodeClient<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::node_client::NodeClient<T>
+pub mod bpfman_csi::v1::node_server
+pub struct bpfman_csi::v1::node_server::NodeServer<T: bpfman_csi::v1::node_server::Node>
+impl<T: bpfman_csi::v1::node_server::Node> bpfman_csi::v1::node_server::NodeServer<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::accept_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::from_arc(inner: alloc::sync::Arc<T>) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::max_decoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::max_encoding_message_size(self, limit: usize) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::new(inner: T) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::send_compressed(self, encoding: tonic::codec::compression::CompressionEncoding) -> Self
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::with_interceptor<F>(inner: T, interceptor: F) -> tonic::service::interceptor::InterceptedService<Self, F> where F: tonic::service::interceptor::Interceptor
+impl<T, B> tower_service::Service<http::request::Request<B>> for bpfman_csi::v1::node_server::NodeServer<T> where T: bpfman_csi::v1::node_server::Node, B: http_body::Body + core::marker::Send + 'static, <B as http_body::Body>::Error: core::convert::Into<tonic::codegen::StdError> + core::marker::Send + 'static
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Error = core::convert::Infallible
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Future = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<<bpfman_csi::v1::node_server::NodeServer<T> as tower_service::Service<http::request::Request<B>>>::Response, <bpfman_csi::v1::node_server::NodeServer<T> as tower_service::Service<http::request::Request<B>>>::Error>> + core::marker::Send)>>
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Response = http::response::Response<http_body::combinators::box_body::UnsyncBoxBody<bytes::bytes::Bytes, tonic::status::Status>>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::call(&mut self, req: http::request::Request<B>) -> Self::Future
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::poll_ready(&mut self, _cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), Self::Error>>
+impl<T: bpfman_csi::v1::node_server::Node> core::clone::Clone for bpfman_csi::v1::node_server::NodeServer<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::clone(&self) -> Self
+impl<T: bpfman_csi::v1::node_server::Node> tonic::server::NamedService for bpfman_csi::v1::node_server::NodeServer<T>
+pub const bpfman_csi::v1::node_server::NodeServer<T>::NAME: &'static str
+impl<T: core::fmt::Debug + bpfman_csi::v1::node_server::Node> core::fmt::Debug for bpfman_csi::v1::node_server::NodeServer<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::marker::Freeze for bpfman_csi::v1::node_server::NodeServer<T>
+impl<T> core::marker::Send for bpfman_csi::v1::node_server::NodeServer<T>
+impl<T> core::marker::Sync for bpfman_csi::v1::node_server::NodeServer<T>
+impl<T> core::marker::Unpin for bpfman_csi::v1::node_server::NodeServer<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::node_server::NodeServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::node_server::NodeServer<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, ReqBody, ResBody> tonic::client::service::GrpcService<ReqBody> for bpfman_csi::v1::node_server::NodeServer<T> where T: tower_service::Service<http::request::Request<ReqBody>, Response = http::response::Response<ResBody>>, <T as tower_service::Service<http::request::Request<ReqBody>>>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>, ResBody: http_body::Body, <ResBody as http_body::Body>::Error: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync)>>
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Error = <T as tower_service::Service<http::request::Request<ReqBody>>>::Error
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Future = <T as tower_service::Service<http::request::Request<ReqBody>>>::Future
+pub type bpfman_csi::v1::node_server::NodeServer<T>::ResponseBody = ResBody
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::call(&mut self, request: http::request::Request<ReqBody>) -> <T as tonic::client::service::GrpcService<ReqBody>>::Future
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::poll_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::result::Result<(), <T as tonic::client::service::GrpcService<ReqBody>>::Error>>
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::node_server::NodeServer<T> where U: core::convert::From<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::node_server::NodeServer<T> where U: core::convert::Into<T>
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::node_server::NodeServer<T> where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::node_server::NodeServer<T> where T: core::clone::Clone
+pub type bpfman_csi::v1::node_server::NodeServer<T>::Owned = T
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::node_server::NodeServer<T> where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::node_server::NodeServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::node_server::NodeServer<T> where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::node_server::NodeServer<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::node_server::NodeServer<T>
+pub fn bpfman_csi::v1::node_server::NodeServer<T>::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::node_server::NodeServer<T>
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::node_server::NodeServer<T>
+pub trait bpfman_csi::v1::node_server::Node: core::marker::Send + core::marker::Sync + 'static
+pub fn bpfman_csi::v1::node_server::Node::node_expand_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeExpandVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeExpandVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_get_capabilities<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeGetCapabilitiesRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetCapabilitiesResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_get_info<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeGetInfoRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetInfoResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_get_volume_stats<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeGetVolumeStatsRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeGetVolumeStatsResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_publish_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodePublishVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodePublishVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_stage_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeStageVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeStageVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_unpublish_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeUnpublishVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeUnpublishVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub fn bpfman_csi::v1::node_server::Node::node_unstage_volume<'life0, 'async_trait>(&'life0 self, request: tonic::request::Request<bpfman_csi::v1::NodeUnstageVolumeRequest>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<tonic::response::Response<bpfman_csi::v1::NodeUnstageVolumeResponse>, tonic::status::Status>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0
+pub mod bpfman_csi::v1::node_service_capability
+pub mod bpfman_csi::v1::node_service_capability::rpc
+#[repr(i32)] pub enum bpfman_csi::v1::node_service_capability::rpc::Type
+pub bpfman_csi::v1::node_service_capability::rpc::Type::ExpandVolume = 3
+pub bpfman_csi::v1::node_service_capability::rpc::Type::GetVolumeStats = 2
+pub bpfman_csi::v1::node_service_capability::rpc::Type::SingleNodeMultiWriter = 5
+pub bpfman_csi::v1::node_service_capability::rpc::Type::StageUnstageVolume = 1
+pub bpfman_csi::v1::node_service_capability::rpc::Type::Unknown = 0
+pub bpfman_csi::v1::node_service_capability::rpc::Type::VolumeCondition = 4
+pub bpfman_csi::v1::node_service_capability::rpc::Type::VolumeMountGroup = 6
+impl bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::node_service_capability::rpc::Type>
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::clone(&self) -> bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::cmp::Eq for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::cmp::Ord for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::cmp(&self, other: &bpfman_csi::v1::node_service_capability::rpc::Type) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::eq(&self, other: &bpfman_csi::v1::node_service_capability::rpc::Type) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::partial_cmp(&self, other: &bpfman_csi::v1::node_service_capability::rpc::Type) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::node_service_capability::rpc::Type> for i32
+pub fn i32::from(value: bpfman_csi::v1::node_service_capability::rpc::Type) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::node_service_capability::rpc::Type
+pub type bpfman_csi::v1::node_service_capability::rpc::Type::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::node_service_capability::rpc::Type, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::default() -> bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::fmt::Debug for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::marker::Freeze for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::marker::Send for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::marker::Sync for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::marker::Unpin for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::node_service_capability::rpc::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::node_service_capability::rpc::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::node_service_capability::rpc::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::node_service_capability::rpc::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::node_service_capability::rpc::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::node_service_capability::rpc::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::node_service_capability::rpc::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::node_service_capability::rpc::Type::Owned = T
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::node_service_capability::rpc::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::node_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::node_service_capability::rpc::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::node_service_capability::rpc::Type
+pub fn bpfman_csi::v1::node_service_capability::rpc::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::node_service_capability::rpc::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::node_service_capability::rpc::Type
+pub enum bpfman_csi::v1::node_service_capability::Type
+pub bpfman_csi::v1::node_service_capability::Type::Rpc(bpfman_csi::v1::node_service_capability::Rpc)
+impl bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::node_service_capability::Type::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::node_service_capability::Type::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::node_service_capability::Type>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::clone(&self) -> bpfman_csi::v1::node_service_capability::Type
+impl core::cmp::PartialEq for bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::eq(&self, other: &bpfman_csi::v1::node_service_capability::Type) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::node_service_capability::Type
+impl core::marker::Freeze for bpfman_csi::v1::node_service_capability::Type
+impl core::marker::Send for bpfman_csi::v1::node_service_capability::Type
+impl core::marker::Sync for bpfman_csi::v1::node_service_capability::Type
+impl core::marker::Unpin for bpfman_csi::v1::node_service_capability::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::node_service_capability::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::node_service_capability::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::node_service_capability::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::node_service_capability::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::node_service_capability::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::node_service_capability::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::node_service_capability::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::node_service_capability::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::node_service_capability::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::node_service_capability::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::node_service_capability::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::node_service_capability::Type::Owned = T
+pub fn bpfman_csi::v1::node_service_capability::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::node_service_capability::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::node_service_capability::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::node_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::node_service_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::node_service_capability::Type
+pub fn bpfman_csi::v1::node_service_capability::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::node_service_capability::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::node_service_capability::Type
+pub struct bpfman_csi::v1::node_service_capability::Rpc
+pub bpfman_csi::v1::node_service_capability::Rpc::type: i32
+impl bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::set_type(&mut self, value: bpfman_csi::v1::node_service_capability::rpc::Type)
+pub fn bpfman_csi::v1::node_service_capability::Rpc::type(&self) -> bpfman_csi::v1::node_service_capability::rpc::Type
+impl core::clone::Clone for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::clone(&self) -> bpfman_csi::v1::node_service_capability::Rpc
+impl core::cmp::PartialEq for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::eq(&self, other: &bpfman_csi::v1::node_service_capability::Rpc) -> bool
+impl core::default::Default for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::node_service_capability::Rpc
+impl prost::message::Message for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::clear(&mut self)
+pub fn bpfman_csi::v1::node_service_capability::Rpc::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::node_service_capability::Rpc
+impl core::marker::Send for bpfman_csi::v1::node_service_capability::Rpc
+impl core::marker::Sync for bpfman_csi::v1::node_service_capability::Rpc
+impl core::marker::Unpin for bpfman_csi::v1::node_service_capability::Rpc
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::node_service_capability::Rpc
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::node_service_capability::Rpc
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::node_service_capability::Rpc where U: core::convert::From<T>
+pub fn bpfman_csi::v1::node_service_capability::Rpc::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::node_service_capability::Rpc where U: core::convert::Into<T>
+pub type bpfman_csi::v1::node_service_capability::Rpc::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::node_service_capability::Rpc::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::node_service_capability::Rpc where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::node_service_capability::Rpc::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::node_service_capability::Rpc::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::node_service_capability::Rpc where T: core::clone::Clone
+pub type bpfman_csi::v1::node_service_capability::Rpc::Owned = T
+pub fn bpfman_csi::v1::node_service_capability::Rpc::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::node_service_capability::Rpc::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::node_service_capability::Rpc where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Rpc::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::node_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Rpc::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::node_service_capability::Rpc where T: core::marker::Sized
+pub fn bpfman_csi::v1::node_service_capability::Rpc::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::node_service_capability::Rpc
+pub fn bpfman_csi::v1::node_service_capability::Rpc::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::node_service_capability::Rpc
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::node_service_capability::Rpc
+pub mod bpfman_csi::v1::plugin_capability
+pub mod bpfman_csi::v1::plugin_capability::service
+#[repr(i32)] pub enum bpfman_csi::v1::plugin_capability::service::Type
+pub bpfman_csi::v1::plugin_capability::service::Type::ControllerService = 1
+pub bpfman_csi::v1::plugin_capability::service::Type::GroupControllerService = 3
+pub bpfman_csi::v1::plugin_capability::service::Type::Unknown = 0
+pub bpfman_csi::v1::plugin_capability::service::Type::VolumeAccessibilityConstraints = 2
+impl bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::plugin_capability::service::Type::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::plugin_capability::service::Type>
+pub fn bpfman_csi::v1::plugin_capability::service::Type::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::clone(&self) -> bpfman_csi::v1::plugin_capability::service::Type
+impl core::cmp::Eq for bpfman_csi::v1::plugin_capability::service::Type
+impl core::cmp::Ord for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::cmp(&self, other: &bpfman_csi::v1::plugin_capability::service::Type) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::eq(&self, other: &bpfman_csi::v1::plugin_capability::service::Type) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::partial_cmp(&self, other: &bpfman_csi::v1::plugin_capability::service::Type) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::plugin_capability::service::Type> for i32
+pub fn i32::from(value: bpfman_csi::v1::plugin_capability::service::Type) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::plugin_capability::service::Type
+pub type bpfman_csi::v1::plugin_capability::service::Type::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::plugin_capability::service::Type::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::plugin_capability::service::Type, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::default() -> bpfman_csi::v1::plugin_capability::service::Type
+impl core::fmt::Debug for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::plugin_capability::service::Type
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::plugin_capability::service::Type
+impl core::marker::Freeze for bpfman_csi::v1::plugin_capability::service::Type
+impl core::marker::Send for bpfman_csi::v1::plugin_capability::service::Type
+impl core::marker::Sync for bpfman_csi::v1::plugin_capability::service::Type
+impl core::marker::Unpin for bpfman_csi::v1::plugin_capability::service::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::plugin_capability::service::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::plugin_capability::service::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::plugin_capability::service::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::plugin_capability::service::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::plugin_capability::service::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::plugin_capability::service::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::plugin_capability::service::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::plugin_capability::service::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::plugin_capability::service::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::plugin_capability::service::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::plugin_capability::service::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::plugin_capability::service::Type::Owned = T
+pub fn bpfman_csi::v1::plugin_capability::service::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::plugin_capability::service::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::plugin_capability::service::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::service::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::plugin_capability::service::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::service::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::plugin_capability::service::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::service::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::plugin_capability::service::Type
+pub fn bpfman_csi::v1::plugin_capability::service::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::plugin_capability::service::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::plugin_capability::service::Type
+pub mod bpfman_csi::v1::plugin_capability::volume_expansion
+#[repr(i32)] pub enum bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub bpfman_csi::v1::plugin_capability::volume_expansion::Type::Offline = 2
+pub bpfman_csi::v1::plugin_capability::volume_expansion::Type::Online = 1
+pub bpfman_csi::v1::plugin_capability::volume_expansion::Type::Unknown = 0
+impl bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::plugin_capability::volume_expansion::Type>
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::clone(&self) -> bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::cmp::Eq for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::cmp::Ord for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::cmp(&self, other: &bpfman_csi::v1::plugin_capability::volume_expansion::Type) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::eq(&self, other: &bpfman_csi::v1::plugin_capability::volume_expansion::Type) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::partial_cmp(&self, other: &bpfman_csi::v1::plugin_capability::volume_expansion::Type) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::plugin_capability::volume_expansion::Type> for i32
+pub fn i32::from(value: bpfman_csi::v1::plugin_capability::volume_expansion::Type) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub type bpfman_csi::v1::plugin_capability::volume_expansion::Type::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::plugin_capability::volume_expansion::Type, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::default() -> bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::fmt::Debug for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::marker::Freeze for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::marker::Send for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::marker::Sync for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::marker::Unpin for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::plugin_capability::volume_expansion::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::plugin_capability::volume_expansion::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::plugin_capability::volume_expansion::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::plugin_capability::volume_expansion::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::plugin_capability::volume_expansion::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::plugin_capability::volume_expansion::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::plugin_capability::volume_expansion::Type::Owned = T
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::plugin_capability::volume_expansion::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::plugin_capability::volume_expansion::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::plugin_capability::volume_expansion::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub fn bpfman_csi::v1::plugin_capability::volume_expansion::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::plugin_capability::volume_expansion::Type
+pub enum bpfman_csi::v1::plugin_capability::Type
+pub bpfman_csi::v1::plugin_capability::Type::Service(bpfman_csi::v1::plugin_capability::Service)
+pub bpfman_csi::v1::plugin_capability::Type::VolumeExpansion(bpfman_csi::v1::plugin_capability::VolumeExpansion)
+impl bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::plugin_capability::Type::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::plugin_capability::Type::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::plugin_capability::Type>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::clone(&self) -> bpfman_csi::v1::plugin_capability::Type
+impl core::cmp::PartialEq for bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::eq(&self, other: &bpfman_csi::v1::plugin_capability::Type) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::plugin_capability::Type
+impl core::marker::Freeze for bpfman_csi::v1::plugin_capability::Type
+impl core::marker::Send for bpfman_csi::v1::plugin_capability::Type
+impl core::marker::Sync for bpfman_csi::v1::plugin_capability::Type
+impl core::marker::Unpin for bpfman_csi::v1::plugin_capability::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::plugin_capability::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::plugin_capability::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::plugin_capability::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::plugin_capability::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::plugin_capability::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::plugin_capability::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::plugin_capability::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::plugin_capability::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::plugin_capability::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::plugin_capability::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::plugin_capability::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::plugin_capability::Type::Owned = T
+pub fn bpfman_csi::v1::plugin_capability::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::plugin_capability::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::plugin_capability::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::plugin_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::plugin_capability::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::plugin_capability::Type
+pub fn bpfman_csi::v1::plugin_capability::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::plugin_capability::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::plugin_capability::Type
+pub struct bpfman_csi::v1::plugin_capability::Service
+pub bpfman_csi::v1::plugin_capability::Service::type: i32
+impl bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::set_type(&mut self, value: bpfman_csi::v1::plugin_capability::service::Type)
+pub fn bpfman_csi::v1::plugin_capability::Service::type(&self) -> bpfman_csi::v1::plugin_capability::service::Type
+impl core::clone::Clone for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::clone(&self) -> bpfman_csi::v1::plugin_capability::Service
+impl core::cmp::PartialEq for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::eq(&self, other: &bpfman_csi::v1::plugin_capability::Service) -> bool
+impl core::default::Default for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::plugin_capability::Service
+impl prost::message::Message for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::clear(&mut self)
+pub fn bpfman_csi::v1::plugin_capability::Service::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::plugin_capability::Service
+impl core::marker::Send for bpfman_csi::v1::plugin_capability::Service
+impl core::marker::Sync for bpfman_csi::v1::plugin_capability::Service
+impl core::marker::Unpin for bpfman_csi::v1::plugin_capability::Service
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::plugin_capability::Service
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::plugin_capability::Service
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::plugin_capability::Service where U: core::convert::From<T>
+pub fn bpfman_csi::v1::plugin_capability::Service::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::plugin_capability::Service where U: core::convert::Into<T>
+pub type bpfman_csi::v1::plugin_capability::Service::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::plugin_capability::Service::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::plugin_capability::Service where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::plugin_capability::Service::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::plugin_capability::Service::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::plugin_capability::Service where T: core::clone::Clone
+pub type bpfman_csi::v1::plugin_capability::Service::Owned = T
+pub fn bpfman_csi::v1::plugin_capability::Service::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::plugin_capability::Service::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::plugin_capability::Service where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Service::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::plugin_capability::Service where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Service::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::plugin_capability::Service where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::Service::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::plugin_capability::Service
+pub fn bpfman_csi::v1::plugin_capability::Service::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::plugin_capability::Service
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::plugin_capability::Service
+pub struct bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub bpfman_csi::v1::plugin_capability::VolumeExpansion::type: i32
+impl bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::set_type(&mut self, value: bpfman_csi::v1::plugin_capability::volume_expansion::Type)
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::type(&self) -> bpfman_csi::v1::plugin_capability::volume_expansion::Type
+impl core::clone::Clone for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::clone(&self) -> bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::cmp::PartialEq for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::eq(&self, other: &bpfman_csi::v1::plugin_capability::VolumeExpansion) -> bool
+impl core::default::Default for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl prost::message::Message for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::clear(&mut self)
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::marker::Send for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::marker::Sync for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::marker::Unpin for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::plugin_capability::VolumeExpansion where U: core::convert::From<T>
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::plugin_capability::VolumeExpansion where U: core::convert::Into<T>
+pub type bpfman_csi::v1::plugin_capability::VolumeExpansion::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::plugin_capability::VolumeExpansion where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::plugin_capability::VolumeExpansion::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::plugin_capability::VolumeExpansion where T: core::clone::Clone
+pub type bpfman_csi::v1::plugin_capability::VolumeExpansion::Owned = T
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::plugin_capability::VolumeExpansion where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::plugin_capability::VolumeExpansion where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::plugin_capability::VolumeExpansion where T: core::marker::Sized
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub fn bpfman_csi::v1::plugin_capability::VolumeExpansion::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::plugin_capability::VolumeExpansion
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::plugin_capability::VolumeExpansion
+pub mod bpfman_csi::v1::validate_volume_capabilities_response
+pub struct bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::mutable_parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::volume_capabilities: alloc::vec::Vec<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::clone(&self) -> bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::cmp::PartialEq for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::eq(&self, other: &bpfman_csi::v1::validate_volume_capabilities_response::Confirmed) -> bool
+impl core::default::Default for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl prost::message::Message for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::clear(&mut self)
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::marker::Send for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::marker::Sync for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::marker::Unpin for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where U: core::convert::From<T>
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where U: core::convert::Into<T>
+pub type bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where T: core::clone::Clone
+pub type bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::Owned = T
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where T: core::marker::Sized
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed where T: core::marker::Sized
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub fn bpfman_csi::v1::validate_volume_capabilities_response::Confirmed::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::validate_volume_capabilities_response::Confirmed
+pub mod bpfman_csi::v1::volume_capability
+pub mod bpfman_csi::v1::volume_capability::access_mode
+#[repr(i32)] pub enum bpfman_csi::v1::volume_capability::access_mode::Mode
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::MultiNodeMultiWriter = 5
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::MultiNodeReaderOnly = 3
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::MultiNodeSingleWriter = 4
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::SingleNodeMultiWriter = 7
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::SingleNodeReaderOnly = 2
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::SingleNodeSingleWriter = 6
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::SingleNodeWriter = 1
+pub bpfman_csi::v1::volume_capability::access_mode::Mode::Unknown = 0
+impl bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::volume_capability::access_mode::Mode>
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::clone(&self) -> bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::cmp::Eq for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::cmp::Ord for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::cmp(&self, other: &bpfman_csi::v1::volume_capability::access_mode::Mode) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::eq(&self, other: &bpfman_csi::v1::volume_capability::access_mode::Mode) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::partial_cmp(&self, other: &bpfman_csi::v1::volume_capability::access_mode::Mode) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::volume_capability::access_mode::Mode> for i32
+pub fn i32::from(value: bpfman_csi::v1::volume_capability::access_mode::Mode) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub type bpfman_csi::v1::volume_capability::access_mode::Mode::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::volume_capability::access_mode::Mode, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::default() -> bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::fmt::Debug for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::marker::Freeze for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::marker::Send for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::marker::Sync for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::marker::Unpin for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_capability::access_mode::Mode where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_capability::access_mode::Mode where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_capability::access_mode::Mode::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_capability::access_mode::Mode where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_capability::access_mode::Mode::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_capability::access_mode::Mode where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_capability::access_mode::Mode::Owned = T
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_capability::access_mode::Mode where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_capability::access_mode::Mode where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_capability::access_mode::Mode where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::access_mode::Mode::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_capability::access_mode::Mode
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_capability::access_mode::Mode
+pub enum bpfman_csi::v1::volume_capability::AccessType
+pub bpfman_csi::v1::volume_capability::AccessType::Block(bpfman_csi::v1::volume_capability::BlockVolume)
+pub bpfman_csi::v1::volume_capability::AccessType::Mount(bpfman_csi::v1::volume_capability::MountVolume)
+impl bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::volume_capability::AccessType::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::volume_capability::AccessType::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::volume_capability::AccessType>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::clone(&self) -> bpfman_csi::v1::volume_capability::AccessType
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::eq(&self, other: &bpfman_csi::v1::volume_capability::AccessType) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_capability::AccessType
+impl core::marker::Freeze for bpfman_csi::v1::volume_capability::AccessType
+impl core::marker::Send for bpfman_csi::v1::volume_capability::AccessType
+impl core::marker::Sync for bpfman_csi::v1::volume_capability::AccessType
+impl core::marker::Unpin for bpfman_csi::v1::volume_capability::AccessType
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_capability::AccessType
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_capability::AccessType
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_capability::AccessType where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_capability::AccessType::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_capability::AccessType where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_capability::AccessType::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_capability::AccessType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_capability::AccessType where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_capability::AccessType::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_capability::AccessType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_capability::AccessType where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_capability::AccessType::Owned = T
+pub fn bpfman_csi::v1::volume_capability::AccessType::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_capability::AccessType::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_capability::AccessType where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessType::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_capability::AccessType where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessType::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_capability::AccessType where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessType::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_capability::AccessType
+pub fn bpfman_csi::v1::volume_capability::AccessType::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_capability::AccessType
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_capability::AccessType
+pub struct bpfman_csi::v1::volume_capability::AccessMode
+pub bpfman_csi::v1::volume_capability::AccessMode::mode: i32
+impl bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::mode(&self) -> bpfman_csi::v1::volume_capability::access_mode::Mode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::set_mode(&mut self, value: bpfman_csi::v1::volume_capability::access_mode::Mode)
+impl core::clone::Clone for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::clone(&self) -> bpfman_csi::v1::volume_capability::AccessMode
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::eq(&self, other: &bpfman_csi::v1::volume_capability::AccessMode) -> bool
+impl core::default::Default for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_capability::AccessMode
+impl prost::message::Message for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::clear(&mut self)
+pub fn bpfman_csi::v1::volume_capability::AccessMode::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::volume_capability::AccessMode
+impl core::marker::Send for bpfman_csi::v1::volume_capability::AccessMode
+impl core::marker::Sync for bpfman_csi::v1::volume_capability::AccessMode
+impl core::marker::Unpin for bpfman_csi::v1::volume_capability::AccessMode
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_capability::AccessMode
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_capability::AccessMode
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_capability::AccessMode where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_capability::AccessMode::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_capability::AccessMode where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_capability::AccessMode::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_capability::AccessMode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_capability::AccessMode where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_capability::AccessMode::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_capability::AccessMode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_capability::AccessMode where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_capability::AccessMode::Owned = T
+pub fn bpfman_csi::v1::volume_capability::AccessMode::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_capability::AccessMode::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_capability::AccessMode where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessMode::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_capability::AccessMode where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessMode::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_capability::AccessMode where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::AccessMode::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_capability::AccessMode
+pub fn bpfman_csi::v1::volume_capability::AccessMode::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_capability::AccessMode
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_capability::AccessMode
+pub struct bpfman_csi::v1::volume_capability::BlockVolume
+impl core::clone::Clone for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::clone(&self) -> bpfman_csi::v1::volume_capability::BlockVolume
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::eq(&self, other: &bpfman_csi::v1::volume_capability::BlockVolume) -> bool
+impl core::default::Default for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_capability::BlockVolume
+impl prost::message::Message for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::clear(&mut self)
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::volume_capability::BlockVolume
+impl core::marker::Send for bpfman_csi::v1::volume_capability::BlockVolume
+impl core::marker::Sync for bpfman_csi::v1::volume_capability::BlockVolume
+impl core::marker::Unpin for bpfman_csi::v1::volume_capability::BlockVolume
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_capability::BlockVolume
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_capability::BlockVolume
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_capability::BlockVolume where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_capability::BlockVolume where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_capability::BlockVolume::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_capability::BlockVolume where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_capability::BlockVolume::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_capability::BlockVolume where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_capability::BlockVolume::Owned = T
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_capability::BlockVolume where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_capability::BlockVolume where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_capability::BlockVolume where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_capability::BlockVolume
+pub fn bpfman_csi::v1::volume_capability::BlockVolume::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_capability::BlockVolume
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_capability::BlockVolume
+pub struct bpfman_csi::v1::volume_capability::MountVolume
+pub bpfman_csi::v1::volume_capability::MountVolume::fs_type: alloc::string::String
+pub bpfman_csi::v1::volume_capability::MountVolume::mount_flags: alloc::vec::Vec<alloc::string::String>
+pub bpfman_csi::v1::volume_capability::MountVolume::volume_mount_group: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::clone(&self) -> bpfman_csi::v1::volume_capability::MountVolume
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::eq(&self, other: &bpfman_csi::v1::volume_capability::MountVolume) -> bool
+impl core::default::Default for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_capability::MountVolume
+impl prost::message::Message for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::clear(&mut self)
+pub fn bpfman_csi::v1::volume_capability::MountVolume::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::volume_capability::MountVolume
+impl core::marker::Send for bpfman_csi::v1::volume_capability::MountVolume
+impl core::marker::Sync for bpfman_csi::v1::volume_capability::MountVolume
+impl core::marker::Unpin for bpfman_csi::v1::volume_capability::MountVolume
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_capability::MountVolume
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_capability::MountVolume
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_capability::MountVolume where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_capability::MountVolume::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_capability::MountVolume where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_capability::MountVolume::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_capability::MountVolume::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_capability::MountVolume where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_capability::MountVolume::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_capability::MountVolume::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_capability::MountVolume where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_capability::MountVolume::Owned = T
+pub fn bpfman_csi::v1::volume_capability::MountVolume::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_capability::MountVolume::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_capability::MountVolume where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::MountVolume::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_capability::MountVolume where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::MountVolume::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_capability::MountVolume where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_capability::MountVolume::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_capability::MountVolume
+pub fn bpfman_csi::v1::volume_capability::MountVolume::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_capability::MountVolume
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_capability::MountVolume
+pub mod bpfman_csi::v1::volume_content_source
+pub enum bpfman_csi::v1::volume_content_source::Type
+pub bpfman_csi::v1::volume_content_source::Type::Snapshot(bpfman_csi::v1::volume_content_source::SnapshotSource)
+pub bpfman_csi::v1::volume_content_source::Type::Volume(bpfman_csi::v1::volume_content_source::VolumeSource)
+impl bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::encode<B>(&self, buf: &mut B) where B: bytes::buf::buf_mut::BufMut
+pub fn bpfman_csi::v1::volume_content_source::Type::encoded_len(&self) -> usize
+pub fn bpfman_csi::v1::volume_content_source::Type::merge<B>(field: &mut core::option::Option<bpfman_csi::v1::volume_content_source::Type>, tag: u32, wire_type: prost::encoding::WireType, buf: &mut B, ctx: prost::encoding::DecodeContext) -> core::result::Result<(), prost::error::DecodeError> where B: bytes::buf::buf_impl::Buf
+impl core::clone::Clone for bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::clone(&self) -> bpfman_csi::v1::volume_content_source::Type
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::eq(&self, other: &bpfman_csi::v1::volume_content_source::Type) -> bool
+impl core::fmt::Debug for bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_content_source::Type
+impl core::marker::Freeze for bpfman_csi::v1::volume_content_source::Type
+impl core::marker::Send for bpfman_csi::v1::volume_content_source::Type
+impl core::marker::Sync for bpfman_csi::v1::volume_content_source::Type
+impl core::marker::Unpin for bpfman_csi::v1::volume_content_source::Type
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_content_source::Type
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_content_source::Type
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_content_source::Type where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_content_source::Type::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_content_source::Type where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_content_source::Type::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_content_source::Type::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_content_source::Type where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_content_source::Type::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_content_source::Type::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_content_source::Type where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_content_source::Type::Owned = T
+pub fn bpfman_csi::v1::volume_content_source::Type::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_content_source::Type::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_content_source::Type where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::Type::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_content_source::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::Type::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_content_source::Type where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::Type::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_content_source::Type
+pub fn bpfman_csi::v1::volume_content_source::Type::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_content_source::Type
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_content_source::Type
+pub struct bpfman_csi::v1::volume_content_source::SnapshotSource
+pub bpfman_csi::v1::volume_content_source::SnapshotSource::snapshot_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::clone(&self) -> bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::eq(&self, other: &bpfman_csi::v1::volume_content_source::SnapshotSource) -> bool
+impl core::default::Default for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl prost::message::Message for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::clear(&mut self)
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::marker::Send for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::marker::Sync for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::marker::Unpin for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_content_source::SnapshotSource where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_content_source::SnapshotSource where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_content_source::SnapshotSource::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_content_source::SnapshotSource where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_content_source::SnapshotSource::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_content_source::SnapshotSource where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_content_source::SnapshotSource::Owned = T
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_content_source::SnapshotSource where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_content_source::SnapshotSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_content_source::SnapshotSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub fn bpfman_csi::v1::volume_content_source::SnapshotSource::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_content_source::SnapshotSource
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_content_source::SnapshotSource
+pub struct bpfman_csi::v1::volume_content_source::VolumeSource
+pub bpfman_csi::v1::volume_content_source::VolumeSource::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::clone(&self) -> bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::eq(&self, other: &bpfman_csi::v1::volume_content_source::VolumeSource) -> bool
+impl core::default::Default for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_content_source::VolumeSource
+impl prost::message::Message for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::clear(&mut self)
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::marker::Send for bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::marker::Sync for bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::marker::Unpin for bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_content_source::VolumeSource
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_content_source::VolumeSource
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_content_source::VolumeSource where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_content_source::VolumeSource where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_content_source::VolumeSource::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_content_source::VolumeSource where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_content_source::VolumeSource::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_content_source::VolumeSource where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_content_source::VolumeSource::Owned = T
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_content_source::VolumeSource where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_content_source::VolumeSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_content_source::VolumeSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_content_source::VolumeSource
+pub fn bpfman_csi::v1::volume_content_source::VolumeSource::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_content_source::VolumeSource
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_content_source::VolumeSource
+pub mod bpfman_csi::v1::volume_usage
+#[repr(i32)] pub enum bpfman_csi::v1::volume_usage::Unit
+pub bpfman_csi::v1::volume_usage::Unit::Bytes = 1
+pub bpfman_csi::v1::volume_usage::Unit::Inodes = 2
+pub bpfman_csi::v1::volume_usage::Unit::Unknown = 0
+impl bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::as_str_name(&self) -> &'static str
+pub fn bpfman_csi::v1::volume_usage::Unit::from_str_name(value: &str) -> core::option::Option<Self>
+impl bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::from_i32(value: i32) -> core::option::Option<bpfman_csi::v1::volume_usage::Unit>
+pub fn bpfman_csi::v1::volume_usage::Unit::is_valid(value: i32) -> bool
+impl core::clone::Clone for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::clone(&self) -> bpfman_csi::v1::volume_usage::Unit
+impl core::cmp::Eq for bpfman_csi::v1::volume_usage::Unit
+impl core::cmp::Ord for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::cmp(&self, other: &bpfman_csi::v1::volume_usage::Unit) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::eq(&self, other: &bpfman_csi::v1::volume_usage::Unit) -> bool
+impl core::cmp::PartialOrd for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::partial_cmp(&self, other: &bpfman_csi::v1::volume_usage::Unit) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<bpfman_csi::v1::volume_usage::Unit> for i32
+pub fn i32::from(value: bpfman_csi::v1::volume_usage::Unit) -> i32
+impl core::convert::TryFrom<i32> for bpfman_csi::v1::volume_usage::Unit
+pub type bpfman_csi::v1::volume_usage::Unit::Error = prost::error::DecodeError
+pub fn bpfman_csi::v1::volume_usage::Unit::try_from(value: i32) -> core::result::Result<bpfman_csi::v1::volume_usage::Unit, prost::error::DecodeError>
+impl core::default::Default for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::default() -> bpfman_csi::v1::volume_usage::Unit
+impl core::fmt::Debug for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman_csi::v1::volume_usage::Unit
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::volume_usage::Unit
+impl core::marker::Freeze for bpfman_csi::v1::volume_usage::Unit
+impl core::marker::Send for bpfman_csi::v1::volume_usage::Unit
+impl core::marker::Sync for bpfman_csi::v1::volume_usage::Unit
+impl core::marker::Unpin for bpfman_csi::v1::volume_usage::Unit
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::volume_usage::Unit
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::volume_usage::Unit
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::volume_usage::Unit where U: core::convert::From<T>
+pub fn bpfman_csi::v1::volume_usage::Unit::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::volume_usage::Unit where U: core::convert::Into<T>
+pub type bpfman_csi::v1::volume_usage::Unit::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::volume_usage::Unit::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::volume_usage::Unit where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::volume_usage::Unit::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::volume_usage::Unit::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::volume_usage::Unit where T: core::clone::Clone
+pub type bpfman_csi::v1::volume_usage::Unit::Owned = T
+pub fn bpfman_csi::v1::volume_usage::Unit::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::volume_usage::Unit::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::volume_usage::Unit where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::volume_usage::Unit::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::volume_usage::Unit where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_usage::Unit::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::volume_usage::Unit where T: core::marker::Sized
+pub fn bpfman_csi::v1::volume_usage::Unit::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::volume_usage::Unit
+pub fn bpfman_csi::v1::volume_usage::Unit::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::volume_usage::Unit
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::volume_usage::Unit
+pub struct bpfman_csi::v1::CapacityRange
+pub bpfman_csi::v1::CapacityRange::limit_bytes: i64
+pub bpfman_csi::v1::CapacityRange::required_bytes: i64
+impl core::clone::Clone for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::clone(&self) -> bpfman_csi::v1::CapacityRange
+impl core::cmp::PartialEq for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::eq(&self, other: &bpfman_csi::v1::CapacityRange) -> bool
+impl core::default::Default for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CapacityRange
+impl prost::message::Message for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::clear(&mut self)
+pub fn bpfman_csi::v1::CapacityRange::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CapacityRange
+impl core::marker::Send for bpfman_csi::v1::CapacityRange
+impl core::marker::Sync for bpfman_csi::v1::CapacityRange
+impl core::marker::Unpin for bpfman_csi::v1::CapacityRange
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CapacityRange
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CapacityRange
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CapacityRange where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CapacityRange::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CapacityRange where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CapacityRange::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CapacityRange::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CapacityRange where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CapacityRange::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CapacityRange::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CapacityRange where T: core::clone::Clone
+pub type bpfman_csi::v1::CapacityRange::Owned = T
+pub fn bpfman_csi::v1::CapacityRange::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CapacityRange::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CapacityRange where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CapacityRange::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CapacityRange where T: core::marker::Sized
+pub fn bpfman_csi::v1::CapacityRange::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CapacityRange where T: core::marker::Sized
+pub fn bpfman_csi::v1::CapacityRange::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CapacityRange
+pub fn bpfman_csi::v1::CapacityRange::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CapacityRange
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CapacityRange
+pub struct bpfman_csi::v1::ControllerExpandVolumeRequest
+pub bpfman_csi::v1::ControllerExpandVolumeRequest::capacity_range: core::option::Option<bpfman_csi::v1::CapacityRange>
+pub bpfman_csi::v1::ControllerExpandVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerExpandVolumeRequest::volume_capability: core::option::Option<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::ControllerExpandVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::clone(&self) -> bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::eq(&self, other: &bpfman_csi::v1::ControllerExpandVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerExpandVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerExpandVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerExpandVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerExpandVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerExpandVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerExpandVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerExpandVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerExpandVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerExpandVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerExpandVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub fn bpfman_csi::v1::ControllerExpandVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerExpandVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerExpandVolumeRequest
+pub struct bpfman_csi::v1::ControllerExpandVolumeResponse
+pub bpfman_csi::v1::ControllerExpandVolumeResponse::capacity_bytes: i64
+pub bpfman_csi::v1::ControllerExpandVolumeResponse::node_expansion_required: bool
+impl core::clone::Clone for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::clone(&self) -> bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::eq(&self, other: &bpfman_csi::v1::ControllerExpandVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerExpandVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerExpandVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerExpandVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerExpandVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerExpandVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerExpandVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerExpandVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerExpandVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerExpandVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerExpandVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub fn bpfman_csi::v1::ControllerExpandVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerExpandVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerExpandVolumeResponse
+pub struct bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::clone::Clone for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::clone(&self) -> bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::eq(&self, other: &bpfman_csi::v1::ControllerGetCapabilitiesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerGetCapabilitiesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerGetCapabilitiesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerGetCapabilitiesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerGetCapabilitiesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerGetCapabilitiesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerGetCapabilitiesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerGetCapabilitiesRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerGetCapabilitiesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerGetCapabilitiesRequest
+pub struct bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub bpfman_csi::v1::ControllerGetCapabilitiesResponse::capabilities: alloc::vec::Vec<bpfman_csi::v1::ControllerServiceCapability>
+impl core::clone::Clone for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::clone(&self) -> bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::eq(&self, other: &bpfman_csi::v1::ControllerGetCapabilitiesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerGetCapabilitiesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerGetCapabilitiesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerGetCapabilitiesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerGetCapabilitiesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerGetCapabilitiesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerGetCapabilitiesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerGetCapabilitiesResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerGetCapabilitiesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::ControllerGetCapabilitiesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerGetCapabilitiesResponse
+pub struct bpfman_csi::v1::ControllerGetVolumeRequest
+pub bpfman_csi::v1::ControllerGetVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::clone(&self) -> bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::eq(&self, other: &bpfman_csi::v1::ControllerGetVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerGetVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerGetVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerGetVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerGetVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerGetVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerGetVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerGetVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerGetVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerGetVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerGetVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerGetVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerGetVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerGetVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerGetVolumeRequest
+pub fn bpfman_csi::v1::ControllerGetVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerGetVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerGetVolumeRequest
+pub struct bpfman_csi::v1::ControllerGetVolumeResponse
+pub bpfman_csi::v1::ControllerGetVolumeResponse::status: core::option::Option<bpfman_csi::v1::controller_get_volume_response::VolumeStatus>
+pub bpfman_csi::v1::ControllerGetVolumeResponse::volume: core::option::Option<bpfman_csi::v1::Volume>
+impl core::clone::Clone for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::clone(&self) -> bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::eq(&self, other: &bpfman_csi::v1::ControllerGetVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerGetVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerGetVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerGetVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerGetVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerGetVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerGetVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerGetVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerGetVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerGetVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerGetVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerGetVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerGetVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerGetVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerGetVolumeResponse
+pub fn bpfman_csi::v1::ControllerGetVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerGetVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerGetVolumeResponse
+pub struct bpfman_csi::v1::ControllerModifyVolumeRequest
+pub bpfman_csi::v1::ControllerModifyVolumeRequest::mutable_parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerModifyVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerModifyVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::clone(&self) -> bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::eq(&self, other: &bpfman_csi::v1::ControllerModifyVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerModifyVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerModifyVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerModifyVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerModifyVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerModifyVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerModifyVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerModifyVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerModifyVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerModifyVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerModifyVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub fn bpfman_csi::v1::ControllerModifyVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerModifyVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerModifyVolumeRequest
+pub struct bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::clone(&self) -> bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::eq(&self, other: &bpfman_csi::v1::ControllerModifyVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerModifyVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerModifyVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerModifyVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerModifyVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerModifyVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerModifyVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerModifyVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerModifyVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerModifyVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerModifyVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub fn bpfman_csi::v1::ControllerModifyVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerModifyVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerModifyVolumeResponse
+pub struct bpfman_csi::v1::ControllerPublishVolumeRequest
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::node_id: alloc::string::String
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::readonly: bool
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::volume_capability: core::option::Option<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerPublishVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::clone(&self) -> bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::eq(&self, other: &bpfman_csi::v1::ControllerPublishVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerPublishVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerPublishVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerPublishVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerPublishVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerPublishVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerPublishVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerPublishVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerPublishVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerPublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerPublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerPublishVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerPublishVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerPublishVolumeRequest
+pub struct bpfman_csi::v1::ControllerPublishVolumeResponse
+pub bpfman_csi::v1::ControllerPublishVolumeResponse::publish_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::clone(&self) -> bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::eq(&self, other: &bpfman_csi::v1::ControllerPublishVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerPublishVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerPublishVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerPublishVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerPublishVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerPublishVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerPublishVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerPublishVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerPublishVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerPublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerPublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerPublishVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerPublishVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerPublishVolumeResponse
+pub struct bpfman_csi::v1::ControllerServiceCapability
+pub bpfman_csi::v1::ControllerServiceCapability::type: core::option::Option<bpfman_csi::v1::controller_service_capability::Type>
+impl core::clone::Clone for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::clone(&self) -> bpfman_csi::v1::ControllerServiceCapability
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::eq(&self, other: &bpfman_csi::v1::ControllerServiceCapability) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerServiceCapability
+impl prost::message::Message for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerServiceCapability::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerServiceCapability
+impl core::marker::Send for bpfman_csi::v1::ControllerServiceCapability
+impl core::marker::Sync for bpfman_csi::v1::ControllerServiceCapability
+impl core::marker::Unpin for bpfman_csi::v1::ControllerServiceCapability
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerServiceCapability
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerServiceCapability
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerServiceCapability where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerServiceCapability::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerServiceCapability where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerServiceCapability::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerServiceCapability::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerServiceCapability where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerServiceCapability::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerServiceCapability::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerServiceCapability where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerServiceCapability::Owned = T
+pub fn bpfman_csi::v1::ControllerServiceCapability::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerServiceCapability::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerServiceCapability where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerServiceCapability::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerServiceCapability::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerServiceCapability::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerServiceCapability
+pub fn bpfman_csi::v1::ControllerServiceCapability::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerServiceCapability
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerServiceCapability
+pub struct bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub bpfman_csi::v1::ControllerUnpublishVolumeRequest::node_id: alloc::string::String
+pub bpfman_csi::v1::ControllerUnpublishVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ControllerUnpublishVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::clone(&self) -> bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::eq(&self, other: &bpfman_csi::v1::ControllerUnpublishVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerUnpublishVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerUnpublishVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerUnpublishVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerUnpublishVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerUnpublishVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerUnpublishVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerUnpublishVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerUnpublishVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerUnpublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerUnpublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerUnpublishVolumeRequest
+pub struct bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::clone(&self) -> bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::eq(&self, other: &bpfman_csi::v1::ControllerUnpublishVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ControllerUnpublishVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ControllerUnpublishVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ControllerUnpublishVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ControllerUnpublishVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ControllerUnpublishVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ControllerUnpublishVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ControllerUnpublishVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ControllerUnpublishVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ControllerUnpublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ControllerUnpublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub fn bpfman_csi::v1::ControllerUnpublishVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ControllerUnpublishVolumeResponse
+pub struct bpfman_csi::v1::CreateSnapshotRequest
+pub bpfman_csi::v1::CreateSnapshotRequest::name: alloc::string::String
+pub bpfman_csi::v1::CreateSnapshotRequest::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateSnapshotRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateSnapshotRequest::source_volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::clone(&self) -> bpfman_csi::v1::CreateSnapshotRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::eq(&self, other: &bpfman_csi::v1::CreateSnapshotRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateSnapshotRequest
+impl prost::message::Message for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::clear(&mut self)
+pub fn bpfman_csi::v1::CreateSnapshotRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateSnapshotRequest
+impl core::marker::Send for bpfman_csi::v1::CreateSnapshotRequest
+impl core::marker::Sync for bpfman_csi::v1::CreateSnapshotRequest
+impl core::marker::Unpin for bpfman_csi::v1::CreateSnapshotRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateSnapshotRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateSnapshotRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateSnapshotRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateSnapshotRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateSnapshotRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateSnapshotRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateSnapshotRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateSnapshotRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateSnapshotRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateSnapshotRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateSnapshotRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateSnapshotRequest::Owned = T
+pub fn bpfman_csi::v1::CreateSnapshotRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateSnapshotRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateSnapshotRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateSnapshotRequest
+pub fn bpfman_csi::v1::CreateSnapshotRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateSnapshotRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateSnapshotRequest
+pub struct bpfman_csi::v1::CreateSnapshotResponse
+pub bpfman_csi::v1::CreateSnapshotResponse::snapshot: core::option::Option<bpfman_csi::v1::Snapshot>
+impl core::clone::Clone for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::clone(&self) -> bpfman_csi::v1::CreateSnapshotResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::eq(&self, other: &bpfman_csi::v1::CreateSnapshotResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateSnapshotResponse
+impl prost::message::Message for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::clear(&mut self)
+pub fn bpfman_csi::v1::CreateSnapshotResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateSnapshotResponse
+impl core::marker::Send for bpfman_csi::v1::CreateSnapshotResponse
+impl core::marker::Sync for bpfman_csi::v1::CreateSnapshotResponse
+impl core::marker::Unpin for bpfman_csi::v1::CreateSnapshotResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateSnapshotResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateSnapshotResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateSnapshotResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateSnapshotResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateSnapshotResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateSnapshotResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateSnapshotResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateSnapshotResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateSnapshotResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateSnapshotResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateSnapshotResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateSnapshotResponse::Owned = T
+pub fn bpfman_csi::v1::CreateSnapshotResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateSnapshotResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateSnapshotResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateSnapshotResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateSnapshotResponse
+pub fn bpfman_csi::v1::CreateSnapshotResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateSnapshotResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateSnapshotResponse
+pub struct bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::name: alloc::string::String
+pub bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::source_volume_ids: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::clone(&self) -> bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::eq(&self, other: &bpfman_csi::v1::CreateVolumeGroupSnapshotRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl prost::message::Message for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::clear(&mut self)
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::marker::Send for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::marker::Sync for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::marker::Unpin for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::Owned = T
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateVolumeGroupSnapshotRequest
+pub struct bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::group_snapshot: core::option::Option<bpfman_csi::v1::VolumeGroupSnapshot>
+impl core::clone::Clone for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::clone(&self) -> bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::eq(&self, other: &bpfman_csi::v1::CreateVolumeGroupSnapshotResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl prost::message::Message for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::clear(&mut self)
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::marker::Send for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::marker::Sync for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::marker::Unpin for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::Owned = T
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::CreateVolumeGroupSnapshotResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateVolumeGroupSnapshotResponse
+pub struct bpfman_csi::v1::CreateVolumeRequest
+pub bpfman_csi::v1::CreateVolumeRequest::accessibility_requirements: core::option::Option<bpfman_csi::v1::TopologyRequirement>
+pub bpfman_csi::v1::CreateVolumeRequest::capacity_range: core::option::Option<bpfman_csi::v1::CapacityRange>
+pub bpfman_csi::v1::CreateVolumeRequest::mutable_parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateVolumeRequest::name: alloc::string::String
+pub bpfman_csi::v1::CreateVolumeRequest::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::CreateVolumeRequest::volume_capabilities: alloc::vec::Vec<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::CreateVolumeRequest::volume_content_source: core::option::Option<bpfman_csi::v1::VolumeContentSource>
+impl core::clone::Clone for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::clone(&self) -> bpfman_csi::v1::CreateVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::eq(&self, other: &bpfman_csi::v1::CreateVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::CreateVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::CreateVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::CreateVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::CreateVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::CreateVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateVolumeRequest
+pub fn bpfman_csi::v1::CreateVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateVolumeRequest
+pub struct bpfman_csi::v1::CreateVolumeResponse
+pub bpfman_csi::v1::CreateVolumeResponse::volume: core::option::Option<bpfman_csi::v1::Volume>
+impl core::clone::Clone for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::clone(&self) -> bpfman_csi::v1::CreateVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::eq(&self, other: &bpfman_csi::v1::CreateVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::CreateVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::CreateVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::CreateVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::CreateVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::CreateVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::CreateVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::CreateVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::CreateVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::CreateVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::CreateVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::CreateVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::CreateVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::CreateVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::CreateVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::CreateVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::CreateVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::CreateVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::CreateVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::CreateVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::CreateVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::CreateVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::CreateVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::CreateVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::CreateVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::CreateVolumeResponse
+pub fn bpfman_csi::v1::CreateVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::CreateVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::CreateVolumeResponse
+pub struct bpfman_csi::v1::DeleteSnapshotRequest
+pub bpfman_csi::v1::DeleteSnapshotRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::DeleteSnapshotRequest::snapshot_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::clone(&self) -> bpfman_csi::v1::DeleteSnapshotRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::eq(&self, other: &bpfman_csi::v1::DeleteSnapshotRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteSnapshotRequest
+impl prost::message::Message for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteSnapshotRequest
+impl core::marker::Send for bpfman_csi::v1::DeleteSnapshotRequest
+impl core::marker::Sync for bpfman_csi::v1::DeleteSnapshotRequest
+impl core::marker::Unpin for bpfman_csi::v1::DeleteSnapshotRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteSnapshotRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteSnapshotRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteSnapshotRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteSnapshotRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteSnapshotRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteSnapshotRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteSnapshotRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteSnapshotRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteSnapshotRequest::Owned = T
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteSnapshotRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteSnapshotRequest
+pub fn bpfman_csi::v1::DeleteSnapshotRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteSnapshotRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteSnapshotRequest
+pub struct bpfman_csi::v1::DeleteSnapshotResponse
+impl core::clone::Clone for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::clone(&self) -> bpfman_csi::v1::DeleteSnapshotResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::eq(&self, other: &bpfman_csi::v1::DeleteSnapshotResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteSnapshotResponse
+impl prost::message::Message for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteSnapshotResponse
+impl core::marker::Send for bpfman_csi::v1::DeleteSnapshotResponse
+impl core::marker::Sync for bpfman_csi::v1::DeleteSnapshotResponse
+impl core::marker::Unpin for bpfman_csi::v1::DeleteSnapshotResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteSnapshotResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteSnapshotResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteSnapshotResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteSnapshotResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteSnapshotResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteSnapshotResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteSnapshotResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteSnapshotResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteSnapshotResponse::Owned = T
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteSnapshotResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteSnapshotResponse
+pub fn bpfman_csi::v1::DeleteSnapshotResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteSnapshotResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteSnapshotResponse
+pub struct bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::group_snapshot_id: alloc::string::String
+pub bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::snapshot_ids: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::clone(&self) -> bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::eq(&self, other: &bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl prost::message::Message for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::marker::Send for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::marker::Sync for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::marker::Unpin for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::Owned = T
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteVolumeGroupSnapshotRequest
+pub struct bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::clone::Clone for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::clone(&self) -> bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::eq(&self, other: &bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl prost::message::Message for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::marker::Send for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::marker::Sync for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::marker::Unpin for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::Owned = T
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteVolumeGroupSnapshotResponse
+pub struct bpfman_csi::v1::DeleteVolumeRequest
+pub bpfman_csi::v1::DeleteVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::DeleteVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::clone(&self) -> bpfman_csi::v1::DeleteVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::eq(&self, other: &bpfman_csi::v1::DeleteVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::DeleteVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::DeleteVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::DeleteVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::DeleteVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteVolumeRequest
+pub fn bpfman_csi::v1::DeleteVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteVolumeRequest
+pub struct bpfman_csi::v1::DeleteVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::clone(&self) -> bpfman_csi::v1::DeleteVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::eq(&self, other: &bpfman_csi::v1::DeleteVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::DeleteVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::DeleteVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::DeleteVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::DeleteVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::DeleteVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::DeleteVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::DeleteVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::DeleteVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::DeleteVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::DeleteVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::DeleteVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::DeleteVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::DeleteVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::DeleteVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::DeleteVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::DeleteVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::DeleteVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::DeleteVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::DeleteVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::DeleteVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::DeleteVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::DeleteVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::DeleteVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::DeleteVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::DeleteVolumeResponse
+pub fn bpfman_csi::v1::DeleteVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::DeleteVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::DeleteVolumeResponse
+pub struct bpfman_csi::v1::GetCapacityRequest
+pub bpfman_csi::v1::GetCapacityRequest::accessible_topology: core::option::Option<bpfman_csi::v1::Topology>
+pub bpfman_csi::v1::GetCapacityRequest::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::GetCapacityRequest::volume_capabilities: alloc::vec::Vec<bpfman_csi::v1::VolumeCapability>
+impl core::clone::Clone for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::clone(&self) -> bpfman_csi::v1::GetCapacityRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::eq(&self, other: &bpfman_csi::v1::GetCapacityRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetCapacityRequest
+impl prost::message::Message for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::clear(&mut self)
+pub fn bpfman_csi::v1::GetCapacityRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetCapacityRequest
+impl core::marker::Send for bpfman_csi::v1::GetCapacityRequest
+impl core::marker::Sync for bpfman_csi::v1::GetCapacityRequest
+impl core::marker::Unpin for bpfman_csi::v1::GetCapacityRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetCapacityRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetCapacityRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetCapacityRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetCapacityRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetCapacityRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetCapacityRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetCapacityRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetCapacityRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetCapacityRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetCapacityRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetCapacityRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::GetCapacityRequest::Owned = T
+pub fn bpfman_csi::v1::GetCapacityRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetCapacityRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetCapacityRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetCapacityRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetCapacityRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetCapacityRequest
+pub fn bpfman_csi::v1::GetCapacityRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetCapacityRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetCapacityRequest
+pub struct bpfman_csi::v1::GetCapacityResponse
+pub bpfman_csi::v1::GetCapacityResponse::available_capacity: i64
+pub bpfman_csi::v1::GetCapacityResponse::maximum_volume_size: core::option::Option<i64>
+pub bpfman_csi::v1::GetCapacityResponse::minimum_volume_size: core::option::Option<i64>
+impl core::clone::Clone for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::clone(&self) -> bpfman_csi::v1::GetCapacityResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::eq(&self, other: &bpfman_csi::v1::GetCapacityResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetCapacityResponse
+impl prost::message::Message for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::clear(&mut self)
+pub fn bpfman_csi::v1::GetCapacityResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetCapacityResponse
+impl core::marker::Send for bpfman_csi::v1::GetCapacityResponse
+impl core::marker::Sync for bpfman_csi::v1::GetCapacityResponse
+impl core::marker::Unpin for bpfman_csi::v1::GetCapacityResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetCapacityResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetCapacityResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetCapacityResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetCapacityResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetCapacityResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetCapacityResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetCapacityResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetCapacityResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetCapacityResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetCapacityResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetCapacityResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::GetCapacityResponse::Owned = T
+pub fn bpfman_csi::v1::GetCapacityResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetCapacityResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetCapacityResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetCapacityResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetCapacityResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetCapacityResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetCapacityResponse
+pub fn bpfman_csi::v1::GetCapacityResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetCapacityResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetCapacityResponse
+pub struct bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::clone::Clone for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::clone(&self) -> bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::eq(&self, other: &bpfman_csi::v1::GetPluginCapabilitiesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl prost::message::Message for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::marker::Send for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::marker::Sync for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::marker::Unpin for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetPluginCapabilitiesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetPluginCapabilitiesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetPluginCapabilitiesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetPluginCapabilitiesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetPluginCapabilitiesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetPluginCapabilitiesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::GetPluginCapabilitiesRequest::Owned = T
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetPluginCapabilitiesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetPluginCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetPluginCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub fn bpfman_csi::v1::GetPluginCapabilitiesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetPluginCapabilitiesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetPluginCapabilitiesRequest
+pub struct bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub bpfman_csi::v1::GetPluginCapabilitiesResponse::capabilities: alloc::vec::Vec<bpfman_csi::v1::PluginCapability>
+impl core::clone::Clone for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::clone(&self) -> bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::eq(&self, other: &bpfman_csi::v1::GetPluginCapabilitiesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl prost::message::Message for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::marker::Send for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::marker::Sync for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::marker::Unpin for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetPluginCapabilitiesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetPluginCapabilitiesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetPluginCapabilitiesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetPluginCapabilitiesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetPluginCapabilitiesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetPluginCapabilitiesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::GetPluginCapabilitiesResponse::Owned = T
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetPluginCapabilitiesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetPluginCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetPluginCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub fn bpfman_csi::v1::GetPluginCapabilitiesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetPluginCapabilitiesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetPluginCapabilitiesResponse
+pub struct bpfman_csi::v1::GetPluginInfoRequest
+impl core::clone::Clone for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::clone(&self) -> bpfman_csi::v1::GetPluginInfoRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::eq(&self, other: &bpfman_csi::v1::GetPluginInfoRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetPluginInfoRequest
+impl prost::message::Message for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::clear(&mut self)
+pub fn bpfman_csi::v1::GetPluginInfoRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetPluginInfoRequest
+impl core::marker::Send for bpfman_csi::v1::GetPluginInfoRequest
+impl core::marker::Sync for bpfman_csi::v1::GetPluginInfoRequest
+impl core::marker::Unpin for bpfman_csi::v1::GetPluginInfoRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetPluginInfoRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetPluginInfoRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetPluginInfoRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetPluginInfoRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetPluginInfoRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetPluginInfoRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetPluginInfoRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetPluginInfoRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetPluginInfoRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetPluginInfoRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetPluginInfoRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::GetPluginInfoRequest::Owned = T
+pub fn bpfman_csi::v1::GetPluginInfoRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetPluginInfoRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetPluginInfoRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetPluginInfoRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetPluginInfoRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetPluginInfoRequest
+pub fn bpfman_csi::v1::GetPluginInfoRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetPluginInfoRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetPluginInfoRequest
+pub struct bpfman_csi::v1::GetPluginInfoResponse
+pub bpfman_csi::v1::GetPluginInfoResponse::manifest: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::GetPluginInfoResponse::name: alloc::string::String
+pub bpfman_csi::v1::GetPluginInfoResponse::vendor_version: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::clone(&self) -> bpfman_csi::v1::GetPluginInfoResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::eq(&self, other: &bpfman_csi::v1::GetPluginInfoResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetPluginInfoResponse
+impl prost::message::Message for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::clear(&mut self)
+pub fn bpfman_csi::v1::GetPluginInfoResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetPluginInfoResponse
+impl core::marker::Send for bpfman_csi::v1::GetPluginInfoResponse
+impl core::marker::Sync for bpfman_csi::v1::GetPluginInfoResponse
+impl core::marker::Unpin for bpfman_csi::v1::GetPluginInfoResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetPluginInfoResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetPluginInfoResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetPluginInfoResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetPluginInfoResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetPluginInfoResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetPluginInfoResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetPluginInfoResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetPluginInfoResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetPluginInfoResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetPluginInfoResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetPluginInfoResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::GetPluginInfoResponse::Owned = T
+pub fn bpfman_csi::v1::GetPluginInfoResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetPluginInfoResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetPluginInfoResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetPluginInfoResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetPluginInfoResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetPluginInfoResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetPluginInfoResponse
+pub fn bpfman_csi::v1::GetPluginInfoResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetPluginInfoResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetPluginInfoResponse
+pub struct bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub bpfman_csi::v1::GetVolumeGroupSnapshotRequest::group_snapshot_id: alloc::string::String
+pub bpfman_csi::v1::GetVolumeGroupSnapshotRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::GetVolumeGroupSnapshotRequest::snapshot_ids: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::clone(&self) -> bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::eq(&self, other: &bpfman_csi::v1::GetVolumeGroupSnapshotRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl prost::message::Message for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::clear(&mut self)
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::marker::Send for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::marker::Sync for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::marker::Unpin for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotRequest::Owned = T
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetVolumeGroupSnapshotRequest
+pub struct bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub bpfman_csi::v1::GetVolumeGroupSnapshotResponse::group_snapshot: core::option::Option<bpfman_csi::v1::VolumeGroupSnapshot>
+impl core::clone::Clone for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::clone(&self) -> bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::eq(&self, other: &bpfman_csi::v1::GetVolumeGroupSnapshotResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl prost::message::Message for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::clear(&mut self)
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::marker::Send for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::marker::Sync for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::marker::Unpin for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::GetVolumeGroupSnapshotResponse::Owned = T
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub fn bpfman_csi::v1::GetVolumeGroupSnapshotResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GetVolumeGroupSnapshotResponse
+pub struct bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::clone::Clone for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::clone(&self) -> bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::eq(&self, other: &bpfman_csi::v1::GroupControllerGetCapabilitiesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl prost::message::Message for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::marker::Send for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::marker::Sync for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::marker::Unpin for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::Owned = T
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GroupControllerGetCapabilitiesRequest
+pub struct bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::capabilities: alloc::vec::Vec<bpfman_csi::v1::GroupControllerServiceCapability>
+impl core::clone::Clone for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::clone(&self) -> bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::eq(&self, other: &bpfman_csi::v1::GroupControllerGetCapabilitiesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl prost::message::Message for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::marker::Send for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::marker::Sync for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::marker::Unpin for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::Owned = T
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub fn bpfman_csi::v1::GroupControllerGetCapabilitiesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GroupControllerGetCapabilitiesResponse
+pub struct bpfman_csi::v1::GroupControllerServiceCapability
+pub bpfman_csi::v1::GroupControllerServiceCapability::type: core::option::Option<bpfman_csi::v1::group_controller_service_capability::Type>
+impl core::clone::Clone for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::clone(&self) -> bpfman_csi::v1::GroupControllerServiceCapability
+impl core::cmp::PartialEq for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::eq(&self, other: &bpfman_csi::v1::GroupControllerServiceCapability) -> bool
+impl core::default::Default for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::GroupControllerServiceCapability
+impl prost::message::Message for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::clear(&mut self)
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::GroupControllerServiceCapability
+impl core::marker::Send for bpfman_csi::v1::GroupControllerServiceCapability
+impl core::marker::Sync for bpfman_csi::v1::GroupControllerServiceCapability
+impl core::marker::Unpin for bpfman_csi::v1::GroupControllerServiceCapability
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::GroupControllerServiceCapability
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::GroupControllerServiceCapability
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::GroupControllerServiceCapability where U: core::convert::From<T>
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::GroupControllerServiceCapability where U: core::convert::Into<T>
+pub type bpfman_csi::v1::GroupControllerServiceCapability::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::GroupControllerServiceCapability where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::GroupControllerServiceCapability::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::GroupControllerServiceCapability where T: core::clone::Clone
+pub type bpfman_csi::v1::GroupControllerServiceCapability::Owned = T
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::GroupControllerServiceCapability where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::GroupControllerServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::GroupControllerServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::GroupControllerServiceCapability
+pub fn bpfman_csi::v1::GroupControllerServiceCapability::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::GroupControllerServiceCapability
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::GroupControllerServiceCapability
+pub struct bpfman_csi::v1::ListSnapshotsRequest
+pub bpfman_csi::v1::ListSnapshotsRequest::max_entries: i32
+pub bpfman_csi::v1::ListSnapshotsRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ListSnapshotsRequest::snapshot_id: alloc::string::String
+pub bpfman_csi::v1::ListSnapshotsRequest::source_volume_id: alloc::string::String
+pub bpfman_csi::v1::ListSnapshotsRequest::starting_token: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::clone(&self) -> bpfman_csi::v1::ListSnapshotsRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::eq(&self, other: &bpfman_csi::v1::ListSnapshotsRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ListSnapshotsRequest
+impl prost::message::Message for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ListSnapshotsRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ListSnapshotsRequest
+impl core::marker::Send for bpfman_csi::v1::ListSnapshotsRequest
+impl core::marker::Sync for bpfman_csi::v1::ListSnapshotsRequest
+impl core::marker::Unpin for bpfman_csi::v1::ListSnapshotsRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ListSnapshotsRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ListSnapshotsRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ListSnapshotsRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ListSnapshotsRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ListSnapshotsRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ListSnapshotsRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ListSnapshotsRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ListSnapshotsRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ListSnapshotsRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ListSnapshotsRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ListSnapshotsRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ListSnapshotsRequest::Owned = T
+pub fn bpfman_csi::v1::ListSnapshotsRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ListSnapshotsRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ListSnapshotsRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ListSnapshotsRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ListSnapshotsRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ListSnapshotsRequest
+pub fn bpfman_csi::v1::ListSnapshotsRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ListSnapshotsRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ListSnapshotsRequest
+pub struct bpfman_csi::v1::ListSnapshotsResponse
+pub bpfman_csi::v1::ListSnapshotsResponse::entries: alloc::vec::Vec<bpfman_csi::v1::list_snapshots_response::Entry>
+pub bpfman_csi::v1::ListSnapshotsResponse::next_token: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::clone(&self) -> bpfman_csi::v1::ListSnapshotsResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::eq(&self, other: &bpfman_csi::v1::ListSnapshotsResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ListSnapshotsResponse
+impl prost::message::Message for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ListSnapshotsResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ListSnapshotsResponse
+impl core::marker::Send for bpfman_csi::v1::ListSnapshotsResponse
+impl core::marker::Sync for bpfman_csi::v1::ListSnapshotsResponse
+impl core::marker::Unpin for bpfman_csi::v1::ListSnapshotsResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ListSnapshotsResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ListSnapshotsResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ListSnapshotsResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ListSnapshotsResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ListSnapshotsResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ListSnapshotsResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ListSnapshotsResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ListSnapshotsResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ListSnapshotsResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ListSnapshotsResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ListSnapshotsResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ListSnapshotsResponse::Owned = T
+pub fn bpfman_csi::v1::ListSnapshotsResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ListSnapshotsResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ListSnapshotsResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ListSnapshotsResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ListSnapshotsResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListSnapshotsResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ListSnapshotsResponse
+pub fn bpfman_csi::v1::ListSnapshotsResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ListSnapshotsResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ListSnapshotsResponse
+pub struct bpfman_csi::v1::ListVolumesRequest
+pub bpfman_csi::v1::ListVolumesRequest::max_entries: i32
+pub bpfman_csi::v1::ListVolumesRequest::starting_token: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::clone(&self) -> bpfman_csi::v1::ListVolumesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::eq(&self, other: &bpfman_csi::v1::ListVolumesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ListVolumesRequest
+impl prost::message::Message for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ListVolumesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ListVolumesRequest
+impl core::marker::Send for bpfman_csi::v1::ListVolumesRequest
+impl core::marker::Sync for bpfman_csi::v1::ListVolumesRequest
+impl core::marker::Unpin for bpfman_csi::v1::ListVolumesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ListVolumesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ListVolumesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ListVolumesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ListVolumesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ListVolumesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ListVolumesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ListVolumesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ListVolumesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ListVolumesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ListVolumesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ListVolumesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ListVolumesRequest::Owned = T
+pub fn bpfman_csi::v1::ListVolumesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ListVolumesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ListVolumesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ListVolumesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ListVolumesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ListVolumesRequest
+pub fn bpfman_csi::v1::ListVolumesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ListVolumesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ListVolumesRequest
+pub struct bpfman_csi::v1::ListVolumesResponse
+pub bpfman_csi::v1::ListVolumesResponse::entries: alloc::vec::Vec<bpfman_csi::v1::list_volumes_response::Entry>
+pub bpfman_csi::v1::ListVolumesResponse::next_token: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::clone(&self) -> bpfman_csi::v1::ListVolumesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::eq(&self, other: &bpfman_csi::v1::ListVolumesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ListVolumesResponse
+impl prost::message::Message for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ListVolumesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ListVolumesResponse
+impl core::marker::Send for bpfman_csi::v1::ListVolumesResponse
+impl core::marker::Sync for bpfman_csi::v1::ListVolumesResponse
+impl core::marker::Unpin for bpfman_csi::v1::ListVolumesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ListVolumesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ListVolumesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ListVolumesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ListVolumesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ListVolumesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ListVolumesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ListVolumesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ListVolumesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ListVolumesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ListVolumesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ListVolumesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ListVolumesResponse::Owned = T
+pub fn bpfman_csi::v1::ListVolumesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ListVolumesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ListVolumesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ListVolumesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ListVolumesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ListVolumesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ListVolumesResponse
+pub fn bpfman_csi::v1::ListVolumesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ListVolumesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ListVolumesResponse
+pub struct bpfman_csi::v1::NodeExpandVolumeRequest
+pub bpfman_csi::v1::NodeExpandVolumeRequest::capacity_range: core::option::Option<bpfman_csi::v1::CapacityRange>
+pub bpfman_csi::v1::NodeExpandVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodeExpandVolumeRequest::staging_target_path: alloc::string::String
+pub bpfman_csi::v1::NodeExpandVolumeRequest::volume_capability: core::option::Option<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::NodeExpandVolumeRequest::volume_id: alloc::string::String
+pub bpfman_csi::v1::NodeExpandVolumeRequest::volume_path: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::clone(&self) -> bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::eq(&self, other: &bpfman_csi::v1::NodeExpandVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeExpandVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeExpandVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeExpandVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeExpandVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeExpandVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeExpandVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeExpandVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeExpandVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeExpandVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeExpandVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeExpandVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeExpandVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeExpandVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeExpandVolumeRequest
+pub fn bpfman_csi::v1::NodeExpandVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeExpandVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeExpandVolumeRequest
+pub struct bpfman_csi::v1::NodeExpandVolumeResponse
+pub bpfman_csi::v1::NodeExpandVolumeResponse::capacity_bytes: i64
+impl core::clone::Clone for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::clone(&self) -> bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::eq(&self, other: &bpfman_csi::v1::NodeExpandVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeExpandVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeExpandVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeExpandVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeExpandVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeExpandVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeExpandVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeExpandVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeExpandVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeExpandVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeExpandVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeExpandVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeExpandVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeExpandVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeExpandVolumeResponse
+pub fn bpfman_csi::v1::NodeExpandVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeExpandVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeExpandVolumeResponse
+pub struct bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::clone::Clone for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::clone(&self) -> bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::eq(&self, other: &bpfman_csi::v1::NodeGetCapabilitiesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl prost::message::Message for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::marker::Send for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetCapabilitiesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetCapabilitiesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetCapabilitiesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetCapabilitiesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetCapabilitiesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetCapabilitiesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetCapabilitiesRequest::Owned = T
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetCapabilitiesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub fn bpfman_csi::v1::NodeGetCapabilitiesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetCapabilitiesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetCapabilitiesRequest
+pub struct bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub bpfman_csi::v1::NodeGetCapabilitiesResponse::capabilities: alloc::vec::Vec<bpfman_csi::v1::NodeServiceCapability>
+impl core::clone::Clone for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::clone(&self) -> bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::eq(&self, other: &bpfman_csi::v1::NodeGetCapabilitiesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl prost::message::Message for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::marker::Send for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetCapabilitiesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetCapabilitiesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetCapabilitiesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetCapabilitiesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetCapabilitiesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetCapabilitiesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetCapabilitiesResponse::Owned = T
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetCapabilitiesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub fn bpfman_csi::v1::NodeGetCapabilitiesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetCapabilitiesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetCapabilitiesResponse
+pub struct bpfman_csi::v1::NodeGetInfoRequest
+impl core::clone::Clone for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::clone(&self) -> bpfman_csi::v1::NodeGetInfoRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::eq(&self, other: &bpfman_csi::v1::NodeGetInfoRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetInfoRequest
+impl prost::message::Message for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetInfoRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetInfoRequest
+impl core::marker::Send for bpfman_csi::v1::NodeGetInfoRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeGetInfoRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetInfoRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetInfoRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetInfoRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetInfoRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetInfoRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetInfoRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetInfoRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetInfoRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetInfoRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetInfoRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetInfoRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetInfoRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetInfoRequest::Owned = T
+pub fn bpfman_csi::v1::NodeGetInfoRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetInfoRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetInfoRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetInfoRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetInfoRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetInfoRequest
+pub fn bpfman_csi::v1::NodeGetInfoRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetInfoRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetInfoRequest
+pub struct bpfman_csi::v1::NodeGetInfoResponse
+pub bpfman_csi::v1::NodeGetInfoResponse::accessible_topology: core::option::Option<bpfman_csi::v1::Topology>
+pub bpfman_csi::v1::NodeGetInfoResponse::max_volumes_per_node: i64
+pub bpfman_csi::v1::NodeGetInfoResponse::node_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::clone(&self) -> bpfman_csi::v1::NodeGetInfoResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::eq(&self, other: &bpfman_csi::v1::NodeGetInfoResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetInfoResponse
+impl prost::message::Message for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetInfoResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetInfoResponse
+impl core::marker::Send for bpfman_csi::v1::NodeGetInfoResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeGetInfoResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetInfoResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetInfoResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetInfoResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetInfoResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetInfoResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetInfoResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetInfoResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetInfoResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetInfoResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetInfoResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetInfoResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetInfoResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetInfoResponse::Owned = T
+pub fn bpfman_csi::v1::NodeGetInfoResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetInfoResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetInfoResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetInfoResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetInfoResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetInfoResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetInfoResponse
+pub fn bpfman_csi::v1::NodeGetInfoResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetInfoResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetInfoResponse
+pub struct bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub bpfman_csi::v1::NodeGetVolumeStatsRequest::staging_target_path: alloc::string::String
+pub bpfman_csi::v1::NodeGetVolumeStatsRequest::volume_id: alloc::string::String
+pub bpfman_csi::v1::NodeGetVolumeStatsRequest::volume_path: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::clone(&self) -> bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::eq(&self, other: &bpfman_csi::v1::NodeGetVolumeStatsRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl prost::message::Message for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::marker::Send for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetVolumeStatsRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetVolumeStatsRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetVolumeStatsRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetVolumeStatsRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetVolumeStatsRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetVolumeStatsRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetVolumeStatsRequest::Owned = T
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetVolumeStatsRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetVolumeStatsRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetVolumeStatsRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub fn bpfman_csi::v1::NodeGetVolumeStatsRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetVolumeStatsRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetVolumeStatsRequest
+pub struct bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub bpfman_csi::v1::NodeGetVolumeStatsResponse::usage: alloc::vec::Vec<bpfman_csi::v1::VolumeUsage>
+pub bpfman_csi::v1::NodeGetVolumeStatsResponse::volume_condition: core::option::Option<bpfman_csi::v1::VolumeCondition>
+impl core::clone::Clone for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::clone(&self) -> bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::eq(&self, other: &bpfman_csi::v1::NodeGetVolumeStatsResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl prost::message::Message for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::marker::Send for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeGetVolumeStatsResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeGetVolumeStatsResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeGetVolumeStatsResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeGetVolumeStatsResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeGetVolumeStatsResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeGetVolumeStatsResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeGetVolumeStatsResponse::Owned = T
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeGetVolumeStatsResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeGetVolumeStatsResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeGetVolumeStatsResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub fn bpfman_csi::v1::NodeGetVolumeStatsResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeGetVolumeStatsResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeGetVolumeStatsResponse
+pub struct bpfman_csi::v1::NodePublishVolumeRequest
+pub bpfman_csi::v1::NodePublishVolumeRequest::publish_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodePublishVolumeRequest::readonly: bool
+pub bpfman_csi::v1::NodePublishVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodePublishVolumeRequest::staging_target_path: alloc::string::String
+pub bpfman_csi::v1::NodePublishVolumeRequest::target_path: alloc::string::String
+pub bpfman_csi::v1::NodePublishVolumeRequest::volume_capability: core::option::Option<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::NodePublishVolumeRequest::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodePublishVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::clone(&self) -> bpfman_csi::v1::NodePublishVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::eq(&self, other: &bpfman_csi::v1::NodePublishVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodePublishVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodePublishVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::NodePublishVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::NodePublishVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodePublishVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodePublishVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodePublishVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodePublishVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodePublishVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodePublishVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodePublishVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodePublishVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodePublishVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodePublishVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodePublishVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodePublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodePublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodePublishVolumeRequest
+pub fn bpfman_csi::v1::NodePublishVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodePublishVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodePublishVolumeRequest
+pub struct bpfman_csi::v1::NodePublishVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::clone(&self) -> bpfman_csi::v1::NodePublishVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::eq(&self, other: &bpfman_csi::v1::NodePublishVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodePublishVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodePublishVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::NodePublishVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::NodePublishVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodePublishVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodePublishVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodePublishVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodePublishVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodePublishVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodePublishVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodePublishVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodePublishVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodePublishVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodePublishVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodePublishVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodePublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodePublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodePublishVolumeResponse
+pub fn bpfman_csi::v1::NodePublishVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodePublishVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodePublishVolumeResponse
+pub struct bpfman_csi::v1::NodeServiceCapability
+pub bpfman_csi::v1::NodeServiceCapability::type: core::option::Option<bpfman_csi::v1::node_service_capability::Type>
+impl core::clone::Clone for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::clone(&self) -> bpfman_csi::v1::NodeServiceCapability
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::eq(&self, other: &bpfman_csi::v1::NodeServiceCapability) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeServiceCapability
+impl prost::message::Message for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::clear(&mut self)
+pub fn bpfman_csi::v1::NodeServiceCapability::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeServiceCapability
+impl core::marker::Send for bpfman_csi::v1::NodeServiceCapability
+impl core::marker::Sync for bpfman_csi::v1::NodeServiceCapability
+impl core::marker::Unpin for bpfman_csi::v1::NodeServiceCapability
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeServiceCapability
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeServiceCapability
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeServiceCapability where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeServiceCapability::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeServiceCapability where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeServiceCapability::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeServiceCapability::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeServiceCapability where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeServiceCapability::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeServiceCapability::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeServiceCapability where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeServiceCapability::Owned = T
+pub fn bpfman_csi::v1::NodeServiceCapability::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeServiceCapability::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeServiceCapability where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeServiceCapability::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeServiceCapability::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeServiceCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeServiceCapability::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeServiceCapability
+pub fn bpfman_csi::v1::NodeServiceCapability::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeServiceCapability
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeServiceCapability
+pub struct bpfman_csi::v1::NodeStageVolumeRequest
+pub bpfman_csi::v1::NodeStageVolumeRequest::publish_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodeStageVolumeRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodeStageVolumeRequest::staging_target_path: alloc::string::String
+pub bpfman_csi::v1::NodeStageVolumeRequest::volume_capability: core::option::Option<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::NodeStageVolumeRequest::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::NodeStageVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::clone(&self) -> bpfman_csi::v1::NodeStageVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::eq(&self, other: &bpfman_csi::v1::NodeStageVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeStageVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeStageVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::NodeStageVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeStageVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeStageVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeStageVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeStageVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeStageVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeStageVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeStageVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeStageVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeStageVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeStageVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeStageVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeStageVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeStageVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeStageVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeStageVolumeRequest
+pub fn bpfman_csi::v1::NodeStageVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeStageVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeStageVolumeRequest
+pub struct bpfman_csi::v1::NodeStageVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::clone(&self) -> bpfman_csi::v1::NodeStageVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::eq(&self, other: &bpfman_csi::v1::NodeStageVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeStageVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeStageVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::NodeStageVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeStageVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeStageVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeStageVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeStageVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeStageVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeStageVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeStageVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeStageVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeStageVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeStageVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeStageVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeStageVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeStageVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeStageVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeStageVolumeResponse
+pub fn bpfman_csi::v1::NodeStageVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeStageVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeStageVolumeResponse
+pub struct bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub bpfman_csi::v1::NodeUnpublishVolumeRequest::target_path: alloc::string::String
+pub bpfman_csi::v1::NodeUnpublishVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::clone(&self) -> bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::eq(&self, other: &bpfman_csi::v1::NodeUnpublishVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeUnpublishVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeUnpublishVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeUnpublishVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeUnpublishVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeUnpublishVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeUnpublishVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeUnpublishVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeUnpublishVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeUnpublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeUnpublishVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub fn bpfman_csi::v1::NodeUnpublishVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeUnpublishVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeUnpublishVolumeRequest
+pub struct bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::clone(&self) -> bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::eq(&self, other: &bpfman_csi::v1::NodeUnpublishVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeUnpublishVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeUnpublishVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeUnpublishVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeUnpublishVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeUnpublishVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeUnpublishVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeUnpublishVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeUnpublishVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeUnpublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeUnpublishVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub fn bpfman_csi::v1::NodeUnpublishVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeUnpublishVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeUnpublishVolumeResponse
+pub struct bpfman_csi::v1::NodeUnstageVolumeRequest
+pub bpfman_csi::v1::NodeUnstageVolumeRequest::staging_target_path: alloc::string::String
+pub bpfman_csi::v1::NodeUnstageVolumeRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::clone(&self) -> bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::eq(&self, other: &bpfman_csi::v1::NodeUnstageVolumeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl prost::message::Message for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::marker::Send for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::marker::Sync for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::marker::Unpin for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeUnstageVolumeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeUnstageVolumeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeUnstageVolumeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeUnstageVolumeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeUnstageVolumeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeUnstageVolumeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeUnstageVolumeRequest::Owned = T
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeUnstageVolumeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeUnstageVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeUnstageVolumeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub fn bpfman_csi::v1::NodeUnstageVolumeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeUnstageVolumeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeUnstageVolumeRequest
+pub struct bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::clone::Clone for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::clone(&self) -> bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::eq(&self, other: &bpfman_csi::v1::NodeUnstageVolumeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl prost::message::Message for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::marker::Send for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::marker::Sync for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::marker::Unpin for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::NodeUnstageVolumeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::NodeUnstageVolumeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::NodeUnstageVolumeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::NodeUnstageVolumeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::NodeUnstageVolumeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::NodeUnstageVolumeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::NodeUnstageVolumeResponse::Owned = T
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::NodeUnstageVolumeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::NodeUnstageVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::NodeUnstageVolumeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub fn bpfman_csi::v1::NodeUnstageVolumeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::NodeUnstageVolumeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::NodeUnstageVolumeResponse
+pub struct bpfman_csi::v1::PluginCapability
+pub bpfman_csi::v1::PluginCapability::type: core::option::Option<bpfman_csi::v1::plugin_capability::Type>
+impl core::clone::Clone for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::clone(&self) -> bpfman_csi::v1::PluginCapability
+impl core::cmp::PartialEq for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::eq(&self, other: &bpfman_csi::v1::PluginCapability) -> bool
+impl core::default::Default for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::PluginCapability
+impl prost::message::Message for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::clear(&mut self)
+pub fn bpfman_csi::v1::PluginCapability::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::PluginCapability
+impl core::marker::Send for bpfman_csi::v1::PluginCapability
+impl core::marker::Sync for bpfman_csi::v1::PluginCapability
+impl core::marker::Unpin for bpfman_csi::v1::PluginCapability
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::PluginCapability
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::PluginCapability
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::PluginCapability where U: core::convert::From<T>
+pub fn bpfman_csi::v1::PluginCapability::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::PluginCapability where U: core::convert::Into<T>
+pub type bpfman_csi::v1::PluginCapability::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::PluginCapability::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::PluginCapability where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::PluginCapability::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::PluginCapability::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::PluginCapability where T: core::clone::Clone
+pub type bpfman_csi::v1::PluginCapability::Owned = T
+pub fn bpfman_csi::v1::PluginCapability::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::PluginCapability::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::PluginCapability where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::PluginCapability::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::PluginCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::PluginCapability::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::PluginCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::PluginCapability::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::PluginCapability
+pub fn bpfman_csi::v1::PluginCapability::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::PluginCapability
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::PluginCapability
+pub struct bpfman_csi::v1::ProbeRequest
+impl core::clone::Clone for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::clone(&self) -> bpfman_csi::v1::ProbeRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::eq(&self, other: &bpfman_csi::v1::ProbeRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ProbeRequest
+impl prost::message::Message for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ProbeRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ProbeRequest
+impl core::marker::Send for bpfman_csi::v1::ProbeRequest
+impl core::marker::Sync for bpfman_csi::v1::ProbeRequest
+impl core::marker::Unpin for bpfman_csi::v1::ProbeRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ProbeRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ProbeRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ProbeRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ProbeRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ProbeRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ProbeRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ProbeRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ProbeRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ProbeRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ProbeRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ProbeRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ProbeRequest::Owned = T
+pub fn bpfman_csi::v1::ProbeRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ProbeRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ProbeRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ProbeRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ProbeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ProbeRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ProbeRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ProbeRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ProbeRequest
+pub fn bpfman_csi::v1::ProbeRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ProbeRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ProbeRequest
+pub struct bpfman_csi::v1::ProbeResponse
+pub bpfman_csi::v1::ProbeResponse::ready: core::option::Option<bool>
+impl core::clone::Clone for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::clone(&self) -> bpfman_csi::v1::ProbeResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::eq(&self, other: &bpfman_csi::v1::ProbeResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ProbeResponse
+impl prost::message::Message for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ProbeResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ProbeResponse
+impl core::marker::Send for bpfman_csi::v1::ProbeResponse
+impl core::marker::Sync for bpfman_csi::v1::ProbeResponse
+impl core::marker::Unpin for bpfman_csi::v1::ProbeResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ProbeResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ProbeResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ProbeResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ProbeResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ProbeResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ProbeResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ProbeResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ProbeResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ProbeResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ProbeResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ProbeResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ProbeResponse::Owned = T
+pub fn bpfman_csi::v1::ProbeResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ProbeResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ProbeResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ProbeResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ProbeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ProbeResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ProbeResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ProbeResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ProbeResponse
+pub fn bpfman_csi::v1::ProbeResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ProbeResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ProbeResponse
+pub struct bpfman_csi::v1::Snapshot
+pub bpfman_csi::v1::Snapshot::creation_time: core::option::Option<prost_types::protobuf::Timestamp>
+pub bpfman_csi::v1::Snapshot::group_snapshot_id: alloc::string::String
+pub bpfman_csi::v1::Snapshot::ready_to_use: bool
+pub bpfman_csi::v1::Snapshot::size_bytes: i64
+pub bpfman_csi::v1::Snapshot::snapshot_id: alloc::string::String
+pub bpfman_csi::v1::Snapshot::source_volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::clone(&self) -> bpfman_csi::v1::Snapshot
+impl core::cmp::PartialEq for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::eq(&self, other: &bpfman_csi::v1::Snapshot) -> bool
+impl core::default::Default for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::Snapshot
+impl prost::message::Message for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::clear(&mut self)
+pub fn bpfman_csi::v1::Snapshot::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::Snapshot
+impl core::marker::Send for bpfman_csi::v1::Snapshot
+impl core::marker::Sync for bpfman_csi::v1::Snapshot
+impl core::marker::Unpin for bpfman_csi::v1::Snapshot
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::Snapshot
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::Snapshot
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::Snapshot where U: core::convert::From<T>
+pub fn bpfman_csi::v1::Snapshot::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::Snapshot where U: core::convert::Into<T>
+pub type bpfman_csi::v1::Snapshot::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::Snapshot::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::Snapshot where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::Snapshot::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::Snapshot::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::Snapshot where T: core::clone::Clone
+pub type bpfman_csi::v1::Snapshot::Owned = T
+pub fn bpfman_csi::v1::Snapshot::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::Snapshot::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::Snapshot where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::Snapshot::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::Snapshot where T: core::marker::Sized
+pub fn bpfman_csi::v1::Snapshot::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::Snapshot where T: core::marker::Sized
+pub fn bpfman_csi::v1::Snapshot::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::Snapshot
+pub fn bpfman_csi::v1::Snapshot::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::Snapshot
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::Snapshot
+pub struct bpfman_csi::v1::Topology
+pub bpfman_csi::v1::Topology::segments: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::clone(&self) -> bpfman_csi::v1::Topology
+impl core::cmp::PartialEq for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::eq(&self, other: &bpfman_csi::v1::Topology) -> bool
+impl core::default::Default for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::Topology
+impl prost::message::Message for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::clear(&mut self)
+pub fn bpfman_csi::v1::Topology::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::Topology
+impl core::marker::Send for bpfman_csi::v1::Topology
+impl core::marker::Sync for bpfman_csi::v1::Topology
+impl core::marker::Unpin for bpfman_csi::v1::Topology
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::Topology
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::Topology
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::Topology where U: core::convert::From<T>
+pub fn bpfman_csi::v1::Topology::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::Topology where U: core::convert::Into<T>
+pub type bpfman_csi::v1::Topology::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::Topology::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::Topology where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::Topology::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::Topology::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::Topology where T: core::clone::Clone
+pub type bpfman_csi::v1::Topology::Owned = T
+pub fn bpfman_csi::v1::Topology::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::Topology::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::Topology where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::Topology::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::Topology where T: core::marker::Sized
+pub fn bpfman_csi::v1::Topology::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::Topology where T: core::marker::Sized
+pub fn bpfman_csi::v1::Topology::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::Topology
+pub fn bpfman_csi::v1::Topology::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::Topology
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::Topology
+pub struct bpfman_csi::v1::TopologyRequirement
+pub bpfman_csi::v1::TopologyRequirement::preferred: alloc::vec::Vec<bpfman_csi::v1::Topology>
+pub bpfman_csi::v1::TopologyRequirement::requisite: alloc::vec::Vec<bpfman_csi::v1::Topology>
+impl core::clone::Clone for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::clone(&self) -> bpfman_csi::v1::TopologyRequirement
+impl core::cmp::PartialEq for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::eq(&self, other: &bpfman_csi::v1::TopologyRequirement) -> bool
+impl core::default::Default for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::TopologyRequirement
+impl prost::message::Message for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::clear(&mut self)
+pub fn bpfman_csi::v1::TopologyRequirement::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::TopologyRequirement
+impl core::marker::Send for bpfman_csi::v1::TopologyRequirement
+impl core::marker::Sync for bpfman_csi::v1::TopologyRequirement
+impl core::marker::Unpin for bpfman_csi::v1::TopologyRequirement
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::TopologyRequirement
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::TopologyRequirement
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::TopologyRequirement where U: core::convert::From<T>
+pub fn bpfman_csi::v1::TopologyRequirement::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::TopologyRequirement where U: core::convert::Into<T>
+pub type bpfman_csi::v1::TopologyRequirement::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::TopologyRequirement::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::TopologyRequirement where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::TopologyRequirement::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::TopologyRequirement::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::TopologyRequirement where T: core::clone::Clone
+pub type bpfman_csi::v1::TopologyRequirement::Owned = T
+pub fn bpfman_csi::v1::TopologyRequirement::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::TopologyRequirement::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::TopologyRequirement where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::TopologyRequirement::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::TopologyRequirement where T: core::marker::Sized
+pub fn bpfman_csi::v1::TopologyRequirement::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::TopologyRequirement where T: core::marker::Sized
+pub fn bpfman_csi::v1::TopologyRequirement::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::TopologyRequirement
+pub fn bpfman_csi::v1::TopologyRequirement::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::TopologyRequirement
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::TopologyRequirement
+pub struct bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::mutable_parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::parameters: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::secrets: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::volume_capabilities: alloc::vec::Vec<bpfman_csi::v1::VolumeCapability>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::clone(&self) -> bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::cmp::PartialEq for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::eq(&self, other: &bpfman_csi::v1::ValidateVolumeCapabilitiesRequest) -> bool
+impl core::default::Default for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl prost::message::Message for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::clear(&mut self)
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::marker::Send for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::marker::Sync for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::marker::Unpin for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where T: core::clone::Clone
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::Owned = T
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest where T: core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesRequest::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ValidateVolumeCapabilitiesRequest
+pub struct bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::confirmed: core::option::Option<bpfman_csi::v1::validate_volume_capabilities_response::Confirmed>
+pub bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::message: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::clone(&self) -> bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::cmp::PartialEq for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::eq(&self, other: &bpfman_csi::v1::ValidateVolumeCapabilitiesResponse) -> bool
+impl core::default::Default for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl prost::message::Message for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::clear(&mut self)
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::marker::Send for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::marker::Sync for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::marker::Unpin for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where U: core::convert::From<T>
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where U: core::convert::Into<T>
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where T: core::clone::Clone
+pub type bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::Owned = T
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse where T: core::marker::Sized
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub fn bpfman_csi::v1::ValidateVolumeCapabilitiesResponse::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::ValidateVolumeCapabilitiesResponse
+pub struct bpfman_csi::v1::Volume
+pub bpfman_csi::v1::Volume::accessible_topology: alloc::vec::Vec<bpfman_csi::v1::Topology>
+pub bpfman_csi::v1::Volume::capacity_bytes: i64
+pub bpfman_csi::v1::Volume::content_source: core::option::Option<bpfman_csi::v1::VolumeContentSource>
+pub bpfman_csi::v1::Volume::volume_context: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bpfman_csi::v1::Volume::volume_id: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::clone(&self) -> bpfman_csi::v1::Volume
+impl core::cmp::PartialEq for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::eq(&self, other: &bpfman_csi::v1::Volume) -> bool
+impl core::default::Default for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::Volume
+impl prost::message::Message for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::clear(&mut self)
+pub fn bpfman_csi::v1::Volume::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::Volume
+impl core::marker::Send for bpfman_csi::v1::Volume
+impl core::marker::Sync for bpfman_csi::v1::Volume
+impl core::marker::Unpin for bpfman_csi::v1::Volume
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::Volume
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::Volume
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::Volume where U: core::convert::From<T>
+pub fn bpfman_csi::v1::Volume::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::Volume where U: core::convert::Into<T>
+pub type bpfman_csi::v1::Volume::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::Volume::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::Volume where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::Volume::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::Volume::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::Volume where T: core::clone::Clone
+pub type bpfman_csi::v1::Volume::Owned = T
+pub fn bpfman_csi::v1::Volume::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::Volume::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::Volume where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::Volume::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::Volume where T: core::marker::Sized
+pub fn bpfman_csi::v1::Volume::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::Volume where T: core::marker::Sized
+pub fn bpfman_csi::v1::Volume::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::Volume
+pub fn bpfman_csi::v1::Volume::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::Volume
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::Volume
+pub struct bpfman_csi::v1::VolumeCapability
+pub bpfman_csi::v1::VolumeCapability::access_mode: core::option::Option<bpfman_csi::v1::volume_capability::AccessMode>
+pub bpfman_csi::v1::VolumeCapability::access_type: core::option::Option<bpfman_csi::v1::volume_capability::AccessType>
+impl core::clone::Clone for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::clone(&self) -> bpfman_csi::v1::VolumeCapability
+impl core::cmp::PartialEq for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::eq(&self, other: &bpfman_csi::v1::VolumeCapability) -> bool
+impl core::default::Default for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::VolumeCapability
+impl prost::message::Message for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::clear(&mut self)
+pub fn bpfman_csi::v1::VolumeCapability::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::VolumeCapability
+impl core::marker::Send for bpfman_csi::v1::VolumeCapability
+impl core::marker::Sync for bpfman_csi::v1::VolumeCapability
+impl core::marker::Unpin for bpfman_csi::v1::VolumeCapability
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::VolumeCapability
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::VolumeCapability
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::VolumeCapability where U: core::convert::From<T>
+pub fn bpfman_csi::v1::VolumeCapability::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::VolumeCapability where U: core::convert::Into<T>
+pub type bpfman_csi::v1::VolumeCapability::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::VolumeCapability::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::VolumeCapability where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::VolumeCapability::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::VolumeCapability::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::VolumeCapability where T: core::clone::Clone
+pub type bpfman_csi::v1::VolumeCapability::Owned = T
+pub fn bpfman_csi::v1::VolumeCapability::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::VolumeCapability::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::VolumeCapability where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCapability::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::VolumeCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCapability::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::VolumeCapability where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCapability::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::VolumeCapability
+pub fn bpfman_csi::v1::VolumeCapability::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::VolumeCapability
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::VolumeCapability
+pub struct bpfman_csi::v1::VolumeCondition
+pub bpfman_csi::v1::VolumeCondition::abnormal: bool
+pub bpfman_csi::v1::VolumeCondition::message: alloc::string::String
+impl core::clone::Clone for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::clone(&self) -> bpfman_csi::v1::VolumeCondition
+impl core::cmp::PartialEq for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::eq(&self, other: &bpfman_csi::v1::VolumeCondition) -> bool
+impl core::default::Default for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::VolumeCondition
+impl prost::message::Message for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::clear(&mut self)
+pub fn bpfman_csi::v1::VolumeCondition::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::VolumeCondition
+impl core::marker::Send for bpfman_csi::v1::VolumeCondition
+impl core::marker::Sync for bpfman_csi::v1::VolumeCondition
+impl core::marker::Unpin for bpfman_csi::v1::VolumeCondition
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::VolumeCondition
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::VolumeCondition
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::VolumeCondition where U: core::convert::From<T>
+pub fn bpfman_csi::v1::VolumeCondition::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::VolumeCondition where U: core::convert::Into<T>
+pub type bpfman_csi::v1::VolumeCondition::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::VolumeCondition::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::VolumeCondition where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::VolumeCondition::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::VolumeCondition::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::VolumeCondition where T: core::clone::Clone
+pub type bpfman_csi::v1::VolumeCondition::Owned = T
+pub fn bpfman_csi::v1::VolumeCondition::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::VolumeCondition::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::VolumeCondition where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCondition::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::VolumeCondition where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCondition::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::VolumeCondition where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeCondition::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::VolumeCondition
+pub fn bpfman_csi::v1::VolumeCondition::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::VolumeCondition
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::VolumeCondition
+pub struct bpfman_csi::v1::VolumeContentSource
+pub bpfman_csi::v1::VolumeContentSource::type: core::option::Option<bpfman_csi::v1::volume_content_source::Type>
+impl core::clone::Clone for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::clone(&self) -> bpfman_csi::v1::VolumeContentSource
+impl core::cmp::PartialEq for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::eq(&self, other: &bpfman_csi::v1::VolumeContentSource) -> bool
+impl core::default::Default for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::VolumeContentSource
+impl prost::message::Message for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::clear(&mut self)
+pub fn bpfman_csi::v1::VolumeContentSource::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::VolumeContentSource
+impl core::marker::Send for bpfman_csi::v1::VolumeContentSource
+impl core::marker::Sync for bpfman_csi::v1::VolumeContentSource
+impl core::marker::Unpin for bpfman_csi::v1::VolumeContentSource
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::VolumeContentSource
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::VolumeContentSource
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::VolumeContentSource where U: core::convert::From<T>
+pub fn bpfman_csi::v1::VolumeContentSource::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::VolumeContentSource where U: core::convert::Into<T>
+pub type bpfman_csi::v1::VolumeContentSource::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::VolumeContentSource::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::VolumeContentSource where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::VolumeContentSource::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::VolumeContentSource::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::VolumeContentSource where T: core::clone::Clone
+pub type bpfman_csi::v1::VolumeContentSource::Owned = T
+pub fn bpfman_csi::v1::VolumeContentSource::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::VolumeContentSource::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::VolumeContentSource where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::VolumeContentSource::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::VolumeContentSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeContentSource::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::VolumeContentSource where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeContentSource::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::VolumeContentSource
+pub fn bpfman_csi::v1::VolumeContentSource::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::VolumeContentSource
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::VolumeContentSource
+pub struct bpfman_csi::v1::VolumeGroupSnapshot
+pub bpfman_csi::v1::VolumeGroupSnapshot::creation_time: core::option::Option<prost_types::protobuf::Timestamp>
+pub bpfman_csi::v1::VolumeGroupSnapshot::group_snapshot_id: alloc::string::String
+pub bpfman_csi::v1::VolumeGroupSnapshot::ready_to_use: bool
+pub bpfman_csi::v1::VolumeGroupSnapshot::snapshots: alloc::vec::Vec<bpfman_csi::v1::Snapshot>
+impl core::clone::Clone for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::clone(&self) -> bpfman_csi::v1::VolumeGroupSnapshot
+impl core::cmp::PartialEq for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::eq(&self, other: &bpfman_csi::v1::VolumeGroupSnapshot) -> bool
+impl core::default::Default for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::VolumeGroupSnapshot
+impl prost::message::Message for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::clear(&mut self)
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::VolumeGroupSnapshot
+impl core::marker::Send for bpfman_csi::v1::VolumeGroupSnapshot
+impl core::marker::Sync for bpfman_csi::v1::VolumeGroupSnapshot
+impl core::marker::Unpin for bpfman_csi::v1::VolumeGroupSnapshot
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::VolumeGroupSnapshot
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::VolumeGroupSnapshot
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::VolumeGroupSnapshot where U: core::convert::From<T>
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::VolumeGroupSnapshot where U: core::convert::Into<T>
+pub type bpfman_csi::v1::VolumeGroupSnapshot::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::VolumeGroupSnapshot where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::VolumeGroupSnapshot::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::VolumeGroupSnapshot where T: core::clone::Clone
+pub type bpfman_csi::v1::VolumeGroupSnapshot::Owned = T
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::VolumeGroupSnapshot where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::VolumeGroupSnapshot where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::VolumeGroupSnapshot where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::VolumeGroupSnapshot
+pub fn bpfman_csi::v1::VolumeGroupSnapshot::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::VolumeGroupSnapshot
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::VolumeGroupSnapshot
+pub struct bpfman_csi::v1::VolumeUsage
+pub bpfman_csi::v1::VolumeUsage::available: i64
+pub bpfman_csi::v1::VolumeUsage::total: i64
+pub bpfman_csi::v1::VolumeUsage::unit: i32
+pub bpfman_csi::v1::VolumeUsage::used: i64
+impl bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::set_unit(&mut self, value: bpfman_csi::v1::volume_usage::Unit)
+pub fn bpfman_csi::v1::VolumeUsage::unit(&self) -> bpfman_csi::v1::volume_usage::Unit
+impl core::clone::Clone for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::clone(&self) -> bpfman_csi::v1::VolumeUsage
+impl core::cmp::PartialEq for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::eq(&self, other: &bpfman_csi::v1::VolumeUsage) -> bool
+impl core::default::Default for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::default() -> Self
+impl core::fmt::Debug for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bpfman_csi::v1::VolumeUsage
+impl prost::message::Message for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::clear(&mut self)
+pub fn bpfman_csi::v1::VolumeUsage::encoded_len(&self) -> usize
+impl core::marker::Freeze for bpfman_csi::v1::VolumeUsage
+impl core::marker::Send for bpfman_csi::v1::VolumeUsage
+impl core::marker::Sync for bpfman_csi::v1::VolumeUsage
+impl core::marker::Unpin for bpfman_csi::v1::VolumeUsage
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman_csi::v1::VolumeUsage
+impl core::panic::unwind_safe::UnwindSafe for bpfman_csi::v1::VolumeUsage
+impl<T, U> core::convert::Into<U> for bpfman_csi::v1::VolumeUsage where U: core::convert::From<T>
+pub fn bpfman_csi::v1::VolumeUsage::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman_csi::v1::VolumeUsage where U: core::convert::Into<T>
+pub type bpfman_csi::v1::VolumeUsage::Error = core::convert::Infallible
+pub fn bpfman_csi::v1::VolumeUsage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman_csi::v1::VolumeUsage where U: core::convert::TryFrom<T>
+pub type bpfman_csi::v1::VolumeUsage::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman_csi::v1::VolumeUsage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman_csi::v1::VolumeUsage where T: core::clone::Clone
+pub type bpfman_csi::v1::VolumeUsage::Owned = T
+pub fn bpfman_csi::v1::VolumeUsage::clone_into(&self, target: &mut T)
+pub fn bpfman_csi::v1::VolumeUsage::to_owned(&self) -> T
+impl<T> core::any::Any for bpfman_csi::v1::VolumeUsage where T: 'static + core::marker::Sized
+pub fn bpfman_csi::v1::VolumeUsage::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman_csi::v1::VolumeUsage where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeUsage::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman_csi::v1::VolumeUsage where T: core::marker::Sized
+pub fn bpfman_csi::v1::VolumeUsage::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::from(t: T) -> T
+impl<T> tonic::request::IntoRequest<T> for bpfman_csi::v1::VolumeUsage
+pub fn bpfman_csi::v1::VolumeUsage::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman_csi::v1::VolumeUsage
+impl<T> tracing::instrument::WithSubscriber for bpfman_csi::v1::VolumeUsage

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -1,0 +1,2202 @@
+pub mod bpfman
+pub mod bpfman::config
+pub enum bpfman::config::XdpMode
+pub bpfman::config::XdpMode::Drv
+pub bpfman::config::XdpMode::Hw
+pub bpfman::config::XdpMode::Skb
+impl bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::as_flags(&self) -> aya::programs::xdp::XdpFlags
+impl core::clone::Clone for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::clone(&self) -> bpfman::config::XdpMode
+impl core::cmp::Eq for bpfman::config::XdpMode
+impl core::cmp::PartialEq for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::eq(&self, other: &bpfman::config::XdpMode) -> bool
+impl core::convert::TryFrom<u32> for bpfman::config::XdpMode
+pub type bpfman::config::XdpMode::Error = bpfman::errors::ParseError
+pub fn bpfman::config::XdpMode::try_from(mode: u32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bpfman::config::XdpMode
+impl core::marker::StructuralPartialEq for bpfman::config::XdpMode
+impl serde::ser::Serialize for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::config::XdpMode
+impl core::marker::Send for bpfman::config::XdpMode
+impl core::marker::Sync for bpfman::config::XdpMode
+impl core::marker::Unpin for bpfman::config::XdpMode
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::config::XdpMode
+impl core::panic::unwind_safe::UnwindSafe for bpfman::config::XdpMode
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::config::XdpMode where C: jwt::ToBase64
+pub fn bpfman::config::XdpMode::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<Q, K> equivalent::Equivalent<K> for bpfman::config::XdpMode where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::config::XdpMode::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for bpfman::config::XdpMode where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::config::XdpMode::equivalent(&self, key: &K) -> bool
+impl<Q, K> indexmap::equivalent::Equivalent<K> for bpfman::config::XdpMode where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::config::XdpMode::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for bpfman::config::XdpMode where U: core::convert::From<T>
+pub fn bpfman::config::XdpMode::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::config::XdpMode where U: core::convert::Into<T>
+pub type bpfman::config::XdpMode::Error = core::convert::Infallible
+pub fn bpfman::config::XdpMode::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::config::XdpMode where U: core::convert::TryFrom<T>
+pub type bpfman::config::XdpMode::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::config::XdpMode::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::config::XdpMode where T: core::clone::Clone
+pub type bpfman::config::XdpMode::Owned = T
+pub fn bpfman::config::XdpMode::clone_into(&self, target: &mut T)
+pub fn bpfman::config::XdpMode::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::config::XdpMode where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::config::XdpMode::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::config::XdpMode where T: core::clone::Clone
+pub fn bpfman::config::XdpMode::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::config::XdpMode where T: 'static + core::marker::Sized
+pub fn bpfman::config::XdpMode::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::config::XdpMode where T: core::marker::Sized
+pub fn bpfman::config::XdpMode::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::config::XdpMode where T: core::marker::Sized
+pub fn bpfman::config::XdpMode::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::config::XdpMode
+pub type bpfman::config::XdpMode::Init = T
+pub const bpfman::config::XdpMode::ALIGN: usize
+pub unsafe fn bpfman::config::XdpMode::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::config::XdpMode::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::config::XdpMode::drop(ptr: usize)
+pub unsafe fn bpfman::config::XdpMode::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::config::XdpMode where T: core::clone::Clone
+pub fn bpfman::config::XdpMode::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::config::XdpMode where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::config::XdpMode::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::config::XdpMode where T: serde::ser::Serialize
+pub fn bpfman::config::XdpMode::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::config::XdpMode where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::config::XdpMode
+pub fn bpfman::config::XdpMode::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::config::XdpMode
+impl<T> tracing::instrument::WithSubscriber for bpfman::config::XdpMode
+impl<T> typenum::type_operators::Same for bpfman::config::XdpMode
+pub type bpfman::config::XdpMode::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::config::XdpMode where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::config::XdpMode::vzip(self) -> V
+pub struct bpfman::config::Config
+pub bpfman::config::Config::database: core::option::Option<bpfman::config::DatabaseConfig>
+pub bpfman::config::Config::interfaces: core::option::Option<std::collections::hash::map::HashMap<alloc::string::String, bpfman::config::InterfaceConfig>>
+pub bpfman::config::Config::signing: core::option::Option<bpfman::config::SigningConfig>
+impl core::clone::Clone for bpfman::config::Config
+pub fn bpfman::config::Config::clone(&self) -> bpfman::config::Config
+impl core::default::Default for bpfman::config::Config
+pub fn bpfman::config::Config::default() -> bpfman::config::Config
+impl core::fmt::Debug for bpfman::config::Config
+pub fn bpfman::config::Config::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::str::traits::FromStr for bpfman::config::Config
+pub type bpfman::config::Config::Err = bpfman::errors::ParseError
+pub fn bpfman::config::Config::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl<'de> serde::de::Deserialize<'de> for bpfman::config::Config
+pub fn bpfman::config::Config::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::config::Config
+impl core::marker::Send for bpfman::config::Config
+impl core::marker::Sync for bpfman::config::Config
+impl core::marker::Unpin for bpfman::config::Config
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::config::Config
+impl core::panic::unwind_safe::UnwindSafe for bpfman::config::Config
+impl<T, U> core::convert::Into<U> for bpfman::config::Config where U: core::convert::From<T>
+pub fn bpfman::config::Config::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::config::Config where U: core::convert::Into<T>
+pub type bpfman::config::Config::Error = core::convert::Infallible
+pub fn bpfman::config::Config::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::config::Config where U: core::convert::TryFrom<T>
+pub type bpfman::config::Config::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::config::Config::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::config::Config where T: core::clone::Clone
+pub type bpfman::config::Config::Owned = T
+pub fn bpfman::config::Config::clone_into(&self, target: &mut T)
+pub fn bpfman::config::Config::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::config::Config where T: core::clone::Clone
+pub fn bpfman::config::Config::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::config::Config where T: 'static + core::marker::Sized
+pub fn bpfman::config::Config::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::config::Config where T: core::marker::Sized
+pub fn bpfman::config::Config::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::config::Config where T: core::marker::Sized
+pub fn bpfman::config::Config::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::config::Config
+pub fn bpfman::config::Config::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::config::Config
+pub type bpfman::config::Config::Init = T
+pub const bpfman::config::Config::ALIGN: usize
+pub unsafe fn bpfman::config::Config::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::config::Config::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::config::Config::drop(ptr: usize)
+pub unsafe fn bpfman::config::Config::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::config::Config where T: core::clone::Clone
+pub fn bpfman::config::Config::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::config::Config where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::config::Config::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> serde::de::DeserializeOwned for bpfman::config::Config where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::config::Config
+pub fn bpfman::config::Config::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::config::Config
+impl<T> tracing::instrument::WithSubscriber for bpfman::config::Config
+impl<T> typenum::type_operators::Same for bpfman::config::Config
+pub type bpfman::config::Config::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::config::Config where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::config::Config::vzip(self) -> V
+pub struct bpfman::config::DatabaseConfig
+pub bpfman::config::DatabaseConfig::max_retries: u32
+pub bpfman::config::DatabaseConfig::millisec_delay: u64
+impl core::clone::Clone for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::clone(&self) -> bpfman::config::DatabaseConfig
+impl core::default::Default for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::default() -> Self
+impl core::fmt::Debug for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde::de::Deserialize<'de> for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::config::DatabaseConfig
+impl core::marker::Send for bpfman::config::DatabaseConfig
+impl core::marker::Sync for bpfman::config::DatabaseConfig
+impl core::marker::Unpin for bpfman::config::DatabaseConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::config::DatabaseConfig
+impl core::panic::unwind_safe::UnwindSafe for bpfman::config::DatabaseConfig
+impl<T, U> core::convert::Into<U> for bpfman::config::DatabaseConfig where U: core::convert::From<T>
+pub fn bpfman::config::DatabaseConfig::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::config::DatabaseConfig where U: core::convert::Into<T>
+pub type bpfman::config::DatabaseConfig::Error = core::convert::Infallible
+pub fn bpfman::config::DatabaseConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::config::DatabaseConfig where U: core::convert::TryFrom<T>
+pub type bpfman::config::DatabaseConfig::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::config::DatabaseConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::config::DatabaseConfig where T: core::clone::Clone
+pub type bpfman::config::DatabaseConfig::Owned = T
+pub fn bpfman::config::DatabaseConfig::clone_into(&self, target: &mut T)
+pub fn bpfman::config::DatabaseConfig::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::config::DatabaseConfig where T: core::clone::Clone
+pub fn bpfman::config::DatabaseConfig::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::config::DatabaseConfig where T: 'static + core::marker::Sized
+pub fn bpfman::config::DatabaseConfig::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::config::DatabaseConfig where T: core::marker::Sized
+pub fn bpfman::config::DatabaseConfig::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::config::DatabaseConfig where T: core::marker::Sized
+pub fn bpfman::config::DatabaseConfig::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::config::DatabaseConfig
+pub type bpfman::config::DatabaseConfig::Init = T
+pub const bpfman::config::DatabaseConfig::ALIGN: usize
+pub unsafe fn bpfman::config::DatabaseConfig::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::config::DatabaseConfig::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::config::DatabaseConfig::drop(ptr: usize)
+pub unsafe fn bpfman::config::DatabaseConfig::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::config::DatabaseConfig where T: core::clone::Clone
+pub fn bpfman::config::DatabaseConfig::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::config::DatabaseConfig where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::config::DatabaseConfig::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> serde::de::DeserializeOwned for bpfman::config::DatabaseConfig where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::config::DatabaseConfig
+pub fn bpfman::config::DatabaseConfig::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::config::DatabaseConfig
+impl<T> tracing::instrument::WithSubscriber for bpfman::config::DatabaseConfig
+impl<T> typenum::type_operators::Same for bpfman::config::DatabaseConfig
+pub type bpfman::config::DatabaseConfig::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::config::DatabaseConfig where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::config::DatabaseConfig::vzip(self) -> V
+pub struct bpfman::config::InterfaceConfig
+pub bpfman::config::InterfaceConfig::xdp_mode: bpfman::config::XdpMode
+impl core::clone::Clone for bpfman::config::InterfaceConfig
+pub fn bpfman::config::InterfaceConfig::clone(&self) -> bpfman::config::InterfaceConfig
+impl core::fmt::Debug for bpfman::config::InterfaceConfig
+pub fn bpfman::config::InterfaceConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bpfman::config::InterfaceConfig
+impl<'de> serde::de::Deserialize<'de> for bpfman::config::InterfaceConfig
+pub fn bpfman::config::InterfaceConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::config::InterfaceConfig
+impl core::marker::Send for bpfman::config::InterfaceConfig
+impl core::marker::Sync for bpfman::config::InterfaceConfig
+impl core::marker::Unpin for bpfman::config::InterfaceConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::config::InterfaceConfig
+impl core::panic::unwind_safe::UnwindSafe for bpfman::config::InterfaceConfig
+impl<T, U> core::convert::Into<U> for bpfman::config::InterfaceConfig where U: core::convert::From<T>
+pub fn bpfman::config::InterfaceConfig::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::config::InterfaceConfig where U: core::convert::Into<T>
+pub type bpfman::config::InterfaceConfig::Error = core::convert::Infallible
+pub fn bpfman::config::InterfaceConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::config::InterfaceConfig where U: core::convert::TryFrom<T>
+pub type bpfman::config::InterfaceConfig::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::config::InterfaceConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::config::InterfaceConfig where T: core::clone::Clone
+pub type bpfman::config::InterfaceConfig::Owned = T
+pub fn bpfman::config::InterfaceConfig::clone_into(&self, target: &mut T)
+pub fn bpfman::config::InterfaceConfig::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::config::InterfaceConfig where T: core::clone::Clone
+pub fn bpfman::config::InterfaceConfig::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::config::InterfaceConfig where T: 'static + core::marker::Sized
+pub fn bpfman::config::InterfaceConfig::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::config::InterfaceConfig where T: core::marker::Sized
+pub fn bpfman::config::InterfaceConfig::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::config::InterfaceConfig where T: core::marker::Sized
+pub fn bpfman::config::InterfaceConfig::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::config::InterfaceConfig
+pub fn bpfman::config::InterfaceConfig::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::config::InterfaceConfig
+pub type bpfman::config::InterfaceConfig::Init = T
+pub const bpfman::config::InterfaceConfig::ALIGN: usize
+pub unsafe fn bpfman::config::InterfaceConfig::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::config::InterfaceConfig::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::config::InterfaceConfig::drop(ptr: usize)
+pub unsafe fn bpfman::config::InterfaceConfig::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::config::InterfaceConfig where T: core::clone::Clone
+pub fn bpfman::config::InterfaceConfig::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::config::InterfaceConfig where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::config::InterfaceConfig::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> serde::de::DeserializeOwned for bpfman::config::InterfaceConfig where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::config::InterfaceConfig
+pub fn bpfman::config::InterfaceConfig::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::config::InterfaceConfig
+impl<T> tracing::instrument::WithSubscriber for bpfman::config::InterfaceConfig
+impl<T> typenum::type_operators::Same for bpfman::config::InterfaceConfig
+pub type bpfman::config::InterfaceConfig::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::config::InterfaceConfig where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::config::InterfaceConfig::vzip(self) -> V
+pub struct bpfman::config::SigningConfig
+pub bpfman::config::SigningConfig::allow_unsigned: bool
+impl core::clone::Clone for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::clone(&self) -> bpfman::config::SigningConfig
+impl core::default::Default for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::default() -> Self
+impl core::fmt::Debug for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde::de::Deserialize<'de> for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::config::SigningConfig
+impl core::marker::Send for bpfman::config::SigningConfig
+impl core::marker::Sync for bpfman::config::SigningConfig
+impl core::marker::Unpin for bpfman::config::SigningConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::config::SigningConfig
+impl core::panic::unwind_safe::UnwindSafe for bpfman::config::SigningConfig
+impl<T, U> core::convert::Into<U> for bpfman::config::SigningConfig where U: core::convert::From<T>
+pub fn bpfman::config::SigningConfig::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::config::SigningConfig where U: core::convert::Into<T>
+pub type bpfman::config::SigningConfig::Error = core::convert::Infallible
+pub fn bpfman::config::SigningConfig::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::config::SigningConfig where U: core::convert::TryFrom<T>
+pub type bpfman::config::SigningConfig::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::config::SigningConfig::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::config::SigningConfig where T: core::clone::Clone
+pub type bpfman::config::SigningConfig::Owned = T
+pub fn bpfman::config::SigningConfig::clone_into(&self, target: &mut T)
+pub fn bpfman::config::SigningConfig::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::config::SigningConfig where T: core::clone::Clone
+pub fn bpfman::config::SigningConfig::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::config::SigningConfig where T: 'static + core::marker::Sized
+pub fn bpfman::config::SigningConfig::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::config::SigningConfig where T: core::marker::Sized
+pub fn bpfman::config::SigningConfig::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::config::SigningConfig where T: core::marker::Sized
+pub fn bpfman::config::SigningConfig::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::config::SigningConfig
+pub type bpfman::config::SigningConfig::Init = T
+pub const bpfman::config::SigningConfig::ALIGN: usize
+pub unsafe fn bpfman::config::SigningConfig::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::config::SigningConfig::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::config::SigningConfig::drop(ptr: usize)
+pub unsafe fn bpfman::config::SigningConfig::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::config::SigningConfig where T: core::clone::Clone
+pub fn bpfman::config::SigningConfig::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::config::SigningConfig where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::config::SigningConfig::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> serde::de::DeserializeOwned for bpfman::config::SigningConfig where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::config::SigningConfig
+pub fn bpfman::config::SigningConfig::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::config::SigningConfig
+impl<T> tracing::instrument::WithSubscriber for bpfman::config::SigningConfig
+impl<T> typenum::type_operators::Same for bpfman::config::SigningConfig
+pub type bpfman::config::SigningConfig::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::config::SigningConfig where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::config::SigningConfig::vzip(self) -> V
+pub mod bpfman::directories
+pub const bpfman::directories::CFGDIR: &str
+pub const bpfman::directories::CFGDIR_MODE: u32 = 3_560u32
+pub const bpfman::directories::CFGDIR_STATIC_PROGRAMS: &str
+pub const bpfman::directories::CFGPATH_BPFMAN_CERTS_KEY: &str
+pub const bpfman::directories::CFGPATH_BPFMAN_CERTS_PEM: &str
+pub const bpfman::directories::CFGPATH_BPFMAN_CLIENT_CERTS_KEY: &str
+pub const bpfman::directories::CFGPATH_BPFMAN_CLIENT_CERTS_PEM: &str
+pub const bpfman::directories::CFGPATH_BPFMAN_CONFIG: &str
+pub const bpfman::directories::CFGPATH_CA_CERTS_KEY: &str
+pub const bpfman::directories::CFGPATH_CA_CERTS_PEM: &str
+pub const bpfman::directories::RTDIR: &str
+pub const bpfman::directories::RTDIR_BPFMAN_CSI: &str
+pub const bpfman::directories::RTDIR_BPFMAN_CSI_FS: &str
+pub const bpfman::directories::RTDIR_FS: &str
+pub const bpfman::directories::RTDIR_FS_MAPS: &str
+pub const bpfman::directories::RTDIR_FS_TC_EGRESS: &str
+pub const bpfman::directories::RTDIR_FS_TC_INGRESS: &str
+pub const bpfman::directories::RTDIR_FS_XDP: &str
+pub const bpfman::directories::RTDIR_MODE: u32 = 3_576u32
+pub const bpfman::directories::RTDIR_PROGRAMS: &str
+pub const bpfman::directories::RTDIR_SOCK: &str
+pub const bpfman::directories::RTDIR_TC_EGRESS_DISPATCHER: &str
+pub const bpfman::directories::RTDIR_TC_INGRESS_DISPATCHER: &str
+pub const bpfman::directories::RTDIR_TUF: &str
+pub const bpfman::directories::RTDIR_XDP_DISPATCHER: &str
+pub const bpfman::directories::RTPATH_BPFMAN_CSI_SOCKET: &str
+pub const bpfman::directories::RTPATH_BPFMAN_SOCKET: &str
+pub const bpfman::directories::STDIR: &str
+pub const bpfman::directories::STDIR_DB: &str
+pub const bpfman::directories::STDIR_MODE: u32 = 3_576u32
+pub mod bpfman::errors
+pub enum bpfman::errors::BpfmanError
+pub bpfman::errors::BpfmanError::BpfBytecodeError(bpfman::oci_utils::ImageError)
+pub bpfman::errors::BpfmanError::BpfFunctionNameNotValid(alloc::string::String)
+pub bpfman::errors::BpfmanError::BpfIOError(std::io::error::Error)
+pub bpfman::errors::BpfmanError::BpfLoadError(aya::bpf::BpfError)
+pub bpfman::errors::BpfmanError::BpfProgramError(aya::programs::ProgramError)
+pub bpfman::errors::BpfmanError::BpfmanProgramDeleteError(anyhow::Error)
+pub bpfman::errors::BpfmanError::BtfError(aya_obj::btf::btf::BtfError)
+pub bpfman::errors::BpfmanError::BytecodeMetaDataMismatch
+pub bpfman::errors::BpfmanError::BytecodeMetaDataMismatch::image_prog_name: alloc::string::String
+pub bpfman::errors::BpfmanError::BytecodeMetaDataMismatch::provided_prog_name: alloc::string::String
+pub bpfman::errors::BpfmanError::ContainerAttachError
+pub bpfman::errors::BpfmanError::ContainerAttachError::container_pid: i32
+pub bpfman::errors::BpfmanError::ContainerAttachError::program_type: alloc::string::String
+pub bpfman::errors::BpfmanError::DatabaseError(alloc::string::String, alloc::string::String)
+pub bpfman::errors::BpfmanError::DatabaseLockError
+pub bpfman::errors::BpfmanError::DispatcherNotRequired
+pub bpfman::errors::BpfmanError::Error(alloc::string::String)
+pub bpfman::errors::BpfmanError::InternalError(alloc::string::String)
+pub bpfman::errors::BpfmanError::InvalidAttach(alloc::string::String)
+pub bpfman::errors::BpfmanError::InvalidInterface
+pub bpfman::errors::BpfmanError::NotLoaded
+pub bpfman::errors::BpfmanError::RpcRecvError(tokio::sync::oneshot::error::RecvError)
+pub bpfman::errors::BpfmanError::RpcSendError(anyhow::Error)
+pub bpfman::errors::BpfmanError::TooManyPrograms
+pub bpfman::errors::BpfmanError::UnableToPinLink(aya::pin::PinError)
+pub bpfman::errors::BpfmanError::UnableToPinMap(aya::pin::PinError)
+pub bpfman::errors::BpfmanError::UnableToPinProgram(aya::pin::PinError)
+impl core::convert::From<anyhow::Error> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: anyhow::Error) -> Self
+impl core::convert::From<aya::bpf::BpfError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: aya::bpf::BpfError) -> Self
+impl core::convert::From<aya::programs::ProgramError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: aya::programs::ProgramError) -> Self
+impl core::convert::From<aya_obj::btf::btf::BtfError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: aya_obj::btf::btf::BtfError) -> Self
+impl core::convert::From<bpfman::oci_utils::ImageError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: bpfman::oci_utils::ImageError) -> Self
+impl core::convert::From<std::io::error::Error> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: std::io::error::Error) -> Self
+impl core::convert::From<tokio::sync::oneshot::error::RecvError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: tokio::sync::oneshot::error::RecvError) -> Self
+impl core::error::Error for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::errors::BpfmanError
+impl core::marker::Send for bpfman::errors::BpfmanError
+impl core::marker::Sync for bpfman::errors::BpfmanError
+impl core::marker::Unpin for bpfman::errors::BpfmanError
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::errors::BpfmanError
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::errors::BpfmanError
+impl<T, U> core::convert::Into<U> for bpfman::errors::BpfmanError where U: core::convert::From<T>
+pub fn bpfman::errors::BpfmanError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::errors::BpfmanError where U: core::convert::Into<T>
+pub type bpfman::errors::BpfmanError::Error = core::convert::Infallible
+pub fn bpfman::errors::BpfmanError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::errors::BpfmanError where U: core::convert::TryFrom<T>
+pub type bpfman::errors::BpfmanError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::errors::BpfmanError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for bpfman::errors::BpfmanError where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::errors::BpfmanError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bpfman::errors::BpfmanError where T: 'static + core::marker::Sized
+pub fn bpfman::errors::BpfmanError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::errors::BpfmanError where T: core::marker::Sized
+pub fn bpfman::errors::BpfmanError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::errors::BpfmanError where T: core::marker::Sized
+pub fn bpfman::errors::BpfmanError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::errors::BpfmanError
+pub type bpfman::errors::BpfmanError::Init = T
+pub const bpfman::errors::BpfmanError::ALIGN: usize
+pub unsafe fn bpfman::errors::BpfmanError::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::errors::BpfmanError::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::errors::BpfmanError::drop(ptr: usize)
+pub unsafe fn bpfman::errors::BpfmanError::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> snafu::AsErrorSource for bpfman::errors::BpfmanError where T: core::error::Error + 'static
+pub fn bpfman::errors::BpfmanError::as_error_source(&self) -> &(dyn core::error::Error + 'static)
+impl<T> tonic::request::IntoRequest<T> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::errors::BpfmanError
+impl<T> tracing::instrument::WithSubscriber for bpfman::errors::BpfmanError
+impl<T> typenum::type_operators::Same for bpfman::errors::BpfmanError
+pub type bpfman::errors::BpfmanError::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::errors::BpfmanError where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::errors::BpfmanError::vzip(self) -> V
+pub enum bpfman::errors::ParseError
+pub bpfman::errors::ParseError::BytecodeLocationParseFailure(url::parser::ParseError)
+pub bpfman::errors::ParseError::ConfigParseError(toml::de::Error)
+pub bpfman::errors::ParseError::InvalidBytecodeImagePullPolicy
+pub bpfman::errors::ParseError::InvalidBytecodeImagePullPolicy::pull_policy: alloc::string::String
+pub bpfman::errors::ParseError::InvalidBytecodeLocation
+pub bpfman::errors::ParseError::InvalidBytecodeLocation::location: alloc::string::String
+pub bpfman::errors::ParseError::InvalidDirection
+pub bpfman::errors::ParseError::InvalidDirection::direction: alloc::string::String
+pub bpfman::errors::ParseError::InvalidProbeType
+pub bpfman::errors::ParseError::InvalidProbeType::probe: alloc::string::String
+pub bpfman::errors::ParseError::InvalidProceedOn
+pub bpfman::errors::ParseError::InvalidProceedOn::proceedon: alloc::string::String
+pub bpfman::errors::ParseError::InvalidProgramType
+pub bpfman::errors::ParseError::InvalidProgramType::program: alloc::string::String
+pub bpfman::errors::ParseError::InvalidXdpMode
+pub bpfman::errors::ParseError::InvalidXdpMode::mode: alloc::string::String
+impl core::convert::From<toml::de::Error> for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::from(source: toml::de::Error) -> Self
+impl core::error::Error for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::errors::ParseError
+impl core::marker::Send for bpfman::errors::ParseError
+impl core::marker::Sync for bpfman::errors::ParseError
+impl core::marker::Unpin for bpfman::errors::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::errors::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bpfman::errors::ParseError
+impl<T, U> core::convert::Into<U> for bpfman::errors::ParseError where U: core::convert::From<T>
+pub fn bpfman::errors::ParseError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::errors::ParseError where U: core::convert::Into<T>
+pub type bpfman::errors::ParseError::Error = core::convert::Infallible
+pub fn bpfman::errors::ParseError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::errors::ParseError where U: core::convert::TryFrom<T>
+pub type bpfman::errors::ParseError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::errors::ParseError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for bpfman::errors::ParseError where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::errors::ParseError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bpfman::errors::ParseError where T: 'static + core::marker::Sized
+pub fn bpfman::errors::ParseError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::errors::ParseError where T: core::marker::Sized
+pub fn bpfman::errors::ParseError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::errors::ParseError where T: core::marker::Sized
+pub fn bpfman::errors::ParseError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::errors::ParseError
+pub type bpfman::errors::ParseError::Init = T
+pub const bpfman::errors::ParseError::ALIGN: usize
+pub unsafe fn bpfman::errors::ParseError::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::errors::ParseError::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::errors::ParseError::drop(ptr: usize)
+pub unsafe fn bpfman::errors::ParseError::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> snafu::AsErrorSource for bpfman::errors::ParseError where T: core::error::Error + 'static
+pub fn bpfman::errors::ParseError::as_error_source(&self) -> &(dyn core::error::Error + 'static)
+impl<T> tonic::request::IntoRequest<T> for bpfman::errors::ParseError
+pub fn bpfman::errors::ParseError::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::errors::ParseError
+impl<T> tracing::instrument::WithSubscriber for bpfman::errors::ParseError
+impl<T> typenum::type_operators::Same for bpfman::errors::ParseError
+pub type bpfman::errors::ParseError::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::errors::ParseError where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::errors::ParseError::vzip(self) -> V
+pub mod bpfman::oci_utils
+pub mod bpfman::oci_utils::image_manager
+pub struct bpfman::oci_utils::image_manager::BytecodeImage
+pub bpfman::oci_utils::image_manager::BytecodeImage::image_pull_policy: bpfman::types::ImagePullPolicy
+pub bpfman::oci_utils::image_manager::BytecodeImage::image_url: alloc::string::String
+pub bpfman::oci_utils::image_manager::BytecodeImage::password: core::option::Option<alloc::string::String>
+pub bpfman::oci_utils::image_manager::BytecodeImage::username: core::option::Option<alloc::string::String>
+impl bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::get_pull_policy(&self) -> &bpfman::types::ImagePullPolicy
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::get_url(&self) -> &str
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::new(image_url: alloc::string::String, image_pull_policy: i32, username: core::option::Option<alloc::string::String>, password: core::option::Option<alloc::string::String>) -> Self
+impl core::clone::Clone for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::clone(&self) -> bpfman::oci_utils::image_manager::BytecodeImage
+impl core::fmt::Debug for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::oci_utils::image_manager::BytecodeImage
+impl core::marker::Send for bpfman::oci_utils::image_manager::BytecodeImage
+impl core::marker::Sync for bpfman::oci_utils::image_manager::BytecodeImage
+impl core::marker::Unpin for bpfman::oci_utils::image_manager::BytecodeImage
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::oci_utils::image_manager::BytecodeImage
+impl core::panic::unwind_safe::UnwindSafe for bpfman::oci_utils::image_manager::BytecodeImage
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::oci_utils::image_manager::BytecodeImage where C: jwt::ToBase64
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::oci_utils::image_manager::BytecodeImage where U: core::convert::From<T>
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::oci_utils::image_manager::BytecodeImage where U: core::convert::Into<T>
+pub type bpfman::oci_utils::image_manager::BytecodeImage::Error = core::convert::Infallible
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::oci_utils::image_manager::BytecodeImage where U: core::convert::TryFrom<T>
+pub type bpfman::oci_utils::image_manager::BytecodeImage::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::oci_utils::image_manager::BytecodeImage where T: core::clone::Clone
+pub type bpfman::oci_utils::image_manager::BytecodeImage::Owned = T
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::clone_into(&self, target: &mut T)
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::oci_utils::image_manager::BytecodeImage where T: core::clone::Clone
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::oci_utils::image_manager::BytecodeImage where T: 'static + core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::oci_utils::image_manager::BytecodeImage where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::oci_utils::image_manager::BytecodeImage where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::oci_utils::image_manager::BytecodeImage
+pub type bpfman::oci_utils::image_manager::BytecodeImage::Init = T
+pub const bpfman::oci_utils::image_manager::BytecodeImage::ALIGN: usize
+pub unsafe fn bpfman::oci_utils::image_manager::BytecodeImage::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::oci_utils::image_manager::BytecodeImage::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::oci_utils::image_manager::BytecodeImage::drop(ptr: usize)
+pub unsafe fn bpfman::oci_utils::image_manager::BytecodeImage::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::oci_utils::image_manager::BytecodeImage where T: core::clone::Clone
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::oci_utils::image_manager::BytecodeImage where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::oci_utils::image_manager::BytecodeImage where T: serde::ser::Serialize
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::oci_utils::image_manager::BytecodeImage where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::oci_utils::image_manager::BytecodeImage
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::oci_utils::image_manager::BytecodeImage
+impl<T> tracing::instrument::WithSubscriber for bpfman::oci_utils::image_manager::BytecodeImage
+impl<T> typenum::type_operators::Same for bpfman::oci_utils::image_manager::BytecodeImage
+pub type bpfman::oci_utils::image_manager::BytecodeImage::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::oci_utils::image_manager::BytecodeImage where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::oci_utils::image_manager::BytecodeImage::vzip(self) -> V
+pub struct bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub bpfman::oci_utils::image_manager::ContainerImageMetadata::bpf_function_name: alloc::string::String
+pub bpfman::oci_utils::image_manager::ContainerImageMetadata::filename: alloc::string::String
+pub bpfman::oci_utils::image_manager::ContainerImageMetadata::name: alloc::string::String
+pub bpfman::oci_utils::image_manager::ContainerImageMetadata::program_type: alloc::string::String
+impl core::default::Default for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::default() -> bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::fmt::Debug for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde::de::Deserialize<'de> for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::marker::Send for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::marker::Sync for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::marker::Unpin for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl core::panic::unwind_safe::UnwindSafe for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl<T, U> core::convert::Into<U> for bpfman::oci_utils::image_manager::ContainerImageMetadata where U: core::convert::From<T>
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::oci_utils::image_manager::ContainerImageMetadata where U: core::convert::Into<T>
+pub type bpfman::oci_utils::image_manager::ContainerImageMetadata::Error = core::convert::Infallible
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::oci_utils::image_manager::ContainerImageMetadata where U: core::convert::TryFrom<T>
+pub type bpfman::oci_utils::image_manager::ContainerImageMetadata::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bpfman::oci_utils::image_manager::ContainerImageMetadata where T: 'static + core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::oci_utils::image_manager::ContainerImageMetadata where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::oci_utils::image_manager::ContainerImageMetadata where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub type bpfman::oci_utils::image_manager::ContainerImageMetadata::Init = T
+pub const bpfman::oci_utils::image_manager::ContainerImageMetadata::ALIGN: usize
+pub unsafe fn bpfman::oci_utils::image_manager::ContainerImageMetadata::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::oci_utils::image_manager::ContainerImageMetadata::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::oci_utils::image_manager::ContainerImageMetadata::drop(ptr: usize)
+pub unsafe fn bpfman::oci_utils::image_manager::ContainerImageMetadata::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> jwt::FromBase64 for bpfman::oci_utils::image_manager::ContainerImageMetadata where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> serde::de::DeserializeOwned for bpfman::oci_utils::image_manager::ContainerImageMetadata where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl<T> tracing::instrument::WithSubscriber for bpfman::oci_utils::image_manager::ContainerImageMetadata
+impl<T> typenum::type_operators::Same for bpfman::oci_utils::image_manager::ContainerImageMetadata
+pub type bpfman::oci_utils::image_manager::ContainerImageMetadata::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::oci_utils::image_manager::ContainerImageMetadata where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::oci_utils::image_manager::ContainerImageMetadata::vzip(self) -> V
+pub struct bpfman::oci_utils::image_manager::ImageManager
+impl bpfman::oci_utils::image_manager::ImageManager
+pub async fn bpfman::oci_utils::image_manager::ImageManager::new(allow_unsigned: bool) -> core::result::Result<Self, anyhow::Error>
+pub async fn bpfman::oci_utils::image_manager::ImageManager::pull_image(&mut self, root_db: &sled::db::Db, image: oci_distribution::reference::Reference, base_key: &str, username: core::option::Option<alloc::string::String>, password: core::option::Option<alloc::string::String>) -> core::result::Result<bpfman::oci_utils::image_manager::ContainerImageMetadata, bpfman::oci_utils::ImageError>
+impl core::marker::Freeze for bpfman::oci_utils::image_manager::ImageManager
+impl core::marker::Send for bpfman::oci_utils::image_manager::ImageManager
+impl core::marker::Sync for bpfman::oci_utils::image_manager::ImageManager
+impl core::marker::Unpin for bpfman::oci_utils::image_manager::ImageManager
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::oci_utils::image_manager::ImageManager
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::oci_utils::image_manager::ImageManager
+impl<T, U> core::convert::Into<U> for bpfman::oci_utils::image_manager::ImageManager where U: core::convert::From<T>
+pub fn bpfman::oci_utils::image_manager::ImageManager::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::oci_utils::image_manager::ImageManager where U: core::convert::Into<T>
+pub type bpfman::oci_utils::image_manager::ImageManager::Error = core::convert::Infallible
+pub fn bpfman::oci_utils::image_manager::ImageManager::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::oci_utils::image_manager::ImageManager where U: core::convert::TryFrom<T>
+pub type bpfman::oci_utils::image_manager::ImageManager::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::oci_utils::image_manager::ImageManager::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bpfman::oci_utils::image_manager::ImageManager where T: 'static + core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ImageManager::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::oci_utils::image_manager::ImageManager where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ImageManager::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::oci_utils::image_manager::ImageManager where T: core::marker::Sized
+pub fn bpfman::oci_utils::image_manager::ImageManager::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::oci_utils::image_manager::ImageManager
+pub fn bpfman::oci_utils::image_manager::ImageManager::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::oci_utils::image_manager::ImageManager
+pub type bpfman::oci_utils::image_manager::ImageManager::Init = T
+pub const bpfman::oci_utils::image_manager::ImageManager::ALIGN: usize
+pub unsafe fn bpfman::oci_utils::image_manager::ImageManager::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::oci_utils::image_manager::ImageManager::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::oci_utils::image_manager::ImageManager::drop(ptr: usize)
+pub unsafe fn bpfman::oci_utils::image_manager::ImageManager::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> tonic::request::IntoRequest<T> for bpfman::oci_utils::image_manager::ImageManager
+pub fn bpfman::oci_utils::image_manager::ImageManager::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::oci_utils::image_manager::ImageManager
+impl<T> tracing::instrument::WithSubscriber for bpfman::oci_utils::image_manager::ImageManager
+impl<T> typenum::type_operators::Same for bpfman::oci_utils::image_manager::ImageManager
+pub type bpfman::oci_utils::image_manager::ImageManager::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::oci_utils::image_manager::ImageManager where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::oci_utils::image_manager::ImageManager::vzip(self) -> V
+pub enum bpfman::oci_utils::ImageError
+pub bpfman::oci_utils::ImageError::ByteCodeImageNotfound(alloc::string::String)
+pub bpfman::oci_utils::ImageError::ByteCodeImageProcessFailure(anyhow::Error)
+pub bpfman::oci_utils::ImageError::BytecodeImageExtractFailure
+pub bpfman::oci_utils::ImageError::BytecodeImagePullFailure(oci_distribution::errors::OciDistributionError)
+pub bpfman::oci_utils::ImageError::DatabaseError(alloc::string::String, alloc::string::String)
+pub bpfman::oci_utils::ImageError::ImageManifestPullFailure(oci_distribution::errors::OciDistributionError)
+pub bpfman::oci_utils::ImageError::InvalidImageUrl(oci_distribution::reference::ParseError)
+impl core::convert::From<anyhow::Error> for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::from(source: anyhow::Error) -> Self
+impl core::convert::From<bpfman::oci_utils::ImageError> for bpfman::errors::BpfmanError
+pub fn bpfman::errors::BpfmanError::from(source: bpfman::oci_utils::ImageError) -> Self
+impl core::error::Error for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::oci_utils::ImageError
+impl core::marker::Send for bpfman::oci_utils::ImageError
+impl core::marker::Sync for bpfman::oci_utils::ImageError
+impl core::marker::Unpin for bpfman::oci_utils::ImageError
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::oci_utils::ImageError
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::oci_utils::ImageError
+impl<T, U> core::convert::Into<U> for bpfman::oci_utils::ImageError where U: core::convert::From<T>
+pub fn bpfman::oci_utils::ImageError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::oci_utils::ImageError where U: core::convert::Into<T>
+pub type bpfman::oci_utils::ImageError::Error = core::convert::Infallible
+pub fn bpfman::oci_utils::ImageError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::oci_utils::ImageError where U: core::convert::TryFrom<T>
+pub type bpfman::oci_utils::ImageError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::oci_utils::ImageError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for bpfman::oci_utils::ImageError where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::oci_utils::ImageError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bpfman::oci_utils::ImageError where T: 'static + core::marker::Sized
+pub fn bpfman::oci_utils::ImageError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::oci_utils::ImageError where T: core::marker::Sized
+pub fn bpfman::oci_utils::ImageError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::oci_utils::ImageError where T: core::marker::Sized
+pub fn bpfman::oci_utils::ImageError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::oci_utils::ImageError
+pub type bpfman::oci_utils::ImageError::Init = T
+pub const bpfman::oci_utils::ImageError::ALIGN: usize
+pub unsafe fn bpfman::oci_utils::ImageError::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::oci_utils::ImageError::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::oci_utils::ImageError::drop(ptr: usize)
+pub unsafe fn bpfman::oci_utils::ImageError::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> snafu::AsErrorSource for bpfman::oci_utils::ImageError where T: core::error::Error + 'static
+pub fn bpfman::oci_utils::ImageError::as_error_source(&self) -> &(dyn core::error::Error + 'static)
+impl<T> tonic::request::IntoRequest<T> for bpfman::oci_utils::ImageError
+pub fn bpfman::oci_utils::ImageError::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::oci_utils::ImageError
+impl<T> tracing::instrument::WithSubscriber for bpfman::oci_utils::ImageError
+impl<T> typenum::type_operators::Same for bpfman::oci_utils::ImageError
+pub type bpfman::oci_utils::ImageError::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::oci_utils::ImageError where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::oci_utils::ImageError::vzip(self) -> V
+pub mod bpfman::storage
+pub struct bpfman::storage::StorageManager
+impl bpfman::storage::StorageManager
+pub fn bpfman::storage::StorageManager::new() -> Self
+pub async fn bpfman::storage::StorageManager::run(self, shutdown_channel: tokio::sync::broadcast::Receiver<()>)
+impl core::default::Default for bpfman::storage::StorageManager
+pub fn bpfman::storage::StorageManager::default() -> Self
+impl core::marker::Freeze for bpfman::storage::StorageManager
+impl core::marker::Send for bpfman::storage::StorageManager
+impl core::marker::Sync for bpfman::storage::StorageManager
+impl core::marker::Unpin for bpfman::storage::StorageManager
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::storage::StorageManager
+impl core::panic::unwind_safe::UnwindSafe for bpfman::storage::StorageManager
+impl<T, U> core::convert::Into<U> for bpfman::storage::StorageManager where U: core::convert::From<T>
+pub fn bpfman::storage::StorageManager::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::storage::StorageManager where U: core::convert::Into<T>
+pub type bpfman::storage::StorageManager::Error = core::convert::Infallible
+pub fn bpfman::storage::StorageManager::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::storage::StorageManager where U: core::convert::TryFrom<T>
+pub type bpfman::storage::StorageManager::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::storage::StorageManager::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bpfman::storage::StorageManager where T: 'static + core::marker::Sized
+pub fn bpfman::storage::StorageManager::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::storage::StorageManager where T: core::marker::Sized
+pub fn bpfman::storage::StorageManager::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::storage::StorageManager where T: core::marker::Sized
+pub fn bpfman::storage::StorageManager::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::storage::StorageManager
+pub fn bpfman::storage::StorageManager::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::storage::StorageManager
+pub type bpfman::storage::StorageManager::Init = T
+pub const bpfman::storage::StorageManager::ALIGN: usize
+pub unsafe fn bpfman::storage::StorageManager::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::storage::StorageManager::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::storage::StorageManager::drop(ptr: usize)
+pub unsafe fn bpfman::storage::StorageManager::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> tonic::request::IntoRequest<T> for bpfman::storage::StorageManager
+pub fn bpfman::storage::StorageManager::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::storage::StorageManager
+impl<T> tracing::instrument::WithSubscriber for bpfman::storage::StorageManager
+impl<T> typenum::type_operators::Same for bpfman::storage::StorageManager
+pub type bpfman::storage::StorageManager::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::storage::StorageManager where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::storage::StorageManager::vzip(self) -> V
+pub mod bpfman::types
+pub enum bpfman::types::Direction
+pub bpfman::types::Direction::Egress = 2
+pub bpfman::types::Direction::Ingress = 1
+impl core::clone::Clone for bpfman::types::Direction
+pub fn bpfman::types::Direction::clone(&self) -> bpfman::types::Direction
+impl core::cmp::Eq for bpfman::types::Direction
+impl core::cmp::PartialEq for bpfman::types::Direction
+pub fn bpfman::types::Direction::eq(&self, other: &bpfman::types::Direction) -> bool
+impl core::convert::TryFrom<alloc::string::String> for bpfman::types::Direction
+pub type bpfman::types::Direction::Error = bpfman::errors::ParseError
+pub fn bpfman::types::Direction::try_from(v: alloc::string::String) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<u32> for bpfman::types::Direction
+pub type bpfman::types::Direction::Error = bpfman::errors::ParseError
+pub fn bpfman::types::Direction::try_from(v: u32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::Direction
+pub fn bpfman::types::Direction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::Direction
+pub fn bpfman::types::Direction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bpfman::types::Direction
+pub fn bpfman::types::Direction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bpfman::types::Direction
+impl core::marker::StructuralPartialEq for bpfman::types::Direction
+impl serde::ser::Serialize for bpfman::types::Direction
+pub fn bpfman::types::Direction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::Direction
+pub fn bpfman::types::Direction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::Direction
+impl core::marker::Send for bpfman::types::Direction
+impl core::marker::Sync for bpfman::types::Direction
+impl core::marker::Unpin for bpfman::types::Direction
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::Direction
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::Direction
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::Direction where C: jwt::ToBase64
+pub fn bpfman::types::Direction::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<Q, K> equivalent::Equivalent<K> for bpfman::types::Direction where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::Direction::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for bpfman::types::Direction where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::Direction::equivalent(&self, key: &K) -> bool
+impl<Q, K> indexmap::equivalent::Equivalent<K> for bpfman::types::Direction where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::Direction::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for bpfman::types::Direction where U: core::convert::From<T>
+pub fn bpfman::types::Direction::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::Direction where U: core::convert::Into<T>
+pub type bpfman::types::Direction::Error = core::convert::Infallible
+pub fn bpfman::types::Direction::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::Direction where U: core::convert::TryFrom<T>
+pub type bpfman::types::Direction::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::Direction::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::Direction where T: core::clone::Clone
+pub type bpfman::types::Direction::Owned = T
+pub fn bpfman::types::Direction::clone_into(&self, target: &mut T)
+pub fn bpfman::types::Direction::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::Direction where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::Direction::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::Direction where T: core::clone::Clone
+pub fn bpfman::types::Direction::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::Direction where T: 'static + core::marker::Sized
+pub fn bpfman::types::Direction::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::Direction where T: core::marker::Sized
+pub fn bpfman::types::Direction::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::Direction where T: core::marker::Sized
+pub fn bpfman::types::Direction::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::Direction
+pub fn bpfman::types::Direction::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::Direction
+pub type bpfman::types::Direction::Init = T
+pub const bpfman::types::Direction::ALIGN: usize
+pub unsafe fn bpfman::types::Direction::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::Direction::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::Direction::drop(ptr: usize)
+pub unsafe fn bpfman::types::Direction::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::Direction where T: core::clone::Clone
+pub fn bpfman::types::Direction::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::Direction where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::Direction::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::Direction where T: serde::ser::Serialize
+pub fn bpfman::types::Direction::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::Direction where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::Direction
+pub fn bpfman::types::Direction::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::Direction
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::Direction
+impl<T> typenum::type_operators::Same for bpfman::types::Direction
+pub type bpfman::types::Direction::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Direction where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::Direction::vzip(self) -> V
+pub enum bpfman::types::ImagePullPolicy
+pub bpfman::types::ImagePullPolicy::Always
+pub bpfman::types::ImagePullPolicy::IfNotPresent
+pub bpfman::types::ImagePullPolicy::Never
+impl core::clone::Clone for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::clone(&self) -> bpfman::types::ImagePullPolicy
+impl core::convert::From<bpfman::types::ImagePullPolicy> for i32
+pub fn i32::from(value: bpfman::types::ImagePullPolicy) -> Self
+impl core::convert::TryFrom<&str> for bpfman::types::ImagePullPolicy
+pub type bpfman::types::ImagePullPolicy::Error = bpfman::errors::ParseError
+pub fn bpfman::types::ImagePullPolicy::try_from(value: &str) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<i32> for bpfman::types::ImagePullPolicy
+pub type bpfman::types::ImagePullPolicy::Error = bpfman::errors::ParseError
+pub fn bpfman::types::ImagePullPolicy::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::ImagePullPolicy
+impl core::marker::Send for bpfman::types::ImagePullPolicy
+impl core::marker::Sync for bpfman::types::ImagePullPolicy
+impl core::marker::Unpin for bpfman::types::ImagePullPolicy
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::ImagePullPolicy
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::ImagePullPolicy
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::ImagePullPolicy where C: jwt::ToBase64
+pub fn bpfman::types::ImagePullPolicy::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::ImagePullPolicy where U: core::convert::From<T>
+pub fn bpfman::types::ImagePullPolicy::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::ImagePullPolicy where U: core::convert::Into<T>
+pub type bpfman::types::ImagePullPolicy::Error = core::convert::Infallible
+pub fn bpfman::types::ImagePullPolicy::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::ImagePullPolicy where U: core::convert::TryFrom<T>
+pub type bpfman::types::ImagePullPolicy::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::ImagePullPolicy::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::ImagePullPolicy where T: core::clone::Clone
+pub type bpfman::types::ImagePullPolicy::Owned = T
+pub fn bpfman::types::ImagePullPolicy::clone_into(&self, target: &mut T)
+pub fn bpfman::types::ImagePullPolicy::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::ImagePullPolicy where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::ImagePullPolicy::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::ImagePullPolicy where T: core::clone::Clone
+pub fn bpfman::types::ImagePullPolicy::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::ImagePullPolicy where T: 'static + core::marker::Sized
+pub fn bpfman::types::ImagePullPolicy::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::ImagePullPolicy where T: core::marker::Sized
+pub fn bpfman::types::ImagePullPolicy::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::ImagePullPolicy where T: core::marker::Sized
+pub fn bpfman::types::ImagePullPolicy::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::ImagePullPolicy
+pub type bpfman::types::ImagePullPolicy::Init = T
+pub const bpfman::types::ImagePullPolicy::ALIGN: usize
+pub unsafe fn bpfman::types::ImagePullPolicy::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::ImagePullPolicy::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::ImagePullPolicy::drop(ptr: usize)
+pub unsafe fn bpfman::types::ImagePullPolicy::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::ImagePullPolicy where T: core::clone::Clone
+pub fn bpfman::types::ImagePullPolicy::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::ImagePullPolicy where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::ImagePullPolicy::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::ImagePullPolicy where T: serde::ser::Serialize
+pub fn bpfman::types::ImagePullPolicy::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::ImagePullPolicy where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::ImagePullPolicy
+pub fn bpfman::types::ImagePullPolicy::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::ImagePullPolicy
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::ImagePullPolicy
+impl<T> typenum::type_operators::Same for bpfman::types::ImagePullPolicy
+pub type bpfman::types::ImagePullPolicy::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ImagePullPolicy where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::ImagePullPolicy::vzip(self) -> V
+pub enum bpfman::types::Location
+pub bpfman::types::Location::File(alloc::string::String)
+pub bpfman::types::Location::Image(bpfman::oci_utils::image_manager::BytecodeImage)
+impl core::clone::Clone for bpfman::types::Location
+pub fn bpfman::types::Location::clone(&self) -> bpfman::types::Location
+impl core::fmt::Debug for bpfman::types::Location
+pub fn bpfman::types::Location::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::Location
+pub fn bpfman::types::Location::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for bpfman::types::Location
+pub fn bpfman::types::Location::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::Location
+pub fn bpfman::types::Location::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::Location
+impl core::marker::Send for bpfman::types::Location
+impl core::marker::Sync for bpfman::types::Location
+impl core::marker::Unpin for bpfman::types::Location
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::Location
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::Location
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::Location where C: jwt::ToBase64
+pub fn bpfman::types::Location::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::Location where U: core::convert::From<T>
+pub fn bpfman::types::Location::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::Location where U: core::convert::Into<T>
+pub type bpfman::types::Location::Error = core::convert::Infallible
+pub fn bpfman::types::Location::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::Location where U: core::convert::TryFrom<T>
+pub type bpfman::types::Location::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::Location::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::Location where T: core::clone::Clone
+pub type bpfman::types::Location::Owned = T
+pub fn bpfman::types::Location::clone_into(&self, target: &mut T)
+pub fn bpfman::types::Location::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::Location where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::Location::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::Location where T: core::clone::Clone
+pub fn bpfman::types::Location::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::Location where T: 'static + core::marker::Sized
+pub fn bpfman::types::Location::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::Location where T: core::marker::Sized
+pub fn bpfman::types::Location::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::Location where T: core::marker::Sized
+pub fn bpfman::types::Location::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::Location
+pub fn bpfman::types::Location::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::Location
+pub type bpfman::types::Location::Init = T
+pub const bpfman::types::Location::ALIGN: usize
+pub unsafe fn bpfman::types::Location::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::Location::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::Location::drop(ptr: usize)
+pub unsafe fn bpfman::types::Location::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::Location where T: core::clone::Clone
+pub fn bpfman::types::Location::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::Location where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::Location::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::Location where T: serde::ser::Serialize
+pub fn bpfman::types::Location::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::Location where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::Location
+pub fn bpfman::types::Location::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::Location
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::Location
+impl<T> typenum::type_operators::Same for bpfman::types::Location
+pub type bpfman::types::Location::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Location where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::Location::vzip(self) -> V
+pub enum bpfman::types::ProbeType
+pub bpfman::types::ProbeType::Kprobe
+pub bpfman::types::ProbeType::Kretprobe
+pub bpfman::types::ProbeType::Uprobe
+pub bpfman::types::ProbeType::Uretprobe
+impl core::clone::Clone for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::clone(&self) -> bpfman::types::ProbeType
+impl core::cmp::Eq for bpfman::types::ProbeType
+impl core::cmp::PartialEq for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::eq(&self, other: &bpfman::types::ProbeType) -> bool
+impl core::convert::From<aya::programs::probe::ProbeKind> for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::from(value: aya::programs::probe::ProbeKind) -> Self
+impl core::convert::TryFrom<i32> for bpfman::types::ProbeType
+pub type bpfman::types::ProbeType::Error = bpfman::errors::ParseError
+pub fn bpfman::types::ProbeType::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bpfman::types::ProbeType
+impl core::marker::StructuralPartialEq for bpfman::types::ProbeType
+impl serde::ser::Serialize for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::ProbeType
+impl core::marker::Send for bpfman::types::ProbeType
+impl core::marker::Sync for bpfman::types::ProbeType
+impl core::marker::Unpin for bpfman::types::ProbeType
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::ProbeType
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::ProbeType
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::ProbeType where C: jwt::ToBase64
+pub fn bpfman::types::ProbeType::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<Q, K> equivalent::Equivalent<K> for bpfman::types::ProbeType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProbeType::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for bpfman::types::ProbeType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProbeType::equivalent(&self, key: &K) -> bool
+impl<Q, K> indexmap::equivalent::Equivalent<K> for bpfman::types::ProbeType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProbeType::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for bpfman::types::ProbeType where U: core::convert::From<T>
+pub fn bpfman::types::ProbeType::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::ProbeType where U: core::convert::Into<T>
+pub type bpfman::types::ProbeType::Error = core::convert::Infallible
+pub fn bpfman::types::ProbeType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::ProbeType where U: core::convert::TryFrom<T>
+pub type bpfman::types::ProbeType::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::ProbeType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::ProbeType where T: core::clone::Clone
+pub type bpfman::types::ProbeType::Owned = T
+pub fn bpfman::types::ProbeType::clone_into(&self, target: &mut T)
+pub fn bpfman::types::ProbeType::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::ProbeType where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::ProbeType::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::ProbeType where T: core::clone::Clone
+pub fn bpfman::types::ProbeType::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::ProbeType where T: 'static + core::marker::Sized
+pub fn bpfman::types::ProbeType::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::ProbeType where T: core::marker::Sized
+pub fn bpfman::types::ProbeType::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::ProbeType where T: core::marker::Sized
+pub fn bpfman::types::ProbeType::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::ProbeType
+pub type bpfman::types::ProbeType::Init = T
+pub const bpfman::types::ProbeType::ALIGN: usize
+pub unsafe fn bpfman::types::ProbeType::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::ProbeType::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::ProbeType::drop(ptr: usize)
+pub unsafe fn bpfman::types::ProbeType::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::ProbeType where T: core::clone::Clone
+pub fn bpfman::types::ProbeType::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::ProbeType where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::ProbeType::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::ProbeType where T: serde::ser::Serialize
+pub fn bpfman::types::ProbeType::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::ProbeType where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::ProbeType
+pub fn bpfman::types::ProbeType::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::ProbeType
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProbeType
+impl<T> typenum::type_operators::Same for bpfman::types::ProbeType
+pub type bpfman::types::ProbeType::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProbeType where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::ProbeType::vzip(self) -> V
+pub enum bpfman::types::Program
+pub bpfman::types::Program::Fentry(bpfman::types::FentryProgram)
+pub bpfman::types::Program::Fexit(bpfman::types::FexitProgram)
+pub bpfman::types::Program::Kprobe(bpfman::types::KprobeProgram)
+pub bpfman::types::Program::Tc(bpfman::types::TcProgram)
+pub bpfman::types::Program::Tracepoint(bpfman::types::TracepointProgram)
+pub bpfman::types::Program::Unsupported(bpfman::types::ProgramData)
+pub bpfman::types::Program::Uprobe(bpfman::types::UprobeProgram)
+pub bpfman::types::Program::Xdp(bpfman::types::XdpProgram)
+impl bpfman::types::Program
+pub fn bpfman::types::Program::get_data(&self) -> &bpfman::types::ProgramData
+pub fn bpfman::types::Program::kind(&self) -> bpfman::types::ProgramType
+impl core::clone::Clone for bpfman::types::Program
+pub fn bpfman::types::Program::clone(&self) -> bpfman::types::Program
+impl core::fmt::Debug for bpfman::types::Program
+pub fn bpfman::types::Program::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::Program
+impl core::marker::Send for bpfman::types::Program
+impl core::marker::Sync for bpfman::types::Program
+impl core::marker::Unpin for bpfman::types::Program
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::Program
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::Program
+impl<T, U> core::convert::Into<U> for bpfman::types::Program where U: core::convert::From<T>
+pub fn bpfman::types::Program::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::Program where U: core::convert::Into<T>
+pub type bpfman::types::Program::Error = core::convert::Infallible
+pub fn bpfman::types::Program::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::Program where U: core::convert::TryFrom<T>
+pub type bpfman::types::Program::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::Program::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::Program where T: core::clone::Clone
+pub type bpfman::types::Program::Owned = T
+pub fn bpfman::types::Program::clone_into(&self, target: &mut T)
+pub fn bpfman::types::Program::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::Program where T: core::clone::Clone
+pub fn bpfman::types::Program::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::Program where T: 'static + core::marker::Sized
+pub fn bpfman::types::Program::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::Program where T: core::marker::Sized
+pub fn bpfman::types::Program::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::Program where T: core::marker::Sized
+pub fn bpfman::types::Program::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::Program
+pub fn bpfman::types::Program::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::Program
+pub type bpfman::types::Program::Init = T
+pub const bpfman::types::Program::ALIGN: usize
+pub unsafe fn bpfman::types::Program::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::Program::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::Program::drop(ptr: usize)
+pub unsafe fn bpfman::types::Program::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::Program where T: core::clone::Clone
+pub fn bpfman::types::Program::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::Program
+pub fn bpfman::types::Program::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::Program
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::Program
+impl<T> typenum::type_operators::Same for bpfman::types::Program
+pub type bpfman::types::Program::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Program where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::Program::vzip(self) -> V
+pub enum bpfman::types::ProgramType
+pub bpfman::types::ProgramType::CgroupDevice
+pub bpfman::types::ProgramType::CgroupSkb
+pub bpfman::types::ProgramType::CgroupSock
+pub bpfman::types::ProgramType::CgroupSockAddr
+pub bpfman::types::ProgramType::CgroupSockopt
+pub bpfman::types::ProgramType::CgroupSysctl
+pub bpfman::types::ProgramType::Ext
+pub bpfman::types::ProgramType::FlowDissector
+pub bpfman::types::ProgramType::LircMode2
+pub bpfman::types::ProgramType::Lsm
+pub bpfman::types::ProgramType::LwtIn
+pub bpfman::types::ProgramType::LwtOut
+pub bpfman::types::ProgramType::LwtSeg6Local
+pub bpfman::types::ProgramType::LwtXmit
+pub bpfman::types::ProgramType::PerfEvent
+pub bpfman::types::ProgramType::Probe
+pub bpfman::types::ProgramType::RawTracepoint
+pub bpfman::types::ProgramType::RawTracepointWritable
+pub bpfman::types::ProgramType::SchedAct
+pub bpfman::types::ProgramType::SkLookup
+pub bpfman::types::ProgramType::SkMsg
+pub bpfman::types::ProgramType::SkReuseport
+pub bpfman::types::ProgramType::SkSkb
+pub bpfman::types::ProgramType::SockOps
+pub bpfman::types::ProgramType::SocketFilter
+pub bpfman::types::ProgramType::StructOps
+pub bpfman::types::ProgramType::Syscall
+pub bpfman::types::ProgramType::Tc
+pub bpfman::types::ProgramType::Tracepoint
+pub bpfman::types::ProgramType::Tracing
+pub bpfman::types::ProgramType::Unspec
+pub bpfman::types::ProgramType::Xdp
+impl clap_builder::derive::ValueEnum for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::to_possible_value<'a>(&self) -> core::option::Option<clap_builder::builder::possible_value::PossibleValue>
+pub fn bpfman::types::ProgramType::value_variants<'a>() -> &'a [Self]
+impl core::clone::Clone for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::clone(&self) -> bpfman::types::ProgramType
+impl core::cmp::Eq for bpfman::types::ProgramType
+impl core::cmp::PartialEq for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::eq(&self, other: &bpfman::types::ProgramType) -> bool
+impl core::convert::From<bpfman::types::ProgramType> for u32
+pub fn u32::from(val: bpfman::types::ProgramType) -> Self
+impl core::convert::TryFrom<alloc::string::String> for bpfman::types::ProgramType
+pub type bpfman::types::ProgramType::Error = bpfman::errors::ParseError
+pub fn bpfman::types::ProgramType::try_from(value: alloc::string::String) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<u32> for bpfman::types::ProgramType
+pub type bpfman::types::ProgramType::Error = bpfman::errors::ParseError
+pub fn bpfman::types::ProgramType::try_from(value: u32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bpfman::types::ProgramType
+impl core::marker::StructuralPartialEq for bpfman::types::ProgramType
+impl serde::ser::Serialize for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::ProgramType
+impl core::marker::Send for bpfman::types::ProgramType
+impl core::marker::Sync for bpfman::types::ProgramType
+impl core::marker::Unpin for bpfman::types::ProgramType
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::ProgramType
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::ProgramType
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::ProgramType where C: jwt::ToBase64
+pub fn bpfman::types::ProgramType::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<Q, K> equivalent::Equivalent<K> for bpfman::types::ProgramType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProgramType::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for bpfman::types::ProgramType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProgramType::equivalent(&self, key: &K) -> bool
+impl<Q, K> indexmap::equivalent::Equivalent<K> for bpfman::types::ProgramType where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn bpfman::types::ProgramType::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for bpfman::types::ProgramType where U: core::convert::From<T>
+pub fn bpfman::types::ProgramType::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::ProgramType where U: core::convert::Into<T>
+pub type bpfman::types::ProgramType::Error = core::convert::Infallible
+pub fn bpfman::types::ProgramType::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::ProgramType where U: core::convert::TryFrom<T>
+pub type bpfman::types::ProgramType::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::ProgramType::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::ProgramType where T: core::clone::Clone
+pub type bpfman::types::ProgramType::Owned = T
+pub fn bpfman::types::ProgramType::clone_into(&self, target: &mut T)
+pub fn bpfman::types::ProgramType::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::ProgramType where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::ProgramType::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::ProgramType where T: core::clone::Clone
+pub fn bpfman::types::ProgramType::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::ProgramType where T: 'static + core::marker::Sized
+pub fn bpfman::types::ProgramType::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::ProgramType where T: core::marker::Sized
+pub fn bpfman::types::ProgramType::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::ProgramType where T: core::marker::Sized
+pub fn bpfman::types::ProgramType::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::ProgramType
+pub type bpfman::types::ProgramType::Init = T
+pub const bpfman::types::ProgramType::ALIGN: usize
+pub unsafe fn bpfman::types::ProgramType::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::ProgramType::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::ProgramType::drop(ptr: usize)
+pub unsafe fn bpfman::types::ProgramType::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::ProgramType where T: core::clone::Clone
+pub fn bpfman::types::ProgramType::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::ProgramType where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::ProgramType::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::ProgramType where T: serde::ser::Serialize
+pub fn bpfman::types::ProgramType::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::ProgramType where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::ProgramType
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProgramType
+impl<T> typenum::type_operators::Same for bpfman::types::ProgramType
+pub type bpfman::types::ProgramType::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProgramType where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::ProgramType::vzip(self) -> V
+pub enum bpfman::types::TcProceedOnEntry
+pub bpfman::types::TcProceedOnEntry::DispatcherReturn = 30
+pub bpfman::types::TcProceedOnEntry::Ok = 0
+pub bpfman::types::TcProceedOnEntry::Pipe
+pub bpfman::types::TcProceedOnEntry::Queued
+pub bpfman::types::TcProceedOnEntry::Reclassify
+pub bpfman::types::TcProceedOnEntry::Redirect
+pub bpfman::types::TcProceedOnEntry::Repeat
+pub bpfman::types::TcProceedOnEntry::Shot
+pub bpfman::types::TcProceedOnEntry::Stolen
+pub bpfman::types::TcProceedOnEntry::Trap
+pub bpfman::types::TcProceedOnEntry::Unspec = -1
+impl core::clone::Clone for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::clone(&self) -> bpfman::types::TcProceedOnEntry
+impl core::convert::TryFrom<alloc::string::String> for bpfman::types::TcProceedOnEntry
+pub type bpfman::types::TcProceedOnEntry::Error = bpfman::errors::ParseError
+pub fn bpfman::types::TcProceedOnEntry::try_from(value: alloc::string::String) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<i32> for bpfman::types::TcProceedOnEntry
+pub type bpfman::types::TcProceedOnEntry::Error = bpfman::errors::ParseError
+pub fn bpfman::types::TcProceedOnEntry::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::FromIterator<bpfman::types::TcProceedOnEntry> for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::from_iter<I: core::iter::traits::collect::IntoIterator<Item = bpfman::types::TcProceedOnEntry>>(iter: I) -> Self
+impl core::marker::Copy for bpfman::types::TcProceedOnEntry
+impl serde::ser::Serialize for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::TcProceedOnEntry
+impl core::marker::Send for bpfman::types::TcProceedOnEntry
+impl core::marker::Sync for bpfman::types::TcProceedOnEntry
+impl core::marker::Unpin for bpfman::types::TcProceedOnEntry
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::TcProceedOnEntry
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::TcProceedOnEntry
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::TcProceedOnEntry where C: jwt::ToBase64
+pub fn bpfman::types::TcProceedOnEntry::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::TcProceedOnEntry where U: core::convert::From<T>
+pub fn bpfman::types::TcProceedOnEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::TcProceedOnEntry where U: core::convert::Into<T>
+pub type bpfman::types::TcProceedOnEntry::Error = core::convert::Infallible
+pub fn bpfman::types::TcProceedOnEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::TcProceedOnEntry where U: core::convert::TryFrom<T>
+pub type bpfman::types::TcProceedOnEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::TcProceedOnEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::TcProceedOnEntry where T: core::clone::Clone
+pub type bpfman::types::TcProceedOnEntry::Owned = T
+pub fn bpfman::types::TcProceedOnEntry::clone_into(&self, target: &mut T)
+pub fn bpfman::types::TcProceedOnEntry::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::TcProceedOnEntry where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::TcProceedOnEntry::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::TcProceedOnEntry where T: core::clone::Clone
+pub fn bpfman::types::TcProceedOnEntry::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::TcProceedOnEntry where T: 'static + core::marker::Sized
+pub fn bpfman::types::TcProceedOnEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::TcProceedOnEntry where T: core::marker::Sized
+pub fn bpfman::types::TcProceedOnEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::TcProceedOnEntry where T: core::marker::Sized
+pub fn bpfman::types::TcProceedOnEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::TcProceedOnEntry
+pub type bpfman::types::TcProceedOnEntry::Init = T
+pub const bpfman::types::TcProceedOnEntry::ALIGN: usize
+pub unsafe fn bpfman::types::TcProceedOnEntry::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::TcProceedOnEntry::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::TcProceedOnEntry::drop(ptr: usize)
+pub unsafe fn bpfman::types::TcProceedOnEntry::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::TcProceedOnEntry where T: core::clone::Clone
+pub fn bpfman::types::TcProceedOnEntry::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::TcProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::TcProceedOnEntry::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::TcProceedOnEntry where T: serde::ser::Serialize
+pub fn bpfman::types::TcProceedOnEntry::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::TcProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::TcProceedOnEntry
+pub fn bpfman::types::TcProceedOnEntry::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::TcProceedOnEntry
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProceedOnEntry
+impl<T> typenum::type_operators::Same for bpfman::types::TcProceedOnEntry
+pub type bpfman::types::TcProceedOnEntry::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProceedOnEntry where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::TcProceedOnEntry::vzip(self) -> V
+pub enum bpfman::types::XdpProceedOnEntry
+pub bpfman::types::XdpProceedOnEntry::Aborted
+pub bpfman::types::XdpProceedOnEntry::DispatcherReturn = 31
+pub bpfman::types::XdpProceedOnEntry::Drop
+pub bpfman::types::XdpProceedOnEntry::Pass
+pub bpfman::types::XdpProceedOnEntry::Redirect
+pub bpfman::types::XdpProceedOnEntry::Tx
+impl core::clone::Clone for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::clone(&self) -> bpfman::types::XdpProceedOnEntry
+impl core::convert::TryFrom<alloc::string::String> for bpfman::types::XdpProceedOnEntry
+pub type bpfman::types::XdpProceedOnEntry::Error = bpfman::errors::ParseError
+pub fn bpfman::types::XdpProceedOnEntry::try_from(value: alloc::string::String) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<i32> for bpfman::types::XdpProceedOnEntry
+pub type bpfman::types::XdpProceedOnEntry::Error = bpfman::errors::ParseError
+pub fn bpfman::types::XdpProceedOnEntry::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::FromIterator<bpfman::types::XdpProceedOnEntry> for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::from_iter<I: core::iter::traits::collect::IntoIterator<Item = bpfman::types::XdpProceedOnEntry>>(iter: I) -> Self
+impl core::marker::Copy for bpfman::types::XdpProceedOnEntry
+impl serde::ser::Serialize for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::XdpProceedOnEntry
+impl core::marker::Send for bpfman::types::XdpProceedOnEntry
+impl core::marker::Sync for bpfman::types::XdpProceedOnEntry
+impl core::marker::Unpin for bpfman::types::XdpProceedOnEntry
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::XdpProceedOnEntry
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::XdpProceedOnEntry
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::XdpProceedOnEntry where C: jwt::ToBase64
+pub fn bpfman::types::XdpProceedOnEntry::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::XdpProceedOnEntry where U: core::convert::From<T>
+pub fn bpfman::types::XdpProceedOnEntry::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::XdpProceedOnEntry where U: core::convert::Into<T>
+pub type bpfman::types::XdpProceedOnEntry::Error = core::convert::Infallible
+pub fn bpfman::types::XdpProceedOnEntry::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::XdpProceedOnEntry where U: core::convert::TryFrom<T>
+pub type bpfman::types::XdpProceedOnEntry::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::XdpProceedOnEntry::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::XdpProceedOnEntry where T: core::clone::Clone
+pub type bpfman::types::XdpProceedOnEntry::Owned = T
+pub fn bpfman::types::XdpProceedOnEntry::clone_into(&self, target: &mut T)
+pub fn bpfman::types::XdpProceedOnEntry::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::XdpProceedOnEntry where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::XdpProceedOnEntry::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::XdpProceedOnEntry where T: core::clone::Clone
+pub fn bpfman::types::XdpProceedOnEntry::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::XdpProceedOnEntry where T: 'static + core::marker::Sized
+pub fn bpfman::types::XdpProceedOnEntry::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::XdpProceedOnEntry where T: core::marker::Sized
+pub fn bpfman::types::XdpProceedOnEntry::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::XdpProceedOnEntry where T: core::marker::Sized
+pub fn bpfman::types::XdpProceedOnEntry::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::XdpProceedOnEntry
+pub type bpfman::types::XdpProceedOnEntry::Init = T
+pub const bpfman::types::XdpProceedOnEntry::ALIGN: usize
+pub unsafe fn bpfman::types::XdpProceedOnEntry::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::XdpProceedOnEntry::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::XdpProceedOnEntry::drop(ptr: usize)
+pub unsafe fn bpfman::types::XdpProceedOnEntry::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::XdpProceedOnEntry where T: core::clone::Clone
+pub fn bpfman::types::XdpProceedOnEntry::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::XdpProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::XdpProceedOnEntry::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::XdpProceedOnEntry where T: serde::ser::Serialize
+pub fn bpfman::types::XdpProceedOnEntry::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::XdpProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::XdpProceedOnEntry
+pub fn bpfman::types::XdpProceedOnEntry::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::XdpProceedOnEntry
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProceedOnEntry
+impl<T> typenum::type_operators::Same for bpfman::types::XdpProceedOnEntry
+pub type bpfman::types::XdpProceedOnEntry::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProceedOnEntry where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::XdpProceedOnEntry::vzip(self) -> V
+pub struct bpfman::types::FentryProgram
+impl bpfman::types::FentryProgram
+pub fn bpfman::types::FentryProgram::get_fn_name(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::FentryProgram::new(data: bpfman::types::ProgramData, fn_name: alloc::string::String) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::FentryProgram
+pub fn bpfman::types::FentryProgram::clone(&self) -> bpfman::types::FentryProgram
+impl core::fmt::Debug for bpfman::types::FentryProgram
+pub fn bpfman::types::FentryProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::FentryProgram
+impl core::marker::Send for bpfman::types::FentryProgram
+impl core::marker::Sync for bpfman::types::FentryProgram
+impl core::marker::Unpin for bpfman::types::FentryProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::FentryProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::FentryProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::FentryProgram where U: core::convert::From<T>
+pub fn bpfman::types::FentryProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::FentryProgram where U: core::convert::Into<T>
+pub type bpfman::types::FentryProgram::Error = core::convert::Infallible
+pub fn bpfman::types::FentryProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::FentryProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::FentryProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::FentryProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::FentryProgram where T: core::clone::Clone
+pub type bpfman::types::FentryProgram::Owned = T
+pub fn bpfman::types::FentryProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::FentryProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::FentryProgram where T: core::clone::Clone
+pub fn bpfman::types::FentryProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::FentryProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::FentryProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::FentryProgram where T: core::marker::Sized
+pub fn bpfman::types::FentryProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::FentryProgram where T: core::marker::Sized
+pub fn bpfman::types::FentryProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::FentryProgram
+pub fn bpfman::types::FentryProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::FentryProgram
+pub type bpfman::types::FentryProgram::Init = T
+pub const bpfman::types::FentryProgram::ALIGN: usize
+pub unsafe fn bpfman::types::FentryProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::FentryProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::FentryProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::FentryProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::FentryProgram where T: core::clone::Clone
+pub fn bpfman::types::FentryProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::FentryProgram
+pub fn bpfman::types::FentryProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::FentryProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::FentryProgram
+impl<T> typenum::type_operators::Same for bpfman::types::FentryProgram
+pub type bpfman::types::FentryProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::FentryProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::FentryProgram::vzip(self) -> V
+pub struct bpfman::types::FexitProgram
+impl bpfman::types::FexitProgram
+pub fn bpfman::types::FexitProgram::get_fn_name(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::FexitProgram::new(data: bpfman::types::ProgramData, fn_name: alloc::string::String) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::FexitProgram
+pub fn bpfman::types::FexitProgram::clone(&self) -> bpfman::types::FexitProgram
+impl core::fmt::Debug for bpfman::types::FexitProgram
+pub fn bpfman::types::FexitProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::FexitProgram
+impl core::marker::Send for bpfman::types::FexitProgram
+impl core::marker::Sync for bpfman::types::FexitProgram
+impl core::marker::Unpin for bpfman::types::FexitProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::FexitProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::FexitProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::FexitProgram where U: core::convert::From<T>
+pub fn bpfman::types::FexitProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::FexitProgram where U: core::convert::Into<T>
+pub type bpfman::types::FexitProgram::Error = core::convert::Infallible
+pub fn bpfman::types::FexitProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::FexitProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::FexitProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::FexitProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::FexitProgram where T: core::clone::Clone
+pub type bpfman::types::FexitProgram::Owned = T
+pub fn bpfman::types::FexitProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::FexitProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::FexitProgram where T: core::clone::Clone
+pub fn bpfman::types::FexitProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::FexitProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::FexitProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::FexitProgram where T: core::marker::Sized
+pub fn bpfman::types::FexitProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::FexitProgram where T: core::marker::Sized
+pub fn bpfman::types::FexitProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::FexitProgram
+pub fn bpfman::types::FexitProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::FexitProgram
+pub type bpfman::types::FexitProgram::Init = T
+pub const bpfman::types::FexitProgram::ALIGN: usize
+pub unsafe fn bpfman::types::FexitProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::FexitProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::FexitProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::FexitProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::FexitProgram where T: core::clone::Clone
+pub fn bpfman::types::FexitProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::FexitProgram
+pub fn bpfman::types::FexitProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::FexitProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::FexitProgram
+impl<T> typenum::type_operators::Same for bpfman::types::FexitProgram
+pub type bpfman::types::FexitProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::FexitProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::FexitProgram::vzip(self) -> V
+pub struct bpfman::types::KprobeProgram
+impl bpfman::types::KprobeProgram
+pub fn bpfman::types::KprobeProgram::get_container_pid(&self) -> core::result::Result<core::option::Option<i32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::KprobeProgram::get_fn_name(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::KprobeProgram::get_offset(&self) -> core::result::Result<u64, bpfman::errors::BpfmanError>
+pub fn bpfman::types::KprobeProgram::get_retprobe(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::KprobeProgram::new(data: bpfman::types::ProgramData, fn_name: alloc::string::String, offset: u64, retprobe: bool, container_pid: core::option::Option<i32>) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::KprobeProgram
+pub fn bpfman::types::KprobeProgram::clone(&self) -> bpfman::types::KprobeProgram
+impl core::fmt::Debug for bpfman::types::KprobeProgram
+pub fn bpfman::types::KprobeProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::KprobeProgram
+impl core::marker::Send for bpfman::types::KprobeProgram
+impl core::marker::Sync for bpfman::types::KprobeProgram
+impl core::marker::Unpin for bpfman::types::KprobeProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::KprobeProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::KprobeProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::KprobeProgram where U: core::convert::From<T>
+pub fn bpfman::types::KprobeProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::KprobeProgram where U: core::convert::Into<T>
+pub type bpfman::types::KprobeProgram::Error = core::convert::Infallible
+pub fn bpfman::types::KprobeProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::KprobeProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::KprobeProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::KprobeProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::KprobeProgram where T: core::clone::Clone
+pub type bpfman::types::KprobeProgram::Owned = T
+pub fn bpfman::types::KprobeProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::KprobeProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::KprobeProgram where T: core::clone::Clone
+pub fn bpfman::types::KprobeProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::KprobeProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::KprobeProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::KprobeProgram where T: core::marker::Sized
+pub fn bpfman::types::KprobeProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::KprobeProgram where T: core::marker::Sized
+pub fn bpfman::types::KprobeProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::KprobeProgram
+pub fn bpfman::types::KprobeProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::KprobeProgram
+pub type bpfman::types::KprobeProgram::Init = T
+pub const bpfman::types::KprobeProgram::ALIGN: usize
+pub unsafe fn bpfman::types::KprobeProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::KprobeProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::KprobeProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::KprobeProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::KprobeProgram where T: core::clone::Clone
+pub fn bpfman::types::KprobeProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::KprobeProgram
+pub fn bpfman::types::KprobeProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::KprobeProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::KprobeProgram
+impl<T> typenum::type_operators::Same for bpfman::types::KprobeProgram
+pub type bpfman::types::KprobeProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::KprobeProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::KprobeProgram::vzip(self) -> V
+pub struct bpfman::types::ListFilter
+impl bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::new(program_type: core::option::Option<u32>, metadata_selector: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, bpfman_programs_only: bool) -> Self
+impl core::clone::Clone for bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::clone(&self) -> bpfman::types::ListFilter
+impl core::default::Default for bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::default() -> bpfman::types::ListFilter
+impl core::fmt::Debug for bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::ListFilter
+impl core::marker::Send for bpfman::types::ListFilter
+impl core::marker::Sync for bpfman::types::ListFilter
+impl core::marker::Unpin for bpfman::types::ListFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::ListFilter
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::ListFilter
+impl<T, U> core::convert::Into<U> for bpfman::types::ListFilter where U: core::convert::From<T>
+pub fn bpfman::types::ListFilter::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::ListFilter where U: core::convert::Into<T>
+pub type bpfman::types::ListFilter::Error = core::convert::Infallible
+pub fn bpfman::types::ListFilter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::ListFilter where U: core::convert::TryFrom<T>
+pub type bpfman::types::ListFilter::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::ListFilter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::ListFilter where T: core::clone::Clone
+pub type bpfman::types::ListFilter::Owned = T
+pub fn bpfman::types::ListFilter::clone_into(&self, target: &mut T)
+pub fn bpfman::types::ListFilter::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::ListFilter where T: core::clone::Clone
+pub fn bpfman::types::ListFilter::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::ListFilter where T: 'static + core::marker::Sized
+pub fn bpfman::types::ListFilter::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::ListFilter where T: core::marker::Sized
+pub fn bpfman::types::ListFilter::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::ListFilter where T: core::marker::Sized
+pub fn bpfman::types::ListFilter::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::ListFilter
+pub type bpfman::types::ListFilter::Init = T
+pub const bpfman::types::ListFilter::ALIGN: usize
+pub unsafe fn bpfman::types::ListFilter::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::ListFilter::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::ListFilter::drop(ptr: usize)
+pub unsafe fn bpfman::types::ListFilter::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::ListFilter where T: core::clone::Clone
+pub fn bpfman::types::ListFilter::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::ListFilter
+pub fn bpfman::types::ListFilter::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::ListFilter
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::ListFilter
+impl<T> typenum::type_operators::Same for bpfman::types::ListFilter
+pub type bpfman::types::ListFilter::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ListFilter where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::ListFilter::vzip(self) -> V
+pub struct bpfman::types::LoadArgs
+pub bpfman::types::LoadArgs::program: bpfman::types::Program
+pub bpfman::types::LoadArgs::responder: tokio::sync::oneshot::Sender<core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>>
+impl core::fmt::Debug for bpfman::types::LoadArgs
+pub fn bpfman::types::LoadArgs::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::LoadArgs
+impl core::marker::Send for bpfman::types::LoadArgs
+impl core::marker::Sync for bpfman::types::LoadArgs
+impl core::marker::Unpin for bpfman::types::LoadArgs
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::LoadArgs
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::LoadArgs
+impl<T, U> core::convert::Into<U> for bpfman::types::LoadArgs where U: core::convert::From<T>
+pub fn bpfman::types::LoadArgs::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::LoadArgs where U: core::convert::Into<T>
+pub type bpfman::types::LoadArgs::Error = core::convert::Infallible
+pub fn bpfman::types::LoadArgs::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::LoadArgs where U: core::convert::TryFrom<T>
+pub type bpfman::types::LoadArgs::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::LoadArgs::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bpfman::types::LoadArgs where T: 'static + core::marker::Sized
+pub fn bpfman::types::LoadArgs::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::LoadArgs where T: core::marker::Sized
+pub fn bpfman::types::LoadArgs::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::LoadArgs where T: core::marker::Sized
+pub fn bpfman::types::LoadArgs::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::LoadArgs
+pub fn bpfman::types::LoadArgs::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::LoadArgs
+pub type bpfman::types::LoadArgs::Init = T
+pub const bpfman::types::LoadArgs::ALIGN: usize
+pub unsafe fn bpfman::types::LoadArgs::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::LoadArgs::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::LoadArgs::drop(ptr: usize)
+pub unsafe fn bpfman::types::LoadArgs::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::LoadArgs
+pub fn bpfman::types::LoadArgs::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::LoadArgs
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::LoadArgs
+impl<T> typenum::type_operators::Same for bpfman::types::LoadArgs
+pub type bpfman::types::LoadArgs::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::LoadArgs where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::LoadArgs::vzip(self) -> V
+pub struct bpfman::types::ProgramData
+impl bpfman::types::ProgramData
+pub fn bpfman::types::ProgramData::get_global_data(&self) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u8>>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_id(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_btf_id(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_bytes_jited(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_bytes_memlock(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_bytes_xlated(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_gpl_compatible(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_jited(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_loaded_at(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_map_ids(&self) -> core::result::Result<alloc::vec::Vec<u32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_name(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_program_type(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_tag(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kernel_verified_insns(&self) -> core::result::Result<u32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_kind(&self) -> core::result::Result<core::option::Option<bpfman::types::ProgramType>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_location(&self) -> core::result::Result<bpfman::types::Location, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_map_owner_id(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_map_pin_path(&self) -> core::result::Result<core::option::Option<std::path::PathBuf>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_maps_used_by(&self) -> core::result::Result<alloc::vec::Vec<u32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_metadata(&self) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::get_name(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::ProgramData::new(tree: sled::tree::Tree) -> Self
+pub fn bpfman::types::ProgramData::new_pre_load(root_db: &sled::db::Db, location: bpfman::types::Location, name: alloc::string::String, metadata: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, global_data: std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u8>>, map_owner_id: core::option::Option<u32>) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::ProgramData
+pub fn bpfman::types::ProgramData::clone(&self) -> bpfman::types::ProgramData
+impl core::fmt::Debug for bpfman::types::ProgramData
+pub fn bpfman::types::ProgramData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::ProgramData
+impl core::marker::Send for bpfman::types::ProgramData
+impl core::marker::Sync for bpfman::types::ProgramData
+impl core::marker::Unpin for bpfman::types::ProgramData
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::ProgramData
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::ProgramData
+impl<T, U> core::convert::Into<U> for bpfman::types::ProgramData where U: core::convert::From<T>
+pub fn bpfman::types::ProgramData::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::ProgramData where U: core::convert::Into<T>
+pub type bpfman::types::ProgramData::Error = core::convert::Infallible
+pub fn bpfman::types::ProgramData::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::ProgramData where U: core::convert::TryFrom<T>
+pub type bpfman::types::ProgramData::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::ProgramData::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::ProgramData where T: core::clone::Clone
+pub type bpfman::types::ProgramData::Owned = T
+pub fn bpfman::types::ProgramData::clone_into(&self, target: &mut T)
+pub fn bpfman::types::ProgramData::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::ProgramData where T: core::clone::Clone
+pub fn bpfman::types::ProgramData::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::ProgramData where T: 'static + core::marker::Sized
+pub fn bpfman::types::ProgramData::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::ProgramData where T: core::marker::Sized
+pub fn bpfman::types::ProgramData::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::ProgramData where T: core::marker::Sized
+pub fn bpfman::types::ProgramData::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::ProgramData
+pub fn bpfman::types::ProgramData::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::ProgramData
+pub type bpfman::types::ProgramData::Init = T
+pub const bpfman::types::ProgramData::ALIGN: usize
+pub unsafe fn bpfman::types::ProgramData::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::ProgramData::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::ProgramData::drop(ptr: usize)
+pub unsafe fn bpfman::types::ProgramData::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::ProgramData where T: core::clone::Clone
+pub fn bpfman::types::ProgramData::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::ProgramData
+pub fn bpfman::types::ProgramData::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::ProgramData
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProgramData
+impl<T> typenum::type_operators::Same for bpfman::types::ProgramData
+pub type bpfman::types::ProgramData::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProgramData where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::ProgramData::vzip(self) -> V
+pub struct bpfman::types::TcProceedOn(_)
+impl bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::as_action_vec(&self) -> alloc::vec::Vec<i32>
+pub fn bpfman::types::TcProceedOn::from_int32s<T: core::convert::AsRef<[i32]>>(values: T) -> core::result::Result<bpfman::types::TcProceedOn, bpfman::errors::ParseError>
+pub fn bpfman::types::TcProceedOn::from_strings<T: core::convert::AsRef<[alloc::string::String]>>(values: T) -> core::result::Result<bpfman::types::TcProceedOn, bpfman::errors::ParseError>
+pub fn bpfman::types::TcProceedOn::is_empty(&self) -> bool
+pub fn bpfman::types::TcProceedOn::mask(&self) -> u32
+impl core::clone::Clone for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::clone(&self) -> bpfman::types::TcProceedOn
+impl core::default::Default for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::default() -> Self
+impl core::fmt::Debug for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::FromIterator<bpfman::types::TcProceedOnEntry> for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::from_iter<I: core::iter::traits::collect::IntoIterator<Item = bpfman::types::TcProceedOnEntry>>(iter: I) -> Self
+impl serde::ser::Serialize for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::TcProceedOn
+impl core::marker::Send for bpfman::types::TcProceedOn
+impl core::marker::Sync for bpfman::types::TcProceedOn
+impl core::marker::Unpin for bpfman::types::TcProceedOn
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::TcProceedOn
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::TcProceedOn
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::TcProceedOn where C: jwt::ToBase64
+pub fn bpfman::types::TcProceedOn::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::TcProceedOn where U: core::convert::From<T>
+pub fn bpfman::types::TcProceedOn::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::TcProceedOn where U: core::convert::Into<T>
+pub type bpfman::types::TcProceedOn::Error = core::convert::Infallible
+pub fn bpfman::types::TcProceedOn::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::TcProceedOn where U: core::convert::TryFrom<T>
+pub type bpfman::types::TcProceedOn::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::TcProceedOn::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::TcProceedOn where T: core::clone::Clone
+pub type bpfman::types::TcProceedOn::Owned = T
+pub fn bpfman::types::TcProceedOn::clone_into(&self, target: &mut T)
+pub fn bpfman::types::TcProceedOn::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::TcProceedOn where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::TcProceedOn::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::TcProceedOn where T: core::clone::Clone
+pub fn bpfman::types::TcProceedOn::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::TcProceedOn where T: 'static + core::marker::Sized
+pub fn bpfman::types::TcProceedOn::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::TcProceedOn where T: core::marker::Sized
+pub fn bpfman::types::TcProceedOn::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::TcProceedOn where T: core::marker::Sized
+pub fn bpfman::types::TcProceedOn::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::TcProceedOn
+pub type bpfman::types::TcProceedOn::Init = T
+pub const bpfman::types::TcProceedOn::ALIGN: usize
+pub unsafe fn bpfman::types::TcProceedOn::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::TcProceedOn::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::TcProceedOn::drop(ptr: usize)
+pub unsafe fn bpfman::types::TcProceedOn::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::TcProceedOn where T: core::clone::Clone
+pub fn bpfman::types::TcProceedOn::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::TcProceedOn where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::TcProceedOn::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::TcProceedOn where T: serde::ser::Serialize
+pub fn bpfman::types::TcProceedOn::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::TcProceedOn where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::TcProceedOn
+pub fn bpfman::types::TcProceedOn::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::TcProceedOn
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProceedOn
+impl<T> typenum::type_operators::Same for bpfman::types::TcProceedOn
+pub type bpfman::types::TcProceedOn::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProceedOn where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::TcProceedOn::vzip(self) -> V
+pub struct bpfman::types::TcProgram
+impl bpfman::types::TcProgram
+pub fn bpfman::types::TcProgram::get_attached(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_current_position(&self) -> core::result::Result<core::option::Option<usize>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_direction(&self) -> core::result::Result<bpfman::types::Direction, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_if_index(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_iface(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_priority(&self) -> core::result::Result<i32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_proceed_on(&self) -> core::result::Result<bpfman::types::TcProceedOn, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::new(data: bpfman::types::ProgramData, priority: i32, iface: alloc::string::String, proceed_on: bpfman::types::TcProceedOn, direction: bpfman::types::Direction) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::TcProgram
+pub fn bpfman::types::TcProgram::clone(&self) -> bpfman::types::TcProgram
+impl core::fmt::Debug for bpfman::types::TcProgram
+pub fn bpfman::types::TcProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::TcProgram
+impl core::marker::Send for bpfman::types::TcProgram
+impl core::marker::Sync for bpfman::types::TcProgram
+impl core::marker::Unpin for bpfman::types::TcProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::TcProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::TcProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::TcProgram where U: core::convert::From<T>
+pub fn bpfman::types::TcProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::TcProgram where U: core::convert::Into<T>
+pub type bpfman::types::TcProgram::Error = core::convert::Infallible
+pub fn bpfman::types::TcProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::TcProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::TcProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::TcProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::TcProgram where T: core::clone::Clone
+pub type bpfman::types::TcProgram::Owned = T
+pub fn bpfman::types::TcProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::TcProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::TcProgram where T: core::clone::Clone
+pub fn bpfman::types::TcProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::TcProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::TcProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::TcProgram where T: core::marker::Sized
+pub fn bpfman::types::TcProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::TcProgram where T: core::marker::Sized
+pub fn bpfman::types::TcProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::TcProgram
+pub fn bpfman::types::TcProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::TcProgram
+pub type bpfman::types::TcProgram::Init = T
+pub const bpfman::types::TcProgram::ALIGN: usize
+pub unsafe fn bpfman::types::TcProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::TcProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::TcProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::TcProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::TcProgram where T: core::clone::Clone
+pub fn bpfman::types::TcProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::TcProgram
+pub fn bpfman::types::TcProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::TcProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProgram
+impl<T> typenum::type_operators::Same for bpfman::types::TcProgram
+pub type bpfman::types::TcProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::TcProgram::vzip(self) -> V
+pub struct bpfman::types::TracepointProgram
+impl bpfman::types::TracepointProgram
+pub fn bpfman::types::TracepointProgram::get_tracepoint(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TracepointProgram::new(data: bpfman::types::ProgramData, tracepoint: alloc::string::String) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::TracepointProgram
+pub fn bpfman::types::TracepointProgram::clone(&self) -> bpfman::types::TracepointProgram
+impl core::fmt::Debug for bpfman::types::TracepointProgram
+pub fn bpfman::types::TracepointProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::TracepointProgram
+impl core::marker::Send for bpfman::types::TracepointProgram
+impl core::marker::Sync for bpfman::types::TracepointProgram
+impl core::marker::Unpin for bpfman::types::TracepointProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::TracepointProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::TracepointProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::TracepointProgram where U: core::convert::From<T>
+pub fn bpfman::types::TracepointProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::TracepointProgram where U: core::convert::Into<T>
+pub type bpfman::types::TracepointProgram::Error = core::convert::Infallible
+pub fn bpfman::types::TracepointProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::TracepointProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::TracepointProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::TracepointProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::TracepointProgram where T: core::clone::Clone
+pub type bpfman::types::TracepointProgram::Owned = T
+pub fn bpfman::types::TracepointProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::TracepointProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::TracepointProgram where T: core::clone::Clone
+pub fn bpfman::types::TracepointProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::TracepointProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::TracepointProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::TracepointProgram where T: core::marker::Sized
+pub fn bpfman::types::TracepointProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::TracepointProgram where T: core::marker::Sized
+pub fn bpfman::types::TracepointProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::TracepointProgram
+pub fn bpfman::types::TracepointProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::TracepointProgram
+pub type bpfman::types::TracepointProgram::Init = T
+pub const bpfman::types::TracepointProgram::ALIGN: usize
+pub unsafe fn bpfman::types::TracepointProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::TracepointProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::TracepointProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::TracepointProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::TracepointProgram where T: core::clone::Clone
+pub fn bpfman::types::TracepointProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::TracepointProgram
+pub fn bpfman::types::TracepointProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::TracepointProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::TracepointProgram
+impl<T> typenum::type_operators::Same for bpfman::types::TracepointProgram
+pub type bpfman::types::TracepointProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TracepointProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::TracepointProgram::vzip(self) -> V
+pub struct bpfman::types::UprobeProgram
+impl bpfman::types::UprobeProgram
+pub fn bpfman::types::UprobeProgram::get_container_pid(&self) -> core::result::Result<core::option::Option<i32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::get_fn_name(&self) -> core::result::Result<core::option::Option<alloc::string::String>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::get_offset(&self) -> core::result::Result<u64, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::get_pid(&self) -> core::result::Result<core::option::Option<i32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::get_retprobe(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::get_target(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::UprobeProgram::new(data: bpfman::types::ProgramData, fn_name: core::option::Option<alloc::string::String>, offset: u64, target: alloc::string::String, retprobe: bool, pid: core::option::Option<i32>, container_pid: core::option::Option<i32>) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::UprobeProgram
+pub fn bpfman::types::UprobeProgram::clone(&self) -> bpfman::types::UprobeProgram
+impl core::fmt::Debug for bpfman::types::UprobeProgram
+pub fn bpfman::types::UprobeProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::UprobeProgram
+impl core::marker::Send for bpfman::types::UprobeProgram
+impl core::marker::Sync for bpfman::types::UprobeProgram
+impl core::marker::Unpin for bpfman::types::UprobeProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::UprobeProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::UprobeProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::UprobeProgram where U: core::convert::From<T>
+pub fn bpfman::types::UprobeProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::UprobeProgram where U: core::convert::Into<T>
+pub type bpfman::types::UprobeProgram::Error = core::convert::Infallible
+pub fn bpfman::types::UprobeProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::UprobeProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::UprobeProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::UprobeProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::UprobeProgram where T: core::clone::Clone
+pub type bpfman::types::UprobeProgram::Owned = T
+pub fn bpfman::types::UprobeProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::UprobeProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::UprobeProgram where T: core::clone::Clone
+pub fn bpfman::types::UprobeProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::UprobeProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::UprobeProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::UprobeProgram where T: core::marker::Sized
+pub fn bpfman::types::UprobeProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::UprobeProgram where T: core::marker::Sized
+pub fn bpfman::types::UprobeProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::UprobeProgram
+pub fn bpfman::types::UprobeProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::UprobeProgram
+pub type bpfman::types::UprobeProgram::Init = T
+pub const bpfman::types::UprobeProgram::ALIGN: usize
+pub unsafe fn bpfman::types::UprobeProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::UprobeProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::UprobeProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::UprobeProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::UprobeProgram where T: core::clone::Clone
+pub fn bpfman::types::UprobeProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::UprobeProgram
+pub fn bpfman::types::UprobeProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::UprobeProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::UprobeProgram
+impl<T> typenum::type_operators::Same for bpfman::types::UprobeProgram
+pub type bpfman::types::UprobeProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::UprobeProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::UprobeProgram::vzip(self) -> V
+pub struct bpfman::types::XdpProceedOn(_)
+impl bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::as_action_vec(&self) -> alloc::vec::Vec<i32>
+pub fn bpfman::types::XdpProceedOn::from_int32s<T: core::convert::AsRef<[i32]>>(values: T) -> core::result::Result<bpfman::types::XdpProceedOn, bpfman::errors::ParseError>
+pub fn bpfman::types::XdpProceedOn::from_strings<T: core::convert::AsRef<[alloc::string::String]>>(values: T) -> core::result::Result<bpfman::types::XdpProceedOn, bpfman::errors::ParseError>
+pub fn bpfman::types::XdpProceedOn::mask(&self) -> u32
+impl core::clone::Clone for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::clone(&self) -> bpfman::types::XdpProceedOn
+impl core::default::Default for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::default() -> Self
+impl core::fmt::Debug for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::FromIterator<bpfman::types::XdpProceedOnEntry> for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::from_iter<I: core::iter::traits::collect::IntoIterator<Item = bpfman::types::XdpProceedOnEntry>>(iter: I) -> Self
+impl serde::ser::Serialize for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for bpfman::types::XdpProceedOn
+impl core::marker::Send for bpfman::types::XdpProceedOn
+impl core::marker::Sync for bpfman::types::XdpProceedOn
+impl core::marker::Unpin for bpfman::types::XdpProceedOn
+impl core::panic::unwind_safe::RefUnwindSafe for bpfman::types::XdpProceedOn
+impl core::panic::unwind_safe::UnwindSafe for bpfman::types::XdpProceedOn
+impl<C> jwt::token::signed::SignWithKey<alloc::string::String> for bpfman::types::XdpProceedOn where C: jwt::ToBase64
+pub fn bpfman::types::XdpProceedOn::sign_with_key(self, key: &impl jwt::algorithm::SigningAlgorithm) -> core::result::Result<alloc::string::String, jwt::error::Error>
+impl<T, U> core::convert::Into<U> for bpfman::types::XdpProceedOn where U: core::convert::From<T>
+pub fn bpfman::types::XdpProceedOn::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::XdpProceedOn where U: core::convert::Into<T>
+pub type bpfman::types::XdpProceedOn::Error = core::convert::Infallible
+pub fn bpfman::types::XdpProceedOn::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::XdpProceedOn where U: core::convert::TryFrom<T>
+pub type bpfman::types::XdpProceedOn::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::XdpProceedOn::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::XdpProceedOn where T: core::clone::Clone
+pub type bpfman::types::XdpProceedOn::Owned = T
+pub fn bpfman::types::XdpProceedOn::clone_into(&self, target: &mut T)
+pub fn bpfman::types::XdpProceedOn::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bpfman::types::XdpProceedOn where T: core::fmt::Display + core::marker::Sized
+pub fn bpfman::types::XdpProceedOn::to_string(&self) -> alloc::string::String
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::XdpProceedOn where T: core::clone::Clone
+pub fn bpfman::types::XdpProceedOn::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::XdpProceedOn where T: 'static + core::marker::Sized
+pub fn bpfman::types::XdpProceedOn::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::XdpProceedOn where T: core::marker::Sized
+pub fn bpfman::types::XdpProceedOn::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::XdpProceedOn where T: core::marker::Sized
+pub fn bpfman::types::XdpProceedOn::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::XdpProceedOn
+pub type bpfman::types::XdpProceedOn::Init = T
+pub const bpfman::types::XdpProceedOn::ALIGN: usize
+pub unsafe fn bpfman::types::XdpProceedOn::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::XdpProceedOn::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::XdpProceedOn::drop(ptr: usize)
+pub unsafe fn bpfman::types::XdpProceedOn::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::XdpProceedOn where T: core::clone::Clone
+pub fn bpfman::types::XdpProceedOn::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> jwt::FromBase64 for bpfman::types::XdpProceedOn where T: for<'de> serde::de::Deserialize<'de>
+pub fn bpfman::types::XdpProceedOn::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
+impl<T> jwt::ToBase64 for bpfman::types::XdpProceedOn where T: serde::ser::Serialize
+pub fn bpfman::types::XdpProceedOn::to_base64(&self) -> core::result::Result<alloc::borrow::Cow<'_, str>, jwt::error::Error>
+impl<T> serde::de::DeserializeOwned for bpfman::types::XdpProceedOn where T: for<'de> serde::de::Deserialize<'de>
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::XdpProceedOn
+pub fn bpfman::types::XdpProceedOn::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::XdpProceedOn
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProceedOn
+impl<T> typenum::type_operators::Same for bpfman::types::XdpProceedOn
+pub type bpfman::types::XdpProceedOn::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProceedOn where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::XdpProceedOn::vzip(self) -> V
+pub struct bpfman::types::XdpProgram
+impl bpfman::types::XdpProgram
+pub fn bpfman::types::XdpProgram::get_attached(&self) -> core::result::Result<bool, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_current_position(&self) -> core::result::Result<core::option::Option<usize>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_if_index(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_iface(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_priority(&self) -> core::result::Result<i32, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_proceed_on(&self) -> core::result::Result<bpfman::types::XdpProceedOn, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::new(data: bpfman::types::ProgramData, priority: i32, iface: alloc::string::String, proceed_on: bpfman::types::XdpProceedOn) -> core::result::Result<Self, bpfman::errors::BpfmanError>
+impl core::clone::Clone for bpfman::types::XdpProgram
+pub fn bpfman::types::XdpProgram::clone(&self) -> bpfman::types::XdpProgram
+impl core::fmt::Debug for bpfman::types::XdpProgram
+pub fn bpfman::types::XdpProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bpfman::types::XdpProgram
+impl core::marker::Send for bpfman::types::XdpProgram
+impl core::marker::Sync for bpfman::types::XdpProgram
+impl core::marker::Unpin for bpfman::types::XdpProgram
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::types::XdpProgram
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::types::XdpProgram
+impl<T, U> core::convert::Into<U> for bpfman::types::XdpProgram where U: core::convert::From<T>
+pub fn bpfman::types::XdpProgram::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::types::XdpProgram where U: core::convert::Into<T>
+pub type bpfman::types::XdpProgram::Error = core::convert::Infallible
+pub fn bpfman::types::XdpProgram::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::types::XdpProgram where U: core::convert::TryFrom<T>
+pub type bpfman::types::XdpProgram::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::types::XdpProgram::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bpfman::types::XdpProgram where T: core::clone::Clone
+pub type bpfman::types::XdpProgram::Owned = T
+pub fn bpfman::types::XdpProgram::clone_into(&self, target: &mut T)
+pub fn bpfman::types::XdpProgram::to_owned(&self) -> T
+impl<T> axum_core::extract::from_ref::FromRef<T> for bpfman::types::XdpProgram where T: core::clone::Clone
+pub fn bpfman::types::XdpProgram::from_ref(input: &T) -> T
+impl<T> core::any::Any for bpfman::types::XdpProgram where T: 'static + core::marker::Sized
+pub fn bpfman::types::XdpProgram::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::types::XdpProgram where T: core::marker::Sized
+pub fn bpfman::types::XdpProgram::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::types::XdpProgram where T: core::marker::Sized
+pub fn bpfman::types::XdpProgram::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::types::XdpProgram
+pub fn bpfman::types::XdpProgram::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::types::XdpProgram
+pub type bpfman::types::XdpProgram::Init = T
+pub const bpfman::types::XdpProgram::ALIGN: usize
+pub unsafe fn bpfman::types::XdpProgram::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::types::XdpProgram::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::types::XdpProgram::drop(ptr: usize)
+pub unsafe fn bpfman::types::XdpProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> dyn_clone::DynClone for bpfman::types::XdpProgram where T: core::clone::Clone
+pub fn bpfman::types::XdpProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> tonic::request::IntoRequest<T> for bpfman::types::XdpProgram
+pub fn bpfman::types::XdpProgram::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::types::XdpProgram
+impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProgram
+impl<T> typenum::type_operators::Same for bpfman::types::XdpProgram
+pub type bpfman::types::XdpProgram::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProgram where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::types::XdpProgram::vzip(self) -> V
+pub mod bpfman::utils
+pub const bpfman::utils::SOCK_MODE: u32 = 432u32
+pub fn bpfman::utils::create_bpffs(directory: &str) -> anyhow::Result<()>
+pub fn bpfman::utils::initialize_bpfman() -> anyhow::Result<()>
+pub fn bpfman::utils::open_config_file() -> bpfman::config::Config
+pub fn bpfman::utils::set_file_permissions(path: &std::path::Path, mode: u32)
+pub struct bpfman::BpfManager
+pub bpfman::BpfManager::image_manager: core::option::Option<bpfman::oci_utils::image_manager::ImageManager>
+pub bpfman::BpfManager::root_db: sled::db::Db
+impl bpfman::BpfManager
+pub async fn bpfman::BpfManager::add_program(&mut self, program: bpfman::types::Program) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
+pub fn bpfman::BpfManager::get_program(&mut self, id: u32) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
+pub fn bpfman::BpfManager::list_programs(&mut self, filter: bpfman::types::ListFilter) -> alloc::vec::Vec<bpfman::types::Program>
+pub fn bpfman::BpfManager::new(config: bpfman::config::Config) -> Self
+pub async fn bpfman::BpfManager::pull_bytecode(&mut self, image: bpfman::oci_utils::image_manager::BytecodeImage) -> anyhow::Result<()>
+pub async fn bpfman::BpfManager::rebuild_state(&mut self) -> core::result::Result<(), anyhow::Error>
+pub async fn bpfman::BpfManager::remove_program(&mut self, id: u32) -> core::result::Result<(), bpfman::errors::BpfmanError>
+impl core::marker::Freeze for bpfman::BpfManager
+impl core::marker::Send for bpfman::BpfManager
+impl core::marker::Sync for bpfman::BpfManager
+impl core::marker::Unpin for bpfman::BpfManager
+impl !core::panic::unwind_safe::RefUnwindSafe for bpfman::BpfManager
+impl !core::panic::unwind_safe::UnwindSafe for bpfman::BpfManager
+impl<T, U> core::convert::Into<U> for bpfman::BpfManager where U: core::convert::From<T>
+pub fn bpfman::BpfManager::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bpfman::BpfManager where U: core::convert::Into<T>
+pub type bpfman::BpfManager::Error = core::convert::Infallible
+pub fn bpfman::BpfManager::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bpfman::BpfManager where U: core::convert::TryFrom<T>
+pub type bpfman::BpfManager::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bpfman::BpfManager::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bpfman::BpfManager where T: 'static + core::marker::Sized
+pub fn bpfman::BpfManager::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bpfman::BpfManager where T: core::marker::Sized
+pub fn bpfman::BpfManager::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bpfman::BpfManager where T: core::marker::Sized
+pub fn bpfman::BpfManager::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for bpfman::BpfManager
+pub fn bpfman::BpfManager::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for bpfman::BpfManager
+pub type bpfman::BpfManager::Init = T
+pub const bpfman::BpfManager::ALIGN: usize
+pub unsafe fn bpfman::BpfManager::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn bpfman::BpfManager::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn bpfman::BpfManager::drop(ptr: usize)
+pub unsafe fn bpfman::BpfManager::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> tonic::request::IntoRequest<T> for bpfman::BpfManager
+pub fn bpfman::BpfManager::into_request(self) -> tonic::request::Request<T>
+impl<T> tracing::instrument::Instrument for bpfman::BpfManager
+impl<T> tracing::instrument::WithSubscriber for bpfman::BpfManager
+impl<T> typenum::type_operators::Same for bpfman::BpfManager
+pub type bpfman::BpfManager::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for bpfman::BpfManager where V: ppv_lite86::types::MultiLane<T>
+pub fn bpfman::BpfManager::vzip(self) -> V
+pub const bpfman::BPFMAN_ENV_LOG_LEVEL: &str
+pub fn bpfman::calc_map_pin_path(id: u32) -> std::path::PathBuf
+pub fn bpfman::create_map_pin_path(p: &std::path::Path) -> core::result::Result<(), bpfman::errors::BpfmanError>

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,11 +4,13 @@ mod build_manpage;
 mod copy;
 mod integration_test;
 mod protobuf;
+mod public_api;
 mod run;
 mod workspace;
 
 use std::process::exit;
 
+use cargo_metadata::MetadataCommand;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -34,10 +36,17 @@ enum Command {
     BuildManPage(build_manpage::Options),
     /// Build the completion scripts for bpfman.
     BuildCompletion(build_completion::Options),
+    /// Generate the public API documentation for bpfman.
+    PublicApi(public_api::Options),
 }
 
 fn main() {
     let opts = Options::parse();
+
+    let metadata = MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .expect("failed to run cargo metadata");
 
     use Command::*;
     let ret = match opts.command {
@@ -48,6 +57,7 @@ fn main() {
         IntegrationTest(opts) => integration_test::test(opts),
         BuildManPage(opts) => build_manpage::build_manpage(opts),
         BuildCompletion(opts) => build_completion::build_completion(opts),
+        PublicApi(opts) => public_api::public_api(opts, metadata),
     };
 
     if let Err(e) = ret {

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -1,0 +1,162 @@
+use std::{
+    fmt::Write as _,
+    fs::{read_to_string, File},
+    io::Write as _,
+    path::Path,
+};
+
+use anyhow::{bail, Context as _, Result};
+use cargo_metadata::{Metadata, Package, Target};
+use clap::Parser;
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use diff::{lines, Result as Diff};
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    /// Bless new API changes.
+    #[clap(long)]
+    pub bless: bool,
+
+    /// Bless new API changes.
+    #[clap(long)]
+    pub target: Option<String>,
+}
+
+pub fn public_api(options: Options, metadata: Metadata) -> Result<()> {
+    let toolchain = "nightly";
+    let Options { bless, target } = options;
+
+    if !rustup_toolchain::is_installed(toolchain)? {
+        if Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("No nightly toolchain detected. Would you like to install one?")
+            .interact()?
+        {
+            rustup_toolchain::install(toolchain)?;
+        } else {
+            bail!("nightly toolchain not installed")
+        }
+    }
+
+    let Metadata {
+        workspace_root,
+        packages,
+        ..
+    } = metadata;
+
+    let errors: Vec<_> = packages
+        .into_iter()
+        .map(
+            |Package {
+                 name,
+                 publish,
+                 targets,
+                 ..
+             }| {
+                if matches!(publish, Some(publish) if publish.is_empty()) {
+                    Ok(())
+                } else {
+                    if !targets
+                        .clone()
+                        .into_iter()
+                        .any(|target| target.kind.contains(&"lib".to_string()))
+                    {
+                        return Ok(());
+                    }
+
+                    let arch = target.as_ref().and_then(|target| {
+                        let proc_macro = targets.iter().any(|Target { kind, .. }| {
+                            kind.iter().any(|kind| kind == "proc-macro")
+                        });
+                        (!proc_macro).then_some(target)
+                    });
+
+                    let diff = check_package_api(
+                        &name,
+                        toolchain,
+                        arch.cloned(),
+                        bless,
+                        workspace_root.as_std_path(),
+                    )
+                    .with_context(|| format!("{name} failed to check public API"))?;
+                    if diff.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "{name} public API changed; re-run with --bless. diff:\n{diff}"
+                        ))
+                    }
+                }
+            },
+        )
+        .filter_map(|result| match result {
+            Ok(()) => None,
+            Err(err) => Some(err),
+        })
+        .collect();
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        for error in errors {
+            eprintln!("{}", error);
+        }
+        bail!("public API generation failed")
+    }
+}
+
+fn check_package_api(
+    package: &str,
+    toolchain: &str,
+    target: Option<String>,
+    bless: bool,
+    workspace_root: &Path,
+) -> Result<String> {
+    let path = workspace_root
+        .join("xtask")
+        .join("public-api")
+        .join(package)
+        .with_extension("txt");
+
+    let mut builder = rustdoc_json::Builder::default()
+        .toolchain(toolchain)
+        .package(package)
+        .all_features(true);
+    if let Some(target) = target {
+        builder = builder.target(target);
+    }
+    let rustdoc_json = builder.build().with_context(|| {
+        format!(
+            "rustdoc_json::Builder::default().toolchain({}).package({}).build()",
+            toolchain, package
+        )
+    })?;
+
+    let public_api = public_api::Builder::from_rustdoc_json(&rustdoc_json)
+        .build()
+        .with_context(|| {
+            format!(
+                "public_api::Builder::from_rustdoc_json({})::build()",
+                rustdoc_json.display()
+            )
+        })?;
+
+    if bless {
+        let mut output =
+            File::create(&path).with_context(|| format!("error creating {}", path.display()))?;
+        write!(&mut output, "{}", public_api)
+            .with_context(|| format!("error writing {}", path.display()))?;
+    }
+    let current_api =
+        read_to_string(&path).with_context(|| format!("error reading {}", path.display()))?;
+
+    Ok(lines(&public_api.to_string(), &current_api)
+        .into_iter()
+        .fold(String::new(), |mut buf, diff| {
+            match diff {
+                Diff::Both(..) => (),
+                Diff::Right(line) => writeln!(&mut buf, "-{}", line).unwrap(),
+                Diff::Left(line) => writeln!(&mut buf, "+{}", line).unwrap(),
+            };
+            buf
+        }))
+}


### PR DESCRIPTION
Now that bpfman is officially a library this adds
a public api check to ensure that changes to our
public api are tightly controlled and explicitly
"blessed" by contributors.  It will maintain
public api text files for the bpfman, bpfman-api,
and bpfman-csi library crates.

Fixes #1036 