### PR TITLE
Add xtask rules to run lint and ut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,29 +180,29 @@ accept and merge it. We recommend that you check the following things locally
 before you submit your code:
 
 * Verify that Rust code has been formatted and that all clippy lints have been fixed:
-
-```console
-cd src/bpfman/
-cargo +nightly fmt --all -- --check
-cargo +nightly clippy --all -- --deny warnings
-```
-
 * Verify that Go code has been formatted and linted
 * Verify that Yaml files have been formatted (see
   [Install Yaml Formatter](https://bpfman.io/main/getting-started/building-bpfman/#install-yaml-formatter))
+* Verify that Bash scripts have been linted using `shellcheck`
+
+```console
+cd src/bpfman/
+cargo xtask lint
+```
+
 * Verify that unit tests are passing locally (see
   [Unit Testing](https://bpfman.io/main/developer-guide/testing/#unit-testing)):
+
+```console
+cd src/bpfman/
+cargo xtask unit-test
+```
 
 * Verify any changes to the bpfman api have been "blessed"
 
 ```console
 cd /src/bpfman/
 cargo +nightly xtask public-api --bless
-```
-
-```console
-cd src/bpfman/
-cargo test
 ```
 
 * Verify that integration tests are passing locally (see

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+lint_all() {
+    echo "### Linting yaml"
+    if command -v prettier &>/dev/null; then
+        find ../ -type f -name '*.yaml' -print0 | xargs -0 prettier -l
+    else
+        echo "### prettier could not be found, skipping Yaml lint"
+    fi
+    echo "### Linting toml"
+    if command -v taplo &>/dev/null; then
+        taplo fmt --check
+    else
+        echo "### taplo could not be found, skipping Toml lint"
+    fi
+    echo "### Linting bash scripts"
+    if command -v shellcheck &>/dev/null; then
+        shellcheck -e SC2046 -e SC2086 -e SC2034 -e SC2181 -e SC2207 -e SC2002 -e  SC2155 -e SC2128 ./*.sh
+    else
+        echo "### shellcheck could not be found, skipping shell lint"
+    fi
+    echo "### Linting rust code"
+    cargo +nightly fmt --all -- --check
+    cargo +nightly clippy --all -- --deny warnings
+    echo "### Linting golang code"
+    golangci-lint run ../bpfman-operator/... ../examples/...
+}
+
+lint_all
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 CALL_POPD=false
 if [[ "$PWD" != */scripts ]]; then
-    pushd scripts &>/dev/null
+    pushd scripts &>/dev/null || exit
 fi
 
 # Source the functions in other files
@@ -121,5 +121,5 @@ case "$1" in
 esac
 
 if [[ "$CALL_POPD" == true ]]; then
-    popd &>/dev/null
+    popd &>/dev/null || exit
 fi

--- a/scripts/verify-golint.sh
+++ b/scripts/verify-golint.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # Copyright 2023 The Kubernetes Authors.

--- a/xtask/src/lint.rs
+++ b/xtask/src/lint.rs
@@ -1,0 +1,25 @@
+use std::{path::PathBuf, process::Command};
+
+use clap::Parser;
+
+use crate::workspace::WORKSPACE_ROOT;
+
+#[derive(Debug, Parser)]
+pub struct Options {}
+
+/// Run linter
+pub fn lint() -> Result<(), anyhow::Error> {
+    let root = PathBuf::from(WORKSPACE_ROOT.to_string());
+    let scripts_dir = root.join("scripts");
+
+    let args = vec!["-E", "./lint.sh"];
+
+    println!("scripts_dir: {}", scripts_dir.display());
+    let status = Command::new("sh")
+        .current_dir(&scripts_dir)
+        .args(args)
+        .status()
+        .expect("failed to run lint");
+    assert!(status.success());
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,9 +3,11 @@ mod build_ebpf;
 mod build_manpage;
 mod copy;
 mod integration_test;
+mod lint;
 mod protobuf;
 mod public_api;
 mod run;
+mod unit_test;
 mod workspace;
 
 use std::process::exit;
@@ -38,6 +40,10 @@ enum Command {
     BuildCompletion(build_completion::Options),
     /// Generate the public API documentation for bpfman.
     PublicApi(public_api::Options),
+    /// Run lint.
+    Lint(lint::Options),
+    /// Run unit tests.
+    UnitTest(unit_test::Options),
 }
 
 fn main() {
@@ -58,6 +64,8 @@ fn main() {
         BuildManPage(opts) => build_manpage::build_manpage(opts),
         BuildCompletion(opts) => build_completion::build_completion(opts),
         PublicApi(opts) => public_api::public_api(opts, metadata),
+        Lint(_) => lint::lint(),
+        UnitTest(opts) => unit_test::unit_test(opts),
     };
 
     if let Err(e) = ret {

--- a/xtask/src/unit_test.rs
+++ b/xtask/src/unit_test.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    /// Optional: Build the release target
+    #[clap(long)]
+    pub release: bool,
+}
+
+/// Run unit-test
+pub fn unit_test(opts: Options) -> Result<(), anyhow::Error> {
+    let mut args = vec!["test"];
+    if opts.release {
+        args.push("--release")
+    }
+    let status = Command::new("cargo")
+        .args(&args)
+        .status()
+        .expect("failed to run rust unit-test");
+    assert!(status.success());
+
+    let args = vec!["test", "./...", "-coverprofile", "cover.out"];
+    let status = Command::new("go")
+        .args(&args)
+        .status()
+        .expect("failed to run go unit-test");
+    assert!(status.success());
+
+    Ok(())
+}


### PR DESCRIPTION
```shell
cargo xtask -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/xtask -h`
Usage: xtask <COMMAND>

Commands:
  build-ebpf        Build the eBPF bytecode for programs used in the integration tests
  build-proto       Build the gRPC protobuf files
  copy              Prep the system for using bpfman by copying binaries to "/usr/sbin/"
  run               Run bpfman on the local host
  integration-test  Run the integration tests for bpfman
  build-man-page    Build the man pages for bpfman
  build-completion  Build the completion scripts for bpfman
  lint              Run the linter
  help              Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```
