### PR TITLE
De-duplicate code in the bpfman-agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,32 @@ jobs:
       - name: Check License Header
         uses: apache/skywalking-eyes@cd7b195c51fd3d6ad52afceb760719ddc6b3ee91
 
+  get-more-space:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check disk space
+        run: df -h
+
+      - name: Free up space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/local/lib/android
+          sudo apt-get update
+          sudo eatmydata apt-get purge --auto-remove -y \
+            azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+            google-chrome-stable \
+            llvm-* microsoft-edge-stable mono-* \
+            msbuild mysql-server-core-* php-* php7* \
+            powershell temurin-* zulu-*
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean -y
+
+      - name: Check disk space again
+        run: df -h
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -279,7 +305,7 @@ jobs:
         run: cargo xtask integration-test
 
   kubernetes-integration-tests:
-    needs: [build, build-go, build-docs]
+    needs: [get-more-space, build, build-go, build-docs, basic-integration-tests]
     runs-on: ubuntu-latest
     env:
       BPFMAN_IMG: quay.io/bpfman/bpfman:int-test
@@ -287,6 +313,15 @@ jobs:
       BPFMAN_OPERATOR_IMG: quay.io/bpfman/bpfman-operator:int-test
       XDP_PASS_PRIVATE_IMAGE_CREDS: ${{ secrets.XDP_PASS_PRIVATE_IMAGE_CREDS }}
     steps:
+      - name: Check disk space
+        run: df -h
+
+      - name: Prune Docker
+        run: sudo docker system prune -a -f --volumes
+
+      - name: Check disk space
+        run: df -h
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -322,16 +357,28 @@ jobs:
         run: |
           go install github.com/cilium/ebpf/cmd/bpf2go@v0.14.0
           cd examples
-          make build-bc-images
+          make build-all-images
 
-      - name: build example userspace images
-        run: cd examples && make build-us-images
+      - name: Check disk space
+        run: df -h
 
       - name: build images
         run: cd bpfman-operator && make build-images
 
+      - name: Check disk space
+        run: df -h
+
+      - name: run cargo clean
+        run: cargo clean
+
+      - name: Check disk space
+        run: df -h
+
       - name: run integration tests
         run: cd bpfman-operator && make test-integration
+
+      - name: Check disk space
+        run: df -h
 
       ## Upload diagnostics if integration test step failed.
       - name: upload diagnostics

--- a/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram.yaml
+++ b/bpfman-operator/config/samples/bpfman.io_v1alpha1_uprobe_uprobeprogram.yaml
@@ -10,7 +10,7 @@ spec:
   bpffunctionname: my_uprobe
   func_name: syscall
   # offset: 0 # optional offset w/in function
-  target: bpfman
+  target: libc
   retprobe: false
   # pid: 0 # optional pid to execute uprobe for
   bytecode:

--- a/bpfman-operator/controllers/bpfman-agent/xdp-program.go
+++ b/bpfman-operator/controllers/bpfman-agent/xdp-program.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +34,7 @@ import (
 
 	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 //+kubebuilder:rbac:groups=bpfman.io,resources=xdpprograms,verbs=get;list;watch
@@ -44,12 +43,8 @@ import (
 type XdpProgramReconciler struct {
 	ReconcilerCommon
 	currentXdpProgram *bpfmaniov1alpha1.XdpProgram
-	ourNode           *v1.Node
 	interfaces        []string
-}
-
-func (r *XdpProgramReconciler) getRecCommon() *ReconcilerCommon {
-	return &r.ReconcilerCommon
+	ourNode           *v1.Node
 }
 
 func (r *XdpProgramReconciler) getFinalizer() string {
@@ -58,6 +53,39 @@ func (r *XdpProgramReconciler) getFinalizer() string {
 
 func (r *XdpProgramReconciler) getRecType() string {
 	return internal.Xdp.String()
+}
+
+func (r *XdpProgramReconciler) getProgType() internal.ProgramType {
+	return internal.Xdp
+}
+
+func (r *XdpProgramReconciler) getName() string {
+	return r.currentXdpProgram.Name
+}
+
+func (r *XdpProgramReconciler) getNode() *v1.Node {
+	return r.ourNode
+}
+
+func (r *XdpProgramReconciler) getBpfProgramCommon() *bpfmaniov1alpha1.BpfProgramCommon {
+	return &r.currentXdpProgram.Spec.BpfProgramCommon
+}
+
+func (r *XdpProgramReconciler) setCurrentProgram(program client.Object) error {
+	var err error
+	var ok bool
+
+	r.currentXdpProgram, ok = program.(*bpfmaniov1alpha1.XdpProgram)
+	if !ok {
+		return fmt.Errorf("failed to cast program to XdpProgram")
+	}
+
+	r.interfaces, err = getInterfaces(&r.currentXdpProgram.Spec.InterfaceSelector, r.ourNode)
+	if err != nil {
+		return fmt.Errorf("failed to get interfaces for XdpProgram: %v", err)
+	}
+
+	return nil
 }
 
 // Must match with bpfman internal types
@@ -108,14 +136,14 @@ func (r *XdpProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *XdpProgramReconciler) expectedBpfPrograms(ctx context.Context) (*bpfmaniov1alpha1.BpfProgramList, error) {
+func (r *XdpProgramReconciler) getExpectedBpfPrograms(ctx context.Context) (*bpfmaniov1alpha1.BpfProgramList, error) {
 	progs := &bpfmaniov1alpha1.BpfProgramList{}
 
 	for _, iface := range r.interfaces {
 		bpfProgramName := fmt.Sprintf("%s-%s-%s", r.currentXdpProgram.Name, r.NodeName, iface)
 		annotations := map[string]string{internal.XdpProgramInterface: iface}
 
-		prog, err := r.createBpfProgram(ctx, bpfProgramName, r.getFinalizer(), r.currentXdpProgram, r.getRecType(), annotations)
+		prog, err := r.createBpfProgram(bpfProgramName, r.getFinalizer(), r.currentXdpProgram, r.getRecType(), annotations)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create BpfProgram %s: %v", bpfProgramName, err)
 		}
@@ -131,7 +159,6 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	r.currentXdpProgram = &bpfmaniov1alpha1.XdpProgram{}
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("xdp")
-	var err error
 
 	ctxLogger := log.FromContext(ctx)
 	ctxLogger.Info("Reconcile XDP: Enter", "ReconcileKey", req)
@@ -155,64 +182,23 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{Requeue: false}, nil
 	}
 
-	// Get existing ebpf state from bpfman.
-	programMap, err := bpfmanagentinternal.ListBpfmanPrograms(ctx, r.BpfmanClient, internal.Xdp)
-	if err != nil {
-		r.Logger.Error(err, "failed to list loaded bpfman programs")
-		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
-	}
-	r.Logger.V(1).Info("Existing XDP programs", "loaded-xdp-programs", programMap)
-
-	// Reconcile each XdpProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
-	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
-	// Note: This only results in grpc calls to bpfman if we need to change something
-	requeue := false // initialize requeue to false
-	for _, xdpProgram := range xdpPrograms.Items {
-		r.Logger.Info("XdpProgramController is reconciling", "currentXdpProgram", xdpProgram.Name)
-		r.currentXdpProgram = &xdpProgram
-
-		r.interfaces, err = getInterfaces(&r.currentXdpProgram.Spec.InterfaceSelector, r.ourNode)
-		if err != nil {
-			r.Logger.Error(err, "failed to get interfaces for XdpProgram")
-			return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
-		}
-
-		// Reconcile each XdpProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
-		// report the error to user and retry if specified. For some errors the controller may not decide to retry.
-		result, err := reconcileProgram(ctx, r, r.currentXdpProgram, &r.currentXdpProgram.Spec.BpfProgramCommon, r.ourNode, programMap)
-		if err != nil {
-			r.Logger.Error(err, "Reconciling XdpProgram Failed", "XdpProgramName", r.currentXdpProgram.Name, "ReconcileResult", result.String())
-		}
-
-		switch result {
-		case internal.Unchanged:
-			// continue with next program
-		case internal.Updated:
-			// return
-			return ctrl.Result{Requeue: false}, nil
-		case internal.Requeue:
-			// remember to do a requeue when we're done and continue with next program
-			requeue = true
-		}
+	// Create a list of Xdp programs to pass into reconcileCommon()
+	var xdpObjects []client.Object = make([]client.Object, len(xdpPrograms.Items))
+	for i := range xdpPrograms.Items {
+		xdpObjects[i] = &xdpPrograms.Items[i]
 	}
 
-	if requeue {
-		// A requeue has been requested
-		return ctrl.Result{RequeueAfter: retryDurationAgent}, nil
-	} else {
-		// We've made it through all the programs in the list without anything being
-		// updated and a reque has not been requested.
-		return ctrl.Result{Requeue: false}, nil
-	}
+	// Reconcile each TcProgram.
+	return r.reconcileCommon(ctx, r, xdpObjects)
 }
 
-func (r *XdpProgramReconciler) buildXdpLoadRequest(
-	bytecode *gobpfman.BytecodeLocation,
-	uuid string,
-	iface string,
-	mapOwnerId *uint32) *gobpfman.LoadRequest {
+func (r *XdpProgramReconciler) getLoadRequest(bpfProgram *bpfmaniov1alpha1.BpfProgram, mapOwnerId *uint32) (*gobpfman.LoadRequest, error) {
+	bytecode, err := bpfmanagentinternal.GetBytecode(r.Client, &r.currentXdpProgram.Spec.ByteCode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process bytecode selector: %v", err)
+	}
 
-	return &gobpfman.LoadRequest{
+	loadRequest := gobpfman.LoadRequest{
 		Bytecode:    bytecode,
 		Name:        r.currentXdpProgram.Spec.BpfFunctionName,
 		ProgramType: uint32(internal.Xdp),
@@ -220,148 +206,15 @@ func (r *XdpProgramReconciler) buildXdpLoadRequest(
 			Info: &gobpfman.AttachInfo_XdpAttachInfo{
 				XdpAttachInfo: &gobpfman.XDPAttachInfo{
 					Priority:  r.currentXdpProgram.Spec.Priority,
-					Iface:     iface,
+					Iface:     bpfProgram.Annotations[internal.XdpProgramInterface],
 					ProceedOn: xdpProceedOnToInt(r.currentXdpProgram.Spec.ProceedOn),
 				},
 			},
 		},
-		Metadata:   map[string]string{internal.UuidMetadataKey: uuid, internal.ProgramNameKey: r.currentXdpProgram.Name},
+		Metadata:   map[string]string{internal.UuidMetadataKey: string(bpfProgram.UID), internal.ProgramNameKey: r.currentXdpProgram.Name},
 		GlobalData: r.currentXdpProgram.Spec.GlobalData,
 		MapOwnerId: mapOwnerId,
 	}
-}
 
-// reconcileBpfmanPrograms ONLY reconciles the bpfman state for a single BpfProgram.
-// It does not interact with the k8s API in any way.
-func (r *XdpProgramReconciler) reconcileBpfmanProgram(ctx context.Context,
-	existingBpfPrograms map[string]*gobpfman.ListResponse_ListResult,
-	bytecodeSelector *bpfmaniov1alpha1.BytecodeSelector,
-	bpfProgram *bpfmaniov1alpha1.BpfProgram,
-	isNodeSelected bool,
-	isBeingDeleted bool,
-	mapOwnerStatus *MapOwnerParamStatus) (bpfmaniov1alpha1.BpfProgramConditionType, error) {
-
-	r.Logger.V(1).Info("Existing bpfProgram", "UUID", bpfProgram.UID, "Name", bpfProgram.Name, "CurrentXdpProgram", r.currentXdpProgram.Name)
-	iface := bpfProgram.Annotations[internal.XdpProgramInterface]
-
-	var err error
-	uuid := string(bpfProgram.UID)
-
-	getLoadRequest := func() (*gobpfman.LoadRequest, bpfmaniov1alpha1.BpfProgramConditionType, error) {
-		bytecode, err := bpfmanagentinternal.GetBytecode(r.Client, bytecodeSelector)
-		if err != nil {
-			return nil, bpfmaniov1alpha1.BpfProgCondBytecodeSelectorError, fmt.Errorf("failed to process bytecode selector: %v", err)
-		}
-		loadRequest := r.buildXdpLoadRequest(bytecode, uuid, iface, mapOwnerStatus.mapOwnerId)
-		return loadRequest, bpfmaniov1alpha1.BpfProgCondNone, nil
-	}
-
-	existingProgram, doesProgramExist := existingBpfPrograms[uuid]
-	if !doesProgramExist {
-		r.Logger.V(1).Info("XdpProgram doesn't exist on node for iface", "interface", iface)
-
-		// If XdpProgram is being deleted just break out and remove finalizer
-		if isBeingDeleted {
-			return bpfmaniov1alpha1.BpfProgCondUnloaded, nil
-		}
-
-		// Make sure if we're not selected just exit
-		if !isNodeSelected {
-			return bpfmaniov1alpha1.BpfProgCondNotSelected, nil
-		}
-
-		// Make sure if the Map Owner is set but not found then just exit
-		if mapOwnerStatus.isSet && !mapOwnerStatus.isFound {
-			return bpfmaniov1alpha1.BpfProgCondMapOwnerNotFound, nil
-		}
-
-		// Make sure if the Map Owner is set but not loaded then just exit
-		if mapOwnerStatus.isSet && !mapOwnerStatus.isLoaded {
-			return bpfmaniov1alpha1.BpfProgCondMapOwnerNotLoaded, nil
-		}
-
-		// otherwise load it
-		loadRequest, condition, err := getLoadRequest()
-		if err != nil {
-			return condition, err
-		}
-
-		r.progId, err = bpfmanagentinternal.LoadBpfmanProgram(ctx, r.BpfmanClient, loadRequest)
-		if err != nil {
-			r.Logger.Error(err, "Failed to load XdpProgram")
-			return bpfmaniov1alpha1.BpfProgCondNotLoaded, nil
-		}
-
-		r.Logger.Info("bpfman called to load XdpProgram on Node", "Name", bpfProgram.Name, "UUID", uuid)
-		return bpfmaniov1alpha1.BpfProgCondLoaded, nil
-	}
-
-	// prog ID should already have been set
-	id, err := bpfmanagentinternal.GetID(bpfProgram)
-	if err != nil {
-		r.Logger.Error(err, "Failed to get program ID")
-		return bpfmaniov1alpha1.BpfProgCondNotLoaded, nil
-	}
-
-	// BpfProgram exists but either XdpProgram is being deleted, node is no
-	// longer selected, or map is not available....unload program
-	if isBeingDeleted || !isNodeSelected ||
-		(mapOwnerStatus.isSet && (!mapOwnerStatus.isFound || !mapOwnerStatus.isLoaded)) {
-		r.Logger.V(1).Info("XdpProgram exists on Node but is scheduled for deletion, not selected, or map not available",
-			"isDeleted", isBeingDeleted, "isSelected", isNodeSelected, "mapIsSet", mapOwnerStatus.isSet,
-			"mapIsFound", mapOwnerStatus.isFound, "mapIsLoaded", mapOwnerStatus.isLoaded)
-
-		if err := bpfmanagentinternal.UnloadBpfmanProgram(ctx, r.BpfmanClient, *id); err != nil {
-			r.Logger.Error(err, "Failed to unload XdpProgram")
-			return bpfmaniov1alpha1.BpfProgCondNotUnloaded, nil
-		}
-
-		r.Logger.Info("bpfman called to unload XdpProgram on Node", "Name", bpfProgram.Name, "UUID", id)
-
-		if isBeingDeleted {
-			return bpfmaniov1alpha1.BpfProgCondUnloaded, nil
-		}
-
-		if !isNodeSelected {
-			return bpfmaniov1alpha1.BpfProgCondNotSelected, nil
-		}
-
-		if mapOwnerStatus.isSet && !mapOwnerStatus.isFound {
-			return bpfmaniov1alpha1.BpfProgCondMapOwnerNotFound, nil
-		}
-
-		if mapOwnerStatus.isSet && !mapOwnerStatus.isLoaded {
-			return bpfmaniov1alpha1.BpfProgCondMapOwnerNotLoaded, nil
-		}
-	}
-
-	// BpfProgram exists but is not correct state, unload and recreate
-	loadRequest, condition, err := getLoadRequest()
-	if err != nil {
-		return condition, err
-	}
-
-	isSame, reasons := bpfmanagentinternal.DoesProgExist(existingProgram, loadRequest)
-	if !isSame {
-		r.Logger.V(1).Info("XdpProgram is in wrong state, unloading and reloading", "Reason", reasons)
-
-		if err := bpfmanagentinternal.UnloadBpfmanProgram(ctx, r.BpfmanClient, *id); err != nil {
-			r.Logger.Error(err, "Failed to unload XdpProgram")
-			return bpfmaniov1alpha1.BpfProgCondNotUnloaded, nil
-		}
-
-		r.progId, err = bpfmanagentinternal.LoadBpfmanProgram(ctx, r.BpfmanClient, loadRequest)
-		if err != nil {
-			r.Logger.Error(err, "Failed to load XdpProgram")
-			return bpfmaniov1alpha1.BpfProgCondNotLoaded, nil
-		}
-
-		r.Logger.Info("bpfman called to reload XdpProgram on Node", "Name", bpfProgram.Name, "UUID", id)
-	} else {
-		// Program exists and bpfProgram K8s Object is up to date
-		r.Logger.V(1).Info("Ignoring Object Change nothing to do in bpfman")
-		r.progId = id
-	}
-
-	return bpfmaniov1alpha1.BpfProgCondLoaded, nil
+	return &loadRequest, nil
 }

--- a/bpfman-operator/controllers/bpfman-operator/fentry-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/fentry-program.go
@@ -57,7 +57,7 @@ func (r *FentryProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &bpfmaniov1alpha1.BpfProgram{}},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.And(statusChangedPredicate(), internal.BpfProgramTypePredicate(internal.Tracing.String()))),
+			builder.WithPredicates(predicate.And(statusChangedPredicate(), internal.BpfProgramTypePredicate(internal.FentryString))),
 		).
 		Complete(r)
 }
@@ -112,5 +112,5 @@ func (r *FentryProgramReconciler) updateStatus(ctx context.Context, name string,
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/fexit-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/fexit-program.go
@@ -57,7 +57,7 @@ func (r *FexitProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &bpfmaniov1alpha1.BpfProgram{}},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.And(statusChangedPredicate(), internal.BpfProgramTypePredicate(internal.Tracing.String()))),
+			builder.WithPredicates(predicate.And(statusChangedPredicate(), internal.BpfProgramTypePredicate(internal.FexitString))),
 		).
 		Complete(r)
 }
@@ -112,5 +112,5 @@ func (r *FexitProgramReconciler) updateStatus(ctx context.Context, name string, 
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/kprobe-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/kprobe-program.go
@@ -112,5 +112,5 @@ func (r *KprobeProgramReconciler) updateStatus(ctx context.Context, name string,
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/tc-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/tc-program.go
@@ -112,5 +112,5 @@ func (r *TcProgramReconciler) updateStatus(ctx context.Context, name string, con
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/tracepoint-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/tracepoint-program.go
@@ -112,5 +112,5 @@ func (r *TracepointProgramReconciler) updateStatus(ctx context.Context, name str
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/uprobe-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/uprobe-program.go
@@ -112,5 +112,5 @@ func (r *UprobeProgramReconciler) updateStatus(ctx context.Context, name string,
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/controllers/bpfman-operator/xdp-program.go
+++ b/bpfman-operator/controllers/bpfman-operator/xdp-program.go
@@ -114,5 +114,5 @@ func (r *XdpProgramReconciler) updateStatus(ctx context.Context, name string, co
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
+	return r.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfman-operator/internal/constants.go
+++ b/bpfman-operator/internal/constants.go
@@ -220,9 +220,12 @@ func (p ProgramType) String() string {
 	}
 }
 
-// Define a constant string for Uprobe.  It has the same kernel ProgramType as
-// Kprobe, so we can't use the ProgramType String() method above.
+// Define a constant strings for Uprobe, Fentry and Fexit.  Uprobe has the same
+// kernel ProgramType as Kprobe, and Fentry and Fexit both have the Tracing
+// ProgramType, so we can't use the ProgramType String() method above.
 const UprobeString = "uprobe"
+const FentryString = "fentry"
+const FexitString = "fexit"
 
 type ReconcileResult uint8
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -107,7 +107,7 @@ generate: ## Run `go generate` to build the bytecode for each of the examples.
 	go generate ./...
 
 .PHONY: build-us-images
-build-us-images: ## Build all example userspace images
+build-us-images: build ## Build all example userspace images
 	docker build -t ${IMAGE_TC_US} -f ./go-tc-counter/container-deployment/Containerfile.go-tc-counter ../
 	docker build -t ${IMAGE_TP_US} -f ./go-tracepoint-counter/container-deployment/Containerfile.go-tracepoint-counter ../
 	docker build -t ${IMAGE_XDP_US} -f ./go-xdp-counter/container-deployment/Containerfile.go-xdp-counter ../
@@ -116,10 +116,11 @@ build-us-images: ## Build all example userspace images
 	docker build -t ${IMAGE_URP_US} -f ./go-uretprobe-counter/container-deployment/Containerfile.go-uretprobe-counter ../
 	docker build -t ${IMAGE_GT_US} -f ./go-target/container-deployment/Containerfile.go-target ../
 
-
 .PHONY: build-bc-images
 build-bc-images: generate ## Build bytecode example userspace images
 	IMAGE_TC_BC=${IMAGE_TC_BC} IMAGE_TP_BC=${IMAGE_TP_BC} IMAGE_XDP_BC=${IMAGE_XDP_BC} IMAGE_KP_BC=${IMAGE_KP_BC} IMAGE_UP_BC=${IMAGE_UP_BC}  IMAGE_URP_BC=${IMAGE_URP_BC} ./build-bytecode-images.sh
+
+build-all-images: build-bc-images build-us-images ## Build both bytecode and userspace images
 
 .PHONY: push-us-images
 push-us-images: ## Push all example userspace images
@@ -335,7 +336,7 @@ endif
 		$(MAKE) $$target $(TAG_COMMAND) || true; \
 	done
 
-UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp undeploy-xdp-ms undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target
+UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp-ms undeploy-xdp undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target
 
 .PHONY: undeploy
 undeploy: ## Undeploy all examples to the cluster specified in ~/.kube/config.


### PR DESCRIPTION
- Created a common loop for reconciling *Programs
- Created a common reconcileBpfmanProgram() function
- Added some more getters to the bpfmanReconciler interface so we don't have to pass as many parameters around
- Made all of the functions in common.go that use ReconcilerCommon methods of ReconcilerCommon

Some additional changes:
- Used a different Type in the BpfProgram CRDs for fentry and fexit. With this change, the fentry and fexit controllers will only get triggered for the their own programs, and you can see the type when you get the bpfprogram CRD.
- Modified Makefile in examples
  - Made building go userspace code and bytecode dependencies of their respective build-*-image targets
  - Added a target to build-all-images
  - This combines 4 steps into one if you want to build both images.

Fixes: #1065