### PR TITLE
small v0.4.0 release fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,15 +389,15 @@ jobs:
           body_path: ./changelogs/CHANGELOG-${{ env.RELEASE_VERSION }}.md
           files: |
             bpfman-linux-x86_64.tar.gz
-
-      - name: publish bpfman crate
-        run: cargo publish -p bpfman --token ${{ secrets.BPFMAN_DEV_TOKEN }}
-
+      
+      - name: publish bpfman-csi crate
+        run: cargo publish -p bpfman-csi --token ${{ secrets.BPFMAN_DEV_TOKEN }}
+      
       - name: publish bpfman-api crate
         run: cargo publish -p bpfman-api --token ${{ secrets.BPFMAN_DEV_TOKEN }}
 
-      - name: publish bpfman-csi crate
-        run: cargo publish -p bpfman-csi --token ${{ secrets.BPFMAN_DEV_TOKEN }}
+      - name: publish bpfman crate
+        run: cargo publish -p bpfman --token ${{ secrets.BPFMAN_DEV_TOKEN }}
 
       - name: publish bpf-log-exporter crate
         run: cargo publish -p bpfman-log-exporter --token ${{ secrets.BPFMAN_DEV_TOKEN }}

--- a/changelogs/CHANGELOG-v0.4.0.md
+++ b/changelogs/CHANGELOG-v0.4.0.md
@@ -9,11 +9,11 @@ difference is that the `bpfctl` CLI can now simply be called directly with the
 On top of transitioning to a library the community has also implemented some
 exciting new features:
 
-- Support for Uprobe Programs
+- Support for Uprobe Programs in both core and kubernetes
 - The ability to attach Uprobes inside containers (locally and in Kubernetes), see [the blog](https://bpfman.io/main/blog/2024/02/26/technical-challenges-for-attaching-ebpf-programs-in-containers/) for more.
-- Support for Kprobe Programs
-- Support for Fentry Programs
-- Support for Fexit Programs
+- Support for Kprobe Programs in both core and kubernetes
+- Support for Fentry Programs in core
+- Support for Fexit Programs in core
 
 Additionally this release provides some new binary crates. The `bpfman-rpc` binary
 allows other languages to call into the bpfman library using the existing


### PR DESCRIPTION
Make sure to publish the bpfman-csi and bpfman-rpc crates before doing the core bpfman one since
they are dependencies.