### PR TITLE
bpfman: dir bpfman-sock missing for bpfman-rpc

### DIFF
--- a/bpfman/src/bin/cli/main.rs
+++ b/bpfman/src/bin/cli/main.rs
@@ -6,6 +6,7 @@ use args::Commands;
 use clap::Parser;
 use get::execute_get;
 use list::execute_list;
+use log::debug;
 use unload::execute_unload;
 
 mod args;
@@ -18,6 +19,9 @@ mod unload;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    env_logger::try_init()?;
+    debug!("Log using env_logger");
+
     let cli = crate::args::Cli::parse();
 
     cli.command.execute().await

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -50,7 +50,6 @@ pub mod utils;
 const MAPS_MODE: u32 = 0o0660;
 const MAP_PREFIX: &str = "map_";
 const MAPS_USED_BY_PREFIX: &str = "map_used_by_";
-pub(crate) const BPFMAN_ENV_LOG_LEVEL: &str = "RUST_LOG";
 
 pub(crate) mod directories {
     // The following directories are used by bpfman. They should be created by bpfman service

--- a/docs/developer-guide/logging.md
+++ b/docs/developer-guide/logging.md
@@ -19,7 +19,6 @@ Example:
 
 ```console
 $ sudo RUST_LOG=info /usr/local/bin/bpfman
-[2022-08-08T20:29:31Z INFO  bpfman] Log using env_logger
 [2022-08-08T20:29:31Z INFO  bpfman::server] Loading static programs from /etc/bpfman/programs.d
 [2022-08-08T20:29:31Z INFO  bpfman::server::bpf] Map veth12fa8e3 to 13
 [2022-08-08T20:29:31Z INFO  bpfman::server] Listening on [::1]:50051
@@ -61,7 +60,6 @@ Check the logs:
 ```console
 $ sudo journalctl -f -u bpfman
 Aug 08 16:25:04 ebpf03 systemd[1]: Started bpfman.service - Run bpfman as a service.
-Aug 08 16:25:04 ebpf03 bpfman[180118]: Log using journald
 Aug 08 16:25:04 ebpf03 bpfman[180118]: Loading static programs from /etc/bpfman/programs.d
 Aug 08 16:25:04 ebpf03 bpfman[180118]: Map veth12fa8e3 to 13
 Aug 08 16:25:04 ebpf03 bpfman[180118]: Listening on [::1]:50051
@@ -100,7 +98,6 @@ To view the `bpfman` logs:
 
 ```console
 kubectl logs -n bpfman bpfman-daemon-dgqzw -c bpfman
-[2023-05-05T14:41:26Z INFO  bpfman] Log using env_logger
 [2023-05-05T14:41:26Z INFO  bpfman] Has CAP_BPF: false
 [2023-05-05T14:41:26Z INFO  bpfman] Has CAP_SYS_ADMIN: true
 :

--- a/docs/getting-started/launching-bpfman.md
+++ b/docs/getting-started/launching-bpfman.md
@@ -32,7 +32,6 @@ For more details on how logging is handled in bpfman, see [Logging](../developer
 
 ```console
 sudo RUST_LOG=info ./target/debug/bpfman-rpc --timeout=0
-[INFO  bpfman::utils] Log using env_logger
 [INFO  bpfman::utils] Has CAP_BPF: true
 [INFO  bpfman::utils] Has CAP_SYS_ADMIN: true
 [WARN  bpfman::utils] Unable to read config file, using defaults
@@ -75,7 +74,6 @@ sudo journalctl -f -u bpfman.service -u bpfman.socket
 Mar 27 09:13:54 server-calvin systemd[1]: Listening on bpfman.socket - bpfman API Socket.
   <RUN "sudo ./go-kprobe-counter">
 Mar 27 09:15:43 server-calvin systemd[1]: Started bpfman.service - Run bpfman as a service.
-Mar 27 09:15:43 server-calvin bpfman-rpc[2548091]: Log using journald
 Mar 27 09:15:43 server-calvin bpfman-rpc[2548091]: Has CAP_BPF: true
 Mar 27 09:15:43 server-calvin bpfman-rpc[2548091]: Has CAP_SYS_ADMIN: true
 Mar 27 09:15:43 server-calvin bpfman-rpc[2548091]: Unable to read config file, using defaults

--- a/docs/getting-started/running-release.md
+++ b/docs/getting-started/running-release.md
@@ -48,7 +48,6 @@ To deploy `bpfman-rpc`:
 
 ```console
 sudo RUST_LOG=info ./bpfman-rpc --timeout=0
-[INFO  bpfman::utils] Log using env_logger
 [INFO  bpfman::utils] Has CAP_BPF: true
 [INFO  bpfman::utils] Has CAP_SYS_ADMIN: true
 [WARN  bpfman::utils] Unable to read config file, using defaults


### PR DESCRIPTION
When running bpfman as a long running process, bpfman-rpc fails to run because directory /run/bpfman-sock is not created.

```
$ sudo RUST_LOG=info ./target/debug/bpfman-rpc --timeout=0
Error: No such file or directory (os error 2)
```

Second issue is that no logs are generated when bpfman-rpc is run.

As part of the rework of bpfman recently, the creation of /run/bpfman-sock was moved from bpfman to bpfman-rpc, but it was inadvertantly moved to a CSI only check. The fix is to move it out of the CSI only logic.

Now that bpfman core is a library, all log initialization should occur in the calling binary. So move the log initialization to bpfman-rpc and bpfman CLI.

Resolves: #1077