### PR TITLE
bpfman: include license in crate workspace

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -7,6 +7,7 @@ header:
     paths:
       - bpfman
     paths-ignore:
+      - "**/LICENSE-*"
       - "**/target/**"
       - "**/*.toml"
       - "**/*.proto"

--- a/bpfman/LICENSE-APACHE
+++ b/bpfman/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE


### PR DESCRIPTION
This PR includes the licenses files in the crate workspace subdirectory.
Without this, they won't be showing on crates.io and would be giving out
errors on tooling such as rust2rpm.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
