### PR TITLE
image: Add missing images to push to quay

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -276,6 +276,26 @@ jobs:
               type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
+            build_language: go
+            bpf_build_wrapper: go
+            repository: bpfman-bytecode
+            image: go-uretprobe-counter
+            context: ./examples/go-uretprobe-counter
+            dockerfile: ./Containerfile.bytecode
+            build_args: |
+              PROGRAM_NAME=uretprobe_counter
+              BPF_FUNCTION_NAME=uretprobe_counter
+              PROGRAM_TYPE=uretprobe
+              BYTECODE_FILENAME=bpf_x86_bpfel.o
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+          - registry: quay.io
             build_language: rust
             bpf_build_wrapper: rust
             repository: bpfman-bytecode
@@ -365,7 +385,7 @@ jobs:
             build_args: |
               PROGRAM_NAME=uprobe
               BPF_FUNCTION_NAME=my_uprobe
-              PROGRAM_TYPE=kprobe
+              PROGRAM_TYPE=uprobe
               BYTECODE_FILENAME=uprobe.bpf.o
             tags: |
               type=ref,event=branch
@@ -385,7 +405,7 @@ jobs:
             build_args: |
               PROGRAM_NAME=uretprobe
               BPF_FUNCTION_NAME=my_uretprobe
-              PROGRAM_TYPE=kprobe
+              PROGRAM_TYPE=uretprobe
               BYTECODE_FILENAME=uprobe.bpf.o
             tags: |
               type=ref,event=branch
@@ -425,8 +445,48 @@ jobs:
             build_args: |
               PROGRAM_NAME=kretprobe
               BPF_FUNCTION_NAME=my_kretprobe
-              PROGRAM_TYPE=kprobe
+              PROGRAM_TYPE=kretprobe
               BYTECODE_FILENAME=kprobe.bpf.o
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+          - registry: quay.io
+            build_language: rust
+            bpf_build_wrapper: rust
+            repository: bpfman-bytecode
+            image: fentry
+            context: ./tests/integration-test/bpf/.output
+            dockerfile: ./Containerfile.bytecode
+            build_args: |
+              PROGRAM_NAME=do_unlinkat
+              BPF_FUNCTION_NAME=test_fentry
+              PROGRAM_TYPE=fentry
+              BYTECODE_FILENAME=fentry.bpf.o
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+          - registry: quay.io
+            build_language: rust
+            bpf_build_wrapper: rust
+            repository: bpfman-bytecode
+            image: fexit
+            context: ./tests/integration-test/bpf/.output
+            dockerfile: ./Containerfile.bytecode
+            build_args: |
+              PROGRAM_NAME=do_unlinkat
+              BPF_FUNCTION_NAME=test_fexit
+              PROGRAM_TYPE=fexit
+              BYTECODE_FILENAME=fentry.bpf.o
             tags: |
               type=ref,event=branch
               type=ref,event=tag

--- a/examples/build-bytecode-images.sh
+++ b/examples/build-bytecode-images.sh
@@ -43,7 +43,7 @@ docker build \
 docker build \
  --build-arg PROGRAM_NAME=uretprobe_counter \
  --build-arg BPF_FUNCTION_NAME=uretprobe_counter \
- --build-arg PROGRAM_TYPE=uprobe \
+ --build-arg PROGRAM_TYPE=uretprobe \
  --build-arg BYTECODE_FILENAME=bpf_x86_bpfel.o \
  -f ../Containerfile.bytecode \
  ./go-uretprobe-counter -t $IMAGE_URP_BC

--- a/tests/integration-test/bpf/build_push_images.sh
+++ b/tests/integration-test/bpf/build_push_images.sh
@@ -45,7 +45,7 @@ docker push quay.io/bpfman-bytecode/tracepoint
 docker build \
  --build-arg PROGRAM_NAME=uprobe \
  --build-arg BPF_FUNCTION_NAME=my_uprobe \
- --build-arg PROGRAM_TYPE=kprobe \
+ --build-arg PROGRAM_TYPE=uprobe \
  --build-arg BYTECODE_FILENAME=uprobe.bpf.o \
  -f ../../../Containerfile.bytecode \
  ./.output -t quay.io/bpfman-bytecode/uprobe:latest
@@ -55,7 +55,7 @@ docker push quay.io/bpfman-bytecode/uprobe
 docker build \
  --build-arg PROGRAM_NAME=uretprobe \
  --build-arg BPF_FUNCTION_NAME=my_uretprobe \
- --build-arg PROGRAM_TYPE=kprobe \
+ --build-arg PROGRAM_TYPE=uretprobe \
  --build-arg BYTECODE_FILENAME=uprobe.bpf.o \
  -f ../../../Containerfile.bytecode \
  ./.output -t quay.io/bpfman-bytecode/uretprobe:latest
@@ -75,7 +75,7 @@ docker push quay.io/bpfman-bytecode/kprobe
 docker build \
  --build-arg PROGRAM_NAME=kretprobe \
  --build-arg BPF_FUNCTION_NAME=my_kretprobe \
- --build-arg PROGRAM_TYPE=kprobe \
+ --build-arg PROGRAM_TYPE=kretprobe \
  --build-arg BYTECODE_FILENAME=kprobe.bpf.o \
  -f ../../../Containerfile.bytecode \
  ./.output -t quay.io/bpfman-bytecode/kretprobe:latest


### PR DESCRIPTION
go-uretprobe-counter, from the examples directory, and fentry/fexit from the integration-tests directory, are not being pushed to quay.io automatically because they are missing from image-build.yaml. So add those images.

While there, noticed that PROGRAM_TYPE is being used inconsistently. Sometimes uprobe uses kprobe and sometimes it uses uprobe. Made them consistent with image type (kprobe, kretprobe, uprobe, uretprobe).