### PR TITLE
fix mounter image to fedora 39

### DIFF
--- a/bpfman-operator/config/bpfman-deployment/daemonset.yaml
+++ b/bpfman-operator/config/bpfman-deployment/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       ## in kind so mount it if needed.
       initContainers:
         - name: mount-bpffs
-          image: quay.io/fedora/fedora-minimal:latest
+          image: quay.io/fedora/fedora-minimal:39
           command:
             - /bin/sh
             - -xc


### PR DESCRIPTION
Fix the image we use to mount the default bpffs
if it's not mounted (i.e kind) to fedora 39 since
the newer fedora-minimal images don't have the
mount binary by default.