### PR TITLE
test: add image name test

### DIFF
--- a/docs/developer-guide/k8s-selinux-distros.md
+++ b/docs/developer-guide/k8s-selinux-distros.md
@@ -1,14 +1,14 @@
-# Running the Examples as Non-Root on Selinux Distributions
+# Running the Examples as Non-Root on SELinux Distributions
 
-Developer instances of Kubernetes such as kind often set SElinux to permissive
+Developer instances of Kubernetes such as kind often set SELinux to permissive
 mode, ensuring the security subsystem does not interfere with the local
 cluster operations.  However, in production distributions such as
-Openshift, EKS, GKE and AWS where security is paramount, selinux and other
+Openshift, EKS, GKE and AWS where security is paramount, SELinux and other
 security subsystems are often enabled by default.  This among other things
 presents unique challenges when determining how to deploy unprivileged applications
 with bpfman.
 
-In order to deploy the provided examples on selinux distributions, users must
+In order to deploy the provided examples on SELinux distributions, users must
 first install the [security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator).
 This will allow bpfman to deploy custom SELinux policies which will allow container users
 access to bpf maps (i.e `map_read` and `map_write` actions).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
       - Debugging: developer-guide/debugging.md
       - Releasing: developer-guide/release.md
       - XDP Tutorial: developer-guide/xdp-overview.md
-      - Running the Examples as Non-Root on Selinux Distributions: developer-guide/k8s-selinux-distros.md
+      - Running the Examples as Non-Root on SELinux Distributions: developer-guide/k8s-selinux-distros.md
   - Design:
       - Daemonless: design/daemonless.md
   - Blog:

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -56,7 +56,7 @@ fn test_load_unload_xdp() {
                 lt,
                 XDP_PASS_IMAGE_LOC,
                 XDP_PASS_FILE_LOC,
-                XDP_PASS_NAME,
+                Some(XDP_PASS_NAME),
                 None, // metadata
                 None, // map_owner_id
             );
@@ -95,7 +95,7 @@ fn test_map_sharing_load_unload_xdp() {
         &load_type,
         XDP_COUNTER_IMAGE_LOC,
         "", // file_path
-        XDP_COUNTER_NAME,
+        None,
         None, // metadata
         None, // map_owner_id
     );
@@ -131,7 +131,7 @@ fn test_map_sharing_load_unload_xdp() {
         &load_type,
         XDP_COUNTER_IMAGE_LOC,
         "", // file_path
-        XDP_COUNTER_NAME,
+        None,
         None, // metadata
         map_owner_id_u32,
     );
@@ -409,7 +409,7 @@ fn test_list_with_metadata() {
                 lt,
                 XDP_PASS_IMAGE_LOC,
                 XDP_PASS_FILE_LOC,
-                XDP_PASS_NAME,
+                Some(XDP_PASS_NAME),
                 None, // metadata
                 None, // map_owner_id
             );
@@ -427,7 +427,7 @@ fn test_list_with_metadata() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         Some(vec![key]),
         None, // map_owner_id
     );

--- a/tests/integration-test/src/tests/e2e.rs
+++ b/tests/integration-test/src/tests/e2e.rs
@@ -48,7 +48,7 @@ fn test_proceed_on_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -78,7 +78,7 @@ fn test_proceed_on_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -109,7 +109,7 @@ fn test_proceed_on_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -159,7 +159,7 @@ fn test_unload_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -176,7 +176,7 @@ fn test_unload_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -193,7 +193,7 @@ fn test_unload_xdp() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -570,7 +570,7 @@ fn test_program_execution_with_global_variables() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -722,7 +722,7 @@ fn test_load_unload_xdp_maps() {
         &LoadType::Image,
         XDP_COUNTER_IMAGE_LOC,
         "", // file_path
-        XDP_COUNTER_NAME,
+        Some(XDP_COUNTER_NAME),
         None, // metadata
         None, // map_owner_id
     );

--- a/tests/integration-test/src/tests/error.rs
+++ b/tests/integration-test/src/tests/error.rs
@@ -67,7 +67,7 @@ fn common_load_parameter_testing() {
         test_bpfmanlist();
     }
 
-    debug!("Error checking common load parameters: non-existent name");
+    debug!("Error checking common load parameters: File non-existent name");
     let (error_prog_id, _) = add_xdp(
         DEFAULT_BPFMAN_IFACE,
         35,   // priority
@@ -76,7 +76,24 @@ fn common_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        NONEXISTENT_XDP_PASS_NAME,
+        Some(NONEXISTENT_XDP_PASS_NAME),
+        None, // metadata
+        None, // map_owner_id
+    );
+    assert!(error_prog_id.is_err());
+    // Make sure bpfman is still accessible after command
+    test_bpfmanlist();
+
+    debug!("Error checking common load parameters: Image non-existent name");
+    let (error_prog_id, _) = add_xdp(
+        DEFAULT_BPFMAN_IFACE,
+        35,   // priority
+        None, // globals
+        None, // proceed_on
+        &LoadType::Image,
+        XDP_PASS_IMAGE_LOC,
+        XDP_PASS_FILE_LOC,
+        Some(NONEXISTENT_XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -93,7 +110,7 @@ fn common_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        INVALID_XDP_PASS_NAME,
+        Some(INVALID_XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -124,7 +141,7 @@ fn common_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         Some(vec![key]), // metadata
         None,            // map_owner_id
     );
@@ -141,7 +158,7 @@ fn common_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -560,7 +577,7 @@ fn xdp_load_parameter_testing() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -577,7 +594,7 @@ fn xdp_load_parameter_testing() {
         &LoadType::Image,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -594,7 +611,7 @@ fn xdp_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -612,7 +629,7 @@ fn xdp_load_parameter_testing() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );
@@ -634,7 +651,7 @@ fn xdp_load_parameter_testing() {
     //        lt,
     //        TC_PASS_IMAGE_LOC,
     //        TC_PASS_FILE_LOC,
-    //        XDP_PASS_NAME,
+    //        Some(XDP_PASS_NAME),
     //        None, // metadata
     //        None, // map_owner_id
     //    );
@@ -750,7 +767,7 @@ fn test_invalid_parameters() {
         &LoadType::File,
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
-        XDP_PASS_NAME,
+        Some(XDP_PASS_NAME),
         None, // metadata
         None, // map_owner_id
     );

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -123,7 +123,7 @@ pub fn add_xdp(
     load_type: &LoadType,
     image_url: &str,
     file_path: &str,
-    name: &str,
+    name: Option<&str>,
     metadata: Option<Vec<&str>>,
     map_owner_id: Option<u32>,
 ) -> (Result<String>, Result<String>) {
@@ -158,9 +158,13 @@ pub fn add_xdp(
         args.extend(["--map-owner-id", owner_id.as_str()]);
     }
 
+    if let Some(n) = name {
+        args.extend(["--name", n]);
+    }
+
     match load_type {
         LoadType::Image => args.extend(["--image-url", image_url, "--pull-policy", "Always"]),
-        LoadType::File => args.extend(["-n", name, "--path", file_path]),
+        LoadType::File => args.extend(["--path", file_path]),
     }
 
     args.extend(["xdp", "--iface", iface]);


### PR DESCRIPTION
Adding one additional test to integration error test cases. For loading from image, if no name is provided, use name from OCI Image. If name is provided, use that instead. So added a test to pass in an invalid name from CLI when laoding from image and make sure command fails.

Also global changed all forms of selinux to SELinux.