### PR TITLE
Remove propose_downstream packit job

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -36,8 +36,3 @@ jobs:
       - fedora-development
       - fedora-stable
     specfile_path: bpfman.spec
-  - job: propose_downstream
-    trigger: release
-    dist_git_branches:
-      - fedora-development
-      - fedora-stable


### PR DESCRIPTION
So far we're still proposing the package to be acceptef on Fedora, so
this job would just fail. Let's remove it until we get the package in
and it gets accepted.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>