### PR TITLE
Add bpfman 0.4.1-rc1 to builds and cargo metadata

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,7 @@ downstream_package_name: bpfman
 upstream_project_url: https://github.com/bpfman/bpfman
 specfile_path: bpfman.spec
 prerelease_suffix_pattern: ([.\-_~^]?)(dev|alpha|beta|rc|pre(view)?)([.\-_]?\d+)?
+prerelease_suffix_macro: prerelease
 srpm_build_deps:
   - cargo
   - rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-log-exporter"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-metrics-exporter"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "aya",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-api"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-ns"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "aya",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "bpfman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"
 repository = "https://github.com/bpfman/bpfman"
-version = "0.4.0"
+version = "0.4.1-rc1"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -28,8 +28,8 @@ async-trait = { version = "0.1", default-features = false }
 aya = { version = "0.12", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.22.0", default-features = false }
-bpfman = { version = "0.4.0", path = "./bpfman" }
-bpfman-api = { version = "0.4.0", path = "./bpfman-api" }
+bpfman = { version = "0.4.1-rc1", path = "./bpfman" }
+bpfman-api = { version = "0.4.1-rc1", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
 caps = { version = "0.5.4", default-features = false }
 cargo_metadata = { version = "0.18.0", default-features = false }

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -4,8 +4,8 @@
 %global crate bpfman
 %global commit GITSHA
 %global shortcommit GITSHORTSHA
-%global base_version 0.4.0
-%global prerelease dev
+%global base_version 0.4.1
+%global prerelease rc1
 %global package_version %{base_version}%{?prerelease:~%{prerelease}}
 %global upstream_version %{base_version}%{?prerelease:~%{prerelease}}
 


### PR DESCRIPTION
This commit changes the now wrong cargo metadata and packit
configuration and adds the new versioning for 0.4.1-rc1.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>