### PR TITLE
cut a rc4 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,10 +425,10 @@ jobs:
         run: cargo publish -p bpfman-api --token ${{ secrets.BPFMAN_DEV_TOKEN }}
 
       - name: publish bpf-log-exporter crate
-        run: cargo publish -p bpfman-log-exporter --token ${{ secrets.BPFMAN_DEV_TOKEN }}
+        run: cargo publish -p bpf-log-exporter --token ${{ secrets.BPFMAN_DEV_TOKEN }}
 
       - name: publish bpf-metrics-exporter crate
-        run: cargo publish -p bpfman-metrics-exporter --token ${{ secrets.BPFMAN_DEV_TOKEN }}
+        run: cargo publish -p bpf-metrics-exporter --token ${{ secrets.BPFMAN_DEV_TOKEN }}
 
   build-workflow-complete:
     needs:

--- a/.packit.yml
+++ b/.packit.yml
@@ -44,6 +44,15 @@ jobs:
     actions:
       fix-spec-file:
         - bash -c "OVERWRITE_RELEASE=false bash .packit.sh"
+      get-current-version:
+        - bash -c 'cargo metadata --format-version 1 | jq -r ".packages[] | select(.name == \"bpfman\") | .version"'
+      post-upstream-clone:
+        bash -c 'if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/coreos/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi &&
+        cd /var/tmp/cargo-vendor-filterer &&
+        cargo build &&
+        cd - &&
+        cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . &&
+        ./cargo-vendor-filterer --format tar.gz --prefix vendor bpfman-bpfman-vendor.tar.gz'
     specfile_path: bpfman.spec
     owner: "@ebpf-sig"
     project: bpfman

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-log-exporter"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-metrics-exporter"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "aya",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-api"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-ns"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "aya",
@@ -3514,18 +3514,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "bpfman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"
 repository = "https://github.com/bpfman/bpfman"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -28,8 +28,8 @@ async-trait = { version = "0.1", default-features = false }
 aya = { version = "0.12", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.22.0", default-features = false }
-bpfman = { version = "0.4.1-rc3", path = "./bpfman" }
-bpfman-api = { version = "0.4.1-rc3", path = "./bpfman-api" }
+bpfman = { version = "0.4.1-rc4", path = "./bpfman" }
+bpfman-api = { version = "0.4.1-rc4", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
 caps = { version = "0.5.4", default-features = false }
 cargo_metadata = { version = "0.18.0", default-features = false }

--- a/changelogs/CHANGELOG-v0.4.1-rc4.md
+++ b/changelogs/CHANGELOG-v0.4.1-rc4.md
@@ -1,0 +1,1 @@
+Pre-release 4 for 0.4.1


### PR DESCRIPTION
Cut a v0.4.1-rc4 release
- Fixup the publish crate action
- fixup packit.yml one last time since we need a custom set of actions when building for a release unfortunately this means we need to copy ALL of the actions since they get overridden.