### PR TITLE
fixup the bpfman-csv

### DIFF
--- a/bpfman-operator/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/bpfman-operator/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -3,6 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: "[]"
+    categories: OpenShift Optional
     capabilities: Basic Install
     containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
     repository: https://github.com/bpfman/bpfman

--- a/bpfman-operator/config/openshift/kustomization.yaml
+++ b/bpfman-operator/config/openshift/kustomization.yaml
@@ -33,4 +33,3 @@ resources:
   - ../bpfman-operator-deployment
   - ../bpfman-deployment
   - rbac.yaml
-  - user-scc.yaml

--- a/examples/config/selinux/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-kprobe-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-kprobe-counter

--- a/examples/config/selinux/go-kprobe-counter/user-scc.yaml
+++ b/examples/config/selinux/go-kprobe-counter/user-scc.yaml
@@ -2,7 +2,7 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: restricted
+  name: bpfman-restricted
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -39,7 +39,7 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user
+  name: bpfman-user
 rules:
   - apiGroups:
       - security.openshift.io

--- a/examples/config/selinux/go-tc-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tc-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-tc-counter

--- a/examples/config/selinux/go-tc-counter/user-scc.yaml
+++ b/examples/config/selinux/go-tc-counter/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---

--- a/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-tracepoint-counter

--- a/examples/config/selinux/go-tracepoint-counter/user-scc.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---

--- a/examples/config/selinux/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uprobe-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-uprobe-counter

--- a/examples/config/selinux/go-uprobe-counter/user-scc.yaml
+++ b/examples/config/selinux/go-uprobe-counter/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---

--- a/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-uretprobe-counter

--- a/examples/config/selinux/go-uretprobe-counter/user-scc.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---

--- a/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
@@ -35,6 +35,7 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-xdp-counter-sharing-map
 images:
   - name: quay.io/bpfman-userspace/go-xdp-counter

--- a/examples/config/selinux/go-xdp-counter-sharing-map/user-scc.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---

--- a/examples/config/selinux/go-xdp-counter/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter/kustomization.yaml
@@ -36,4 +36,5 @@ patches:
 resources:
   - selinux.yaml
   - binding.yaml
+  - user-scc.yaml
   - ../../base/go-xdp-counter

--- a/examples/config/selinux/go-xdp-counter/user-scc.yaml
+++ b/examples/config/selinux/go-xdp-counter/user-scc.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: bpfman-restricted
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bpfman-user
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - bpfman-restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---


### PR DESCRIPTION
- Fixup the csv file
- Move the custom SCC into each application since the CSVs do not support holding the SCC type unfortunately 

see https://github.com/operator-framework/operator-lifecycle-manager/issues/2847