### PR TITLE
RPM fixes 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -238,9 +238,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -264,8 +264,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cesu8"
@@ -1232,9 +1232,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1448,13 +1448,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1504,7 +1506,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1656,6 +1658,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-auth"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,7 +1684,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1698,8 +1734,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1712,14 +1748,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1731,7 +1786,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1744,10 +1799,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1842,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1858,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test-macros"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "quote",
  "syn 2.0.63",
@@ -1879,7 +1970,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -1893,6 +1984,15 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2210,6 +2310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2425,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2441,6 +2551,26 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom",
+ "http 0.2.12",
+ "rand",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -2470,13 +2600,13 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 0.2.12",
  "http-auth",
  "jwt",
  "lazy_static",
  "olpc-cjson",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "sha2",
@@ -2508,6 +2638,38 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openidconnect"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "url",
+]
 
 [[package]]
 name = "openssl"
@@ -2576,7 +2738,7 @@ checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -2618,10 +2780,19 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float",
+ "ordered-float 4.2.0",
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2718,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2759,9 +2930,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.2.6",
@@ -2901,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.63",
@@ -2944,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2969,7 +3140,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -2984,12 +3155,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -3137,11 +3308,11 @@ dependencies = [
  "futures-util",
  "h2",
  "hickory-resolver",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3151,7 +3322,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3168,7 +3339,47 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3252,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -3322,10 +3533,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.5.0"
+name = "rustls-pemfile"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -3359,15 +3580,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "ryu-js"
@@ -3489,11 +3710,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3502,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3512,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
@@ -3526,6 +3747,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -3547,6 +3778,16 @@ checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3694,6 +3935,7 @@ dependencies = [
  "lazy_static",
  "oci-distribution",
  "olpc-cjson",
+ "openidconnect",
  "p256",
  "p384",
  "pem",
@@ -3701,6 +3943,7 @@ dependencies = [
  "pkcs8",
  "rand",
  "regex",
+ "reqwest 0.12.4",
  "rsa",
  "rustls-webpki 0.102.3",
  "scrypt",
@@ -4178,9 +4421,9 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4225,7 +4468,7 @@ dependencies = [
  "olpc-cjson",
  "pem",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.27",
  "ring",
  "serde",
  "serde_json",
@@ -4393,6 +4636,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4839,9 +5083,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -4851,6 +5095,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -4894,18 +5148,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-documentation = "https://docs.bpfman.io"
+documentation = "https://bpfman.io/main/getting-started/overview/"
 edition = "2021"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"

--- a/bpf-log-exporter/Cargo.toml
+++ b/bpf-log-exporter/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 description = "Binary for exporting eBPF events via logs"
-name = "bpf-log-exporter"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpf-log-exporter"
 repository.workspace = true
 version.workspace = true
 

--- a/bpf-log-exporter/Cargo.toml
+++ b/bpf-log-exporter/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 description = "Binary for exporting eBPF events via logs"
+name = "bpf-log-exporter"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpf-log-exporter"
 repository.workspace = true
 version.workspace = true
+
 
 [dependencies]
 anyhow = { workspace = true }

--- a/bpf-metrics-exporter/Cargo.toml
+++ b/bpf-metrics-exporter/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 description = "Binary for exporting eBPF subsystem metrics via prometheus"
-edition.workspace = true
-license.workspace = true
 name = "bpf-metrics-exporter"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/bpf-metrics-exporter/Cargo.toml
+++ b/bpf-metrics-exporter/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 description = "Binary for exporting eBPF subsystem metrics via prometheus"
-name = "bpf-metrics-exporter"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpf-metrics-exporter"
 repository.workspace = true
 version.workspace = true
 

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 description = "gRPC bindings to the bpfman API"
-edition.workspace = true
-license.workspace = true
 name = "bpfman-api"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 version.workspace = true
+
 
 [[bin]]
 name = "bpfman-rpc"
@@ -54,11 +57,7 @@ rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }
-sigstore = { workspace = true, features = [
-    "cached-client",
-    "cosign-rustls-tls",
-    "sigstore-trust-root",
-] }
+sigstore = { workspace = true, features = ["full-native-tls", "cached-client", "sigstore-trust-root", "sign"] }
 sled = { workspace = true }
 systemd-journal-logger = { workspace = true }
 tar = { workspace = true }

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 description = "gRPC bindings to the bpfman API"
-name = "bpfman-api"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpfman-api"
 repository.workspace = true
 version.workspace = true
 
@@ -57,7 +57,12 @@ rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }
-sigstore = { workspace = true, features = ["full-native-tls", "cached-client", "sigstore-trust-root", "sign"] }
+sigstore = { workspace = true, features = [
+    "cached-client",
+    "full-native-tls",
+    "sign",
+    "sigstore-trust-root",
+] }
 sled = { workspace = true }
 systemd-journal-logger = { workspace = true }
 tar = { workspace = true }

--- a/bpfman-ns/Cargo.toml
+++ b/bpfman-ns/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 description = "An executable to attach an eBPF program inside a container"
-name = "bpfman-ns"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpfman-ns"
 repository.workspace = true
 version.workspace = true
 

--- a/bpfman-ns/Cargo.toml
+++ b/bpfman-ns/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 description = "An executable to attach an eBPF program inside a container"
-edition.workspace = true
-license.workspace = true
 name = "bpfman-ns"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -31,6 +31,7 @@ BuildRequires:  cargo-rpm-macros >= 25
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  openssl-devel
 BuildRequires:  pkgconfig(zlib)
+BuildRequires:  gcc
 
 # TODO: Generate Provides for all of the vendored dependencies
 

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -30,6 +30,7 @@ Source1:         bpfman-bpfman-vendor.tar.gz
 BuildRequires:  cargo-rpm-macros >= 25
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  openssl-devel
+BuildRequires:  pkgconfig(zlib)
 
 # TODO: Generate Provides for all of the vendored dependencies
 

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -18,29 +18,7 @@ Version:        %{package_version}
 Release:        %autorelease
 Summary:        An eBPF program manager
 
-SourceLicense:  Apache-2.0
-# (Apache-2.0 OR MIT) AND BSD-3-Clause
-# (MIT OR Apache-2.0) AND Unicode-DFS-2016
-# 0BSD OR MIT OR Apache-2.0
-# Apache-2.0
-# Apache-2.0 OR BSL-1.0
-# Apache-2.0 OR ISC OR MIT
-# Apache-2.0 OR MIT
-# Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
-# BSD-2-Clause OR Apache-2.0 OR MIT
-# BSD-3-Clause
-# ISC
-# MIT
-# MIT AND BSD-3-Clause
-# MIT OR Apache-2.0
-# MIT OR Apache-2.0 OR BSD-1-Clause
-# MIT OR Apache-2.0 OR Zlib
-# MIT OR Zlib OR Apache-2.0
-# MPL-2.0
-# Unlicense OR MIT
-# Zlib OR Apache-2.0 OR MIT
-License: Apache-2.0 AND Unicode-DFS-2016 AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0
-# LICENSE.dependencies contains a full license breakdown
+License: Apache-2.0 
 
 URL:             https://bpfman.io
 Source0:         https://github.com/bpfman/bpfman/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
@@ -104,8 +82,6 @@ install -Dpm 644 \
 
 %files
 %license LICENSE-APACHE
-%license LICENSE-BSD2
-%license LICENSE-GPL2
 %license LICENSE.dependencies
 %license cargo-vendor.txt
 %doc README.md

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -93,6 +93,11 @@ install -Dpm 644 \
 %{_unitdir}/bpfman.socket
 %{_unitdir}/bpfman.service
 
-%cargo_test
+%if %{with check}
+%check
+# Skip image_pull_* tests as require Internet to pull images from a registry
+%cargo_test -- -- --skip oci_utils::image_manager::tests::image_pull_failure --skip oci_utils::image_manager::tests::image_pull_and_bytecode_verify --skip oci_utils::image_manager::tests::private_image_pull_and_bytecode_verify --skip oci_utils::image_manager::tests::image_pull_policy_never_failure
+%endif
+
 %changelog
 %autochangelog

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -93,5 +93,6 @@ install -Dpm 644 \
 %{_unitdir}/bpfman.socket
 %{_unitdir}/bpfman.service
 
+%cargo_test
 %changelog
 %autochangelog

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 description = "An eBPF Program Manager"
-edition.workspace = true
-license.workspace = true
 name = "bpfman"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 version.workspace = true
 

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 description = "An eBPF Program Manager"
-name = "bpfman"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpfman"
 repository.workspace = true
 version.workspace = true
 

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 description = "gRPC bindings to the CSI spec"
-name = "bpfman-csi"
-version = "1.8.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "bpfman-csi"
 repository.workspace = true
+version = "1.8.0"
 
 [dependencies]
 prost = { workspace = true, features = ["prost-derive", "std"] }

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 description = "gRPC bindings to the CSI spec"
-edition.workspace = true
-license.workspace = true
 name = "bpfman-csi"
-repository.workspace = true
 version = "1.8.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 prost = { workspace = true, features = ["prost-derive", "std"] }

--- a/tests/integration-test-macros/Cargo.toml
+++ b/tests/integration-test-macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "integration-test-macros"
-publish = false
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "integration-test-macros"
+publish = false
 repository.workspace = true
 version.workspace = true
 

--- a/tests/integration-test-macros/Cargo.toml
+++ b/tests/integration-test-macros/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-edition = "2021"
 name = "integration-test-macros"
 publish = false
-version = "0.1.0"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 quote = { workspace = true }

--- a/tests/integration-test/Cargo.toml
+++ b/tests/integration-test/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "integration-test"
-publish = false
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "integration-test"
+publish = false
 repository.workspace = true
 version.workspace = true
 

--- a/tests/integration-test/Cargo.toml
+++ b/tests/integration-test/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-edition = "2021"
 name = "integration-test"
 publish = false
-version = "0.1.0"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "xtask"
-publish = false
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+name = "xtask"
+publish = false
 repository.workspace = true
 version.workspace = true
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
-edition = "2021"
 name = "xtask"
 publish = false
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]


### PR DESCRIPTION
A bunch of fixes based on the feedback in https://bugzilla.redhat.com/show_bug.cgi?id=2269411

- [ ] https://github.com/bpfman/bpfman/issues/1127 -> b0530dd054e00657f9af3710a85a28e303207cc4
     - I we need to patch `ring v0.17.8` and `sigstore-protobuf-specs` crates since they don't specify any license metadata. I didn't do it here since we don't maintain a version of the vendor tarball in github
- [x] https://github.com/bpfman/bpfman/issues/1128 -> a4c3a9f1a2142ce28de7159dd290ccce23fd1043
- [x] https://github.com/bpfman/bpfman/issues/1129
- [x] https://github.com/bpfman/bpfman/issues/1130
- [x] https://github.com/bpfman/bpfman/issues/1131
- [x] https://github.com/bpfman/bpfman/issues/1132
- [x] https://github.com/bpfman/bpfman/issues/1133