### PR TITLE
bpfman: don't panic if DatabaseLockError occurred

### DIFF
--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -479,12 +479,7 @@ fn get_programs_iter(root_db: &Db) -> impl Iterator<Item = (u32, Program)> + '_ 
 async fn setup() -> Result<(Config, Db), BpfmanError> {
     initialize_bpfman()?;
 
-    Ok((
-        open_config_file(),
-        init_database(get_db_config())
-            .await
-            .expect("Unable to open root database"),
-    ))
+    Ok((open_config_file(), init_database(get_db_config()).await?))
 }
 
 async fn add_multi_attach_program(


### PR DESCRIPTION
Currently `bpfman` will panic when DatabaseLockError occurred.
```
thread 'main' panicked at /root/go/src/github.com/bpfman/bpfman/bpfman/src/lib.rs:486:14:
Unable to open root database: DatabaseLockError
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
After this patch `bpfman` will print DatabaseLockError message and don't panic
```
Error: Failed to acquire database lock, please try again later
```
Refs: #1018