### PR TITLE
Have systemd-rpm-macros use bpfman service

### DIFF
--- a/bpfman.spec
+++ b/bpfman.spec
@@ -18,7 +18,7 @@ Version:        %{package_version}
 Release:        %autorelease
 Summary:        An eBPF program manager
 
-License: Apache-2.0 
+License: Apache-2.0
 
 URL:             https://bpfman.io
 Source0:         https://github.com/bpfman/bpfman/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
@@ -74,13 +74,13 @@ install -Dpm 644 \
     ./scripts/bpfman.service
 
 %post
-%systemd_post bpfman.socket
+%systemd_post bpfman.service
 
 %preun
-%systemd_preun bpfman.socket
+%systemd_preun bpfman.service
 
 %postun
-%systemd_postun_with_restart bpfman.socket
+%systemd_postun_with_restart bpfman.service
 
 %files
 %license LICENSE-APACHE


### PR DESCRIPTION
This PR changes the specfile so it uses the service directly for
systemd-rpm-macros. Otherwise we hit an issue in fedora-lint as this is
advised in the review [1]

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_scriptlets

Signed-off-by: Daniel Mellado <dmellado@redhat.com>