### PR TITLE
Make DatabaseConfig max_retries work as defined.

### DIFF
--- a/bpfman/src/config.rs
+++ b/bpfman/src/config.rs
@@ -52,7 +52,7 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            // Maximum numbers of times to attempt to open the database after a failed attempt
+            // Maximum number of times to attempt to open the database after a failed attempt
             max_retries: 10,
             // Number of milli-seconds to wait between failed database attempts
             millisec_delay: 1000,

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -307,7 +307,7 @@ pub async fn pull_bytecode(image: BytecodeImage) -> anyhow::Result<()> {
 
 pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanError> {
     let database_config = open_config_file().database().to_owned().unwrap_or_default();
-    for _ in 1..database_config.max_retries {
+    for _ in 0..=database_config.max_retries {
         if let Ok(db) = sled_config.open() {
             debug!("Successfully opened database");
             return Ok(db);


### PR DESCRIPTION
The description for max_retries is "Maximum number of times to attempt to open the database after a failed attempt". However, the way the for loop is implemented, bpfman actually makes max_retries-1 attempts. For example, if you set it to 1, we try 0 times and fail immediately without trying.

Fixes: #1145