### PR TITLE
docs: update the RPM uninstall process

### DIFF
--- a/docs/getting-started/running-rpm.md
+++ b/docs/getting-started/running-rpm.md
@@ -97,9 +97,12 @@ $ sudo rpm -qa | grep bpfman
 bpfman-0.4.0~dev-1.20240117143006587102.main.191.gda44a71.fc39.x86_64
 ```
 
-To uninstall the RPM:
+To stop bpfman and uninstall the RPM:
 
 ```console
+sudo systemctl stop bpfman.socket
+sudo systemctl disable bpfman.socket
+
 sudo dnf erase -y bpfman-0.4.0~dev-1.20240117143006587102.main.191.gda44a71.fc39.x86_64
 
 sudo systemctl daemon-reload
@@ -135,9 +138,26 @@ This will generate several RPMs in a `x86_64/` directory:
 
 ```console
 $ ls x86_64/
-bpfman-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64.rpm
-bpfman-debuginfo-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64.rpm
-bpfman-debugsource-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64.rpm
+bpfman-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64.rpm
+bpfman-debuginfo-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64.rpm
+bpfman-debugsource-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64.rpm
+```
+
+If local RPM builds were previously run on the system, the `packit build locally` command may
+fail with something similar to:
+
+```console
+packit build locally
+2024-05-21 10:00:03.904 base_git.py       INFO   Using user-defined script for ActionName.post_upstream_clone: [['bash', '-c', 'if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/coreos/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi && cd /var/tmp/cargo-vendor-filterer && cargo build && cd - && cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . && ./cargo-vendor-filterer --format tar.gz --prefix vendor bpfman-bpfman-vendor.tar.gz']]
+2024-05-21 10:00:03.956 logging.py        INFO   error: could not find `Cargo.toml` in `/var/tmp/cargo-vendor-filterer` or any parent directory
+2024-05-21 10:00:03.957 commands.py       ERROR  Command 'bash -c if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/coreos/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi && cd /var/tmp/cargo-vendor-filterer && cargo build && cd - && cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . && ./cargo-vendor-filterer --format tar.gz --prefix vendor bpfman-bpfman-vendor.tar.gz' failed.
+2024-05-21 10:00:03.957 utils.py          ERROR  Command 'bash -c if [[ ! -d /var/tmp/cargo-vendor-filterer ]]; then git clone https://github.com/coreos/cargo-vendor-filterer.git /var/tmp/cargo-vendor-filterer; fi && cd /var/tmp/cargo-vendor-filterer && cargo build && cd - && cp /var/tmp/cargo-vendor-filterer/target/debug/cargo-vendor-filterer . && ./cargo-vendor-filterer --format tar.gz --prefix vendor bpfman-bpfman-vendor.tar.gz' failed.
+```
+
+To fix, run:
+
+```console
+sudo rm -rf /var/tmp/cargo-vendor-filterer/
 ```
 
 ### Install Local Build
@@ -145,7 +165,7 @@ bpfman-debugsource-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb
 Install the RPM:
 
 ```console
-sudo rpm -i x86_64/bpfman-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64.rpm
+sudo rpm -i x86_64/bpfman-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64.rpm
 ```
 
 `bpfman` is now installed but not running.
@@ -189,13 +209,16 @@ To determine the RPM that is currently loaded:
 
 ```console
 $ sudo rpm -qa | grep bpfman
-bpfman-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64
+bpfman-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64
 ```
 
-To uninstall the RPM:
+To stop bpfman and uninstall the RPM:
 
 ```console
-sudo rpm -e bpfman-0.4.0~dev-1.20240118212420167308.<USERNAME>.rpm.socket.192.gb2ea1b9.fc39.x86_64
+sudo systemctl stop bpfman.socket
+sudo systemctl disable bpfman.socket
+
+sudo rpm -e bpfman-0.4.1-1.20240521101705214906.main.19.b47994a3.fc39.x86_64
 
 sudo systemctl daemon-reload
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -96,9 +96,12 @@ $ sudo rpm -qa | grep bpfman
 bpfman-0.4.1-1.fc39.x86_64
 ```
 
-Then to uninstall the RPM:
+To stop bpfman and uninstall the RPM:
 
 ```console
+sudo systemctl stop bpfman.socket
+sudo systemctl disable bpfman.socket
+
 sudo dnf erase -y bpfman-0.4.1-1.fc39.x86_64
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
The RPM spec file is being updated to be compliant with Fedora (see #1146). One of the changes requires bpfman to be stopped before uninstalling the RPM, otherwise errors are logged and reinstall of the RPM fails.

Example Error:
```
May 21 10:41:49 nfvsdn-22-oot.lab.eng.rdu2.redhat.com systemd[1]: bpfman.socket: Socket unit configuration has changed while unit has been running, no open socket file descriptor left. The socket unit is not functional until restarted.
```

And subsequent RPM install fails and bpfman is not running:
```
$ sudo ./go-xdp-counter --iface eno3
2024/05/21 11:03:28 Using Input: Interface=eno3 Priority=50 Source=/home/bmcfall/src/bpfman/examples/go-xdp-counter/bpf_bpfel.o
2024/05/21 11:03:28 rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /run/bpfman-sock/bpfman.sock: connect: connection refused"
```

Updated the docs to indicate bpfman should be stopped.