### PR TITLE
fix public-api check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.33.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b759eeee807ac96096fce568abeb9ef8d23db7be771a65252b1e5093fe7938c4"
+checksum = "5c92cea150e7e5501c3f01b90928d26566335e4681c79e0aead3be096bf5e2d4"
 dependencies = [
  "hashbag",
  "rustdoc-types",
@@ -3491,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
+checksum = "0b9be1bc4a0ec3445cfa2e4ba112827544890d43d68b7d1eda5359a9c09d2cd8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ opentelemetry_sdk = { version = "0.22.1", default-features = false }
 predicates = { version = "3.0.4", default-features = false }
 prost = { version = "0.12.6", default-features = false }
 prost-types = { version = "0.12.6", default-features = false }
-public-api = { version = "0.33.1", default-features = false }
+public-api = { version = "0.35.0", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 regex = { version = "1.10.4", default-features = false }


### PR DESCRIPTION
Bump the public-api crate so that our checks
still function.