### PR TITLE
Add application object example

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -133,6 +133,20 @@ jobs:
               # set latest tag for default branch
               type=raw,value=latest,enable={{is_default_branch}}
 
+          - registry: quay.io
+            # build_language: go - Not building locally, so don't install go tools
+            repository: bpfman-userspace
+            image: go-app-counter
+            context: .
+            dockerfile: ./examples/go-app-counter/container-deployment/Containerfile.go-application-counter
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
     name: Build Image (${{ matrix.image.image }})
     steps:
       - name: Checkout bpfman
@@ -323,6 +337,23 @@ jobs:
               BPF_FUNCTION_NAME=uretprobe_counter
               PROGRAM_TYPE=uretprobe
               BYTECODE_FILENAME=bpf_x86_bpfel.o
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+          - registry: quay.io
+            build_language: go
+            bpf_build_wrapper: go
+            repository: bpfman-bytecode
+            image: go-app-counter
+            context: ./examples/go-app-counter
+            dockerfile: ./Containerfile.bytecode
+            build_args: |
+              BYTECODE_FILENAME=bpf_bpfel.o
             tags: |
               type=ref,event=branch
               type=ref,event=tag

--- a/docs/getting-started/example-bpf.md
+++ b/docs/getting-started/example-bpf.md
@@ -11,11 +11,12 @@ Current examples include:
 * [examples/go-uretprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-uretprobe-counter)
 * [examples/go-target/](https://github.com/bpfman/bpfman/tree/main/examples/go-target)
 * [examples/go-xdp-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-xdp-counter)
+* [examples/go-app-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-app-counter)
 
 ## Example Code Breakdown
 
 These examples and the associated documentation are intended to provide the basics on how to deploy
-and manage an eBPF program using bpfman. Each of the examples contain an eBPF Program written in C
+and manage an eBPF program using bpfman. Each of the examples contains an eBPF Program(s) written in C
 ([kprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter/bpf/kprobe_counter.c),
 [tc_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tc-counter/bpf/tc_counter.c),
 [tracepoint_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tracepoint-counter/bpf/tracepoint_counter.c) 
@@ -23,6 +24,7 @@ and manage an eBPF program using bpfman. Each of the examples contain an eBPF Pr
 [uretprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-uretprobe-counter/bpf/uretprobe_counter.c),
 and
 [xdp_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-xdp-counter/bpf/xdp_counter.c))
+([app_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter/bpf/app_counter.c),
 that is compiled into eBPF bytecode (bpf_bpfel.o).
 Each time the eBPF program is called, it increments the packet and byte counts in a map that is accessible
 by the userspace portion.
@@ -193,6 +195,7 @@ Pre-built eBPF container images for the examples can be loaded from:
 - `quay.io/bpfman-bytecode/go-uprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-uretprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-xdp-counter:latest`
+- `quay.io/bpfman-bytecode/go-application-counter:latest`
 
 To build the example eBPF bytecode container images, run the build commands below (the `go generate`
 requires the [Prerequisites](#prerequisites) described above):

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -104,6 +104,9 @@ build: fmt ## Build all the userspace example code.
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o go-uprobe-counter/go-uprobe-counter go-uprobe-counter/main.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o go-uretprobe-counter/go-uretprobe-counter go-uretprobe-counter/main.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o go-target/go-target go-target/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o go-app-counter/go-app-counter \
+	go-app-counter/main.go go-app-counter/kprobe_main.go go-app-counter/tracepoint_main.go \
+	go-app-counter/uprobe_main.go go-app-counter/tc_main.go go-app-counter/xdp_main.go
 
 .PHONY: generate
 generate: ## Run `go generate` to build the bytecode for each of the examples.
@@ -118,10 +121,11 @@ build-us-images: build ## Build all example userspace images
 	docker buildx build -t ${IMAGE_UP_US} --platform ${PLATFORM} --load -f ./go-uprobe-counter/container-deployment/Containerfile.go-uprobe-counter ../
 	docker buildx build -t ${IMAGE_URP_US} --platform ${PLATFORM} --load -f ./go-uretprobe-counter/container-deployment/Containerfile.go-uretprobe-counter ../
 	docker buildx build -t ${IMAGE_GT_US} --platform ${PLATFORM} --load -f ./go-target/container-deployment/Containerfile.go-target ../
+	docker buildx build -t ${IMAGE_GT_US} --platform ${PLATFORM} --load  -f ./go-app-counter/container-deployment/Containerfile.go-application-counter ../
 
 .PHONY: build-bc-images
 build-bc-images: generate ## Build bytecode example userspace images
-	IMAGE_TC_BC=${IMAGE_TC_BC} IMAGE_TP_BC=${IMAGE_TP_BC} IMAGE_XDP_BC=${IMAGE_XDP_BC} IMAGE_KP_BC=${IMAGE_KP_BC} IMAGE_UP_BC=${IMAGE_UP_BC}  IMAGE_URP_BC=${IMAGE_URP_BC} ./build-bytecode-images.sh
+	IMAGE_TC_BC=${IMAGE_TC_BC} IMAGE_TP_BC=${IMAGE_TP_BC} IMAGE_XDP_BC=${IMAGE_XDP_BC} IMAGE_KP_BC=${IMAGE_KP_BC} IMAGE_UP_BC=${IMAGE_UP_BC}  IMAGE_URP_BC=${IMAGE_URP_BC} IMAGE_APP_BC=${IMAGE_APP_BC} ./build-bytecode-images.sh
 
 build-all-images: build-bc-images build-us-images ## Build both bytecode and userspace images
 
@@ -133,6 +137,7 @@ push-us-images: ## Push all example userspace images
 	docker push ${IMAGE_KP_US}
 	docker push ${IMAGE_UP_US}
 	docker push ${IMAGE_URP_US}
+	docker push ${IMAGE_APP_US}
 	docker push ${IMAGE_GT_US}
 
 .PHONY: push-bc-images
@@ -143,11 +148,12 @@ push-bc-images: ## Push all example bytecode images
 	docker push ${IMAGE_KP_BC}
 	docker push ${IMAGE_UP_BC}
 	docker push ${IMAGE_URP_BC}
+	docker push ${IMAGE_APP_BC}
 
 
 .PHONY: load-us-images-kind
 load-us-images-kind: build-us-images ## Build and load all example userspace images into kind
-	kind load docker-image ${IMAGE_TC_US} ${IMAGE_TP_US} ${IMAGE_XDP_US} ${IMAGE_KP_US} ${IMAGE_UP_US} ${IMAGE_GT_US} --name ${KIND_CLUSTER_NAME}
+	kind load docker-image ${IMAGE_TC_US} ${IMAGE_TP_US} ${IMAGE_XDP_US} ${IMAGE_KP_US} ${IMAGE_UP_US} ${IMAGE_GT_US} ${IMAGE_APP_US} --name ${KIND_CLUSTER_NAME}
 
 ##@ Deployment Variables (not commands)
 TAG: ## Used to set all images to a fixed tag. Example: make deploy TAG=v0.2.0
@@ -163,6 +169,8 @@ IMAGE_UP_BC: ## Uprobe Bytecode image. Example: make deploy-uprobe IMAGE_UP_BC=q
 IMAGE_UP_US: ## Uprobe Userspace image. Example: make deploy-uprobe IMAGE_UP_US=quay.io/user1/go-uprobe-counter-userspace:test
 IMAGE_URP_BC: ## URetprobe Userspace image. Example: make deploy-uretprobe IMAGE_URP_BC=quay.io/user1/go-uretprobe-counter-bytecode:test
 IMAGE_URP_US: ## URetprobe Userspace image. Example: make deploy-uretprobe IMAGE_URP_US=quay.io/user1/go-uretprobe-counter-userspace:test
+IMAGE_APP_BC: ## Application Userspace image. Example: make deploy-application IMAGE_URP_BC=quay.io/user1/go-application-counter-bytecode:test
+IMAGE_APP_US: ## Application Userspace image. Example: make deploy-application IMAGE_URP_US=quay.io/user1/go-application-counter-userspace:test
 IMAGE_GT_US: ## Uprobe Userspace target. Example: make deploy-target IMAGE_GT_US=quay.io/user1/go-target-userspace:test
 KIND_CLUSTER_NAME: ## Name of the deployed cluster to load example images to, defaults to `bpfman-deployment`
 ignore-not-found: ## For any undeploy command, set to true to ignore resource not found errors during deletion. Example: make undeploy ignore-not-found=true
@@ -180,6 +188,8 @@ IMAGE_UP_BC ?= quay.io/bpfman-bytecode/go-uprobe-counter:latest
 IMAGE_UP_US ?= quay.io/bpfman-userspace/go-uprobe-counter:latest
 IMAGE_URP_BC ?= quay.io/bpfman-bytecode/go-uretprobe-counter:latest
 IMAGE_URP_US ?= quay.io/bpfman-userspace/go-uretprobe-counter:latest
+IMAGE_APP_BC ?= quay.io/bpfman-bytecode/go-application-counter:latest
+IMAGE_APP_US ?= quay.io/bpfman-userspace/go-application-counter:latest
 IMAGE_GT_US ?= quay.io/bpfman-userspace/go-target:latest
 KIND_CLUSTER_NAME ?= bpfman-deployment
 
@@ -322,6 +332,20 @@ undeploy-uretprobe: IMAGE_BC=$(IMAGE_URP_BC)
 undeploy-uretprobe: IMAGE_US=$(IMAGE_URP_US)
 undeploy-uretprobe: undeploy-prog ## Undeploy go-uretprobe-counter from the cluster specified in ~/.kube/config.
 
+.PHONY: deploy-application
+deploy-application: PROG_NAME=go-application-counter
+deploy-application: CONFIG_DIR=default/go-app-counter
+deploy-application: IMAGE_BC=$(IMAGE_APP_BC)
+deploy-application: IMAGE_US=$(IMAGE_APP_US)
+deploy-application: deploy-prog ## Deploy go-application-counter to the cluster specified in ~/.kube/config.
+
+.PHONY: undeploy-application
+undeploy-application: PROG_NAME=go-application-counter
+undeploy-application: CONFIG_DIR=default/go-app-counter
+undeploy-application: IMAGE_BC=$(IMAGE_APP_BC)
+undeploy-application: IMAGE_US=$(IMAGE_APP_US)
+undeploy-application: undeploy-prog ## Undeploy go-application-counter from the cluster specified in ~/.kube/config.
+
 .PHONY: deploy-tc-selinux
 deploy-tc-selinux: PROG_NAME=go-tc-counter
 deploy-tc-selinux: CONFIG_DIR=selinux/$(PROG_NAME)
@@ -425,6 +449,20 @@ undeploy-uretprobe-selinux: IMAGE_BC=$(IMAGE_URP_BC)
 undeploy-uretprobe-selinux: IMAGE_US=$(IMAGE_URP_US)
 undeploy-uretprobe-selinux: undeploy-prog ## Undeploy go-uretprobe-counter from the cluster specified in ~/.kube/config.
 
+.PHONY: deploy-application-selinux
+deploy-application-selinux: PROG_NAME=go-application-counter
+deploy-application-selinux: CONFIG_DIR=selinux/go-app-counter
+deploy-application-selinux: IMAGE_BC=$(IMAGE_APP_BC)
+deploy-application-selinux: IMAGE_US=$(IMAGE_APP_US)
+deploy-application-selinux: deploy-prog ## Deploy go-application-counter to the cluster specified in ~/.kube/config.
+
+.PHONY: undeploy-application-selinux
+undeploy-application-selinux: PROG_NAME=go-application-counter
+undeploy-application-selinux: CONFIG_DIR=selinux/go-app-counter
+undeploy-application-selinux: IMAGE_BC=$(IMAGE_APP_BC)
+undeploy-application-selinux: IMAGE_US=$(IMAGE_APP_US)
+undeploy-application-selinux: undeploy-prog ## Undeploy go-application-counter from the cluster specified in ~/.kube/config.
+
 .PHONY: deploy-target
 deploy-target: ## Deploy go-target to the cluster specified in ~/.kube/config.
 	kubectl apply -f config/base/go-target/deployment.yaml
@@ -433,7 +471,7 @@ deploy-target: ## Deploy go-target to the cluster specified in ~/.kube/config.
 undeploy-target: ## Undeploy go-target from the cluster specified in ~/.kube/config.
 	kubectl delete -f config/base/go-target/deployment.yaml
 
-DEPLOY_TARGETS = deploy-tc deploy-tracepoint deploy-xdp deploy-xdp-ms deploy-kprobe deploy-target deploy-uprobe deploy-uretprobe
+DEPLOY_TARGETS = deploy-tc deploy-tracepoint deploy-xdp deploy-xdp-ms deploy-kprobe deploy-target deploy-uprobe deploy-uretprobe deploy-application
 
 .PHONY: deploy
 deploy: ## Deploy all examples to the cluster specified in ~/.kube/config.
@@ -444,7 +482,7 @@ endif
 		$(MAKE) $$target $(TAG_COMMAND) || true; \
 	done
 
-UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp-ms undeploy-xdp undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target
+UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp-ms undeploy-xdp undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target undeploy-application
 
 .PHONY: undeploy
 undeploy: ## Undeploy all examples to the cluster specified in ~/.kube/config.

--- a/examples/build-bytecode-images.sh
+++ b/examples/build-bytecode-images.sh
@@ -47,3 +47,8 @@ docker build \
  --build-arg BYTECODE_FILENAME=bpf_x86_bpfel.o \
  -f ../Containerfile.bytecode \
  ./go-uretprobe-counter -t $IMAGE_URP_BC
+
+docker build \
+ --build-arg BYTECODE_FILENAME=bpf_bpfel.o \
+ -f ../Containerfile.bytecode \
+ ./go-app-counter -t $IMAGE_APP_BC

--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -11,7 +11,7 @@ spec:
   bytecode:
     image:
       url: quay.io/bpfman-bytecode/go-application-counter:latest
-      imagepullpolicy: IfNotPresent
+      imagepullpolicy: Always
   programs:
     - type: Kprobe
       kprobe:

--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: bpfman.io/v1alpha1
+kind: BpfApplication
+metadata:
+  labels:
+    app.kubernetes.io/name: bpfapplication
+  name: go-application-counter-example
+spec:
+  # Select all nodes
+  nodeselector: {}
+  bytecode:
+    image:
+      url: quay.io/bpfman-bytecode/go-application-counter:latest
+      imagepullpolicy: IfNotPresent
+  programs:
+    - type: Kprobe
+      kprobe:
+        bpffunctionname: kprobe_counter
+        func_name: try_to_wake_up
+        offset: 0
+        retprobe: false
+    - type: Tracepoint
+      tracepoint:
+        bpffunctionname: tracepoint_kill_recorder
+        names: [syscalls/sys_enter_kill]
+    - type: TC
+      tc:
+        bpffunctionname: stats
+        interfaceselector:
+          primarynodeinterface: true
+        priority: 55
+        direction: ingress
+    - type: Uprobe
+      uprobe:
+        bpffunctionname: uprobe_counter
+        func_name: main.getCount
+        target: /go-target
+        retprobe: false
+        containers:
+          namespace: go-target
+          pods: {}
+          containernames:
+            - go-target
+    - type: XDP
+      xdp:
+        bpffunctionname: xdp_stats
+        interfaceselector:
+          primarynodeinterface: true
+        priority: 55

--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -4,7 +4,7 @@ kind: BpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: bpfapplication
-  name: go-application-counter-example
+  name: app-counter
 spec:
   # Select all nodes
   nodeselector: {}

--- a/examples/config/base/go-app-counter/deployment.yaml
+++ b/examples/config/base/go-app-counter/deployment.yaml
@@ -66,4 +66,4 @@ spec:
             driver: csi.bpfman.io
             volumeAttributes:
               csi.bpfman.io/program: go-application-counter-example
-              csi.bpfman.io/maps: kprobe_stats_map,tracepoint_stats_map
+              csi.bpfman.io/maps: tracepoint_stats_map,kprobe_stats_map,tc_stats_map,uprobe_stats_map,xdp_stats_map

--- a/examples/config/base/go-app-counter/deployment.yaml
+++ b/examples/config/base/go-app-counter/deployment.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-application-counter
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bpfman-app-go-application-counter
+  namespace: go-application-counter
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: go-application-counter-ds
+  namespace: go-application-counter
+  labels:
+    k8s-app: go-application-counter
+spec:
+  selector:
+    matchLabels:
+      name: go-application-counter
+  template:
+    metadata:
+      labels:
+        name: go-application-counter
+    spec:
+      nodeSelector: {}
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: bpfman-app-go-application-counter
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 65534
+      tolerations:
+        # these tolerations are to have the daemonset runnable on control plane nodes
+        # remove them if your control plane nodes should not run pods
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: go-application-counter
+          image: quay.io/bpfman-userspace/go-application-counter:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsUser: 65534
+            runAsGroup: 65534
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: go-application-counter-maps
+              mountPath: /run/kprobe/maps
+              readOnly: true
+      volumes:
+        - name: go-application-counter-maps
+          csi:
+            driver: csi.bpfman.io
+            volumeAttributes:
+              csi.bpfman.io/program: go-application-counter-example
+              csi.bpfman.io/maps: kprobe_stats_map,tracepoint_stats_map

--- a/examples/config/base/go-app-counter/deployment.yaml
+++ b/examples/config/base/go-app-counter/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: go-application-counter
           image: quay.io/bpfman-userspace/go-application-counter:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -58,12 +58,12 @@ spec:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: go-application-counter-maps
-              mountPath: /run/kprobe/maps
+              mountPath: /run/application/maps
               readOnly: true
       volumes:
         - name: go-application-counter-maps
           csi:
             driver: csi.bpfman.io
             volumeAttributes:
-              csi.bpfman.io/program: go-application-counter-example
-              csi.bpfman.io/maps: tracepoint_stats_map,kprobe_stats_map,tc_stats_map,uprobe_stats_map,xdp_stats_map
+              csi.bpfman.io/program: app-counter
+              csi.bpfman.io/maps: kprobe_stats_map,tracepoint_stats_map,tc_stats_map,uprobe_stats_map,xdp_stats_map

--- a/examples/config/base/go-app-counter/kustomization.yaml
+++ b/examples/config/base/go-app-counter/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: [bytecode.yaml, deployment.yaml]

--- a/examples/config/default/go-app-counter/kustomization.yaml
+++ b/examples/config/default/go-app-counter/kustomization.yaml
@@ -3,17 +3,17 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-application-counter
-    newName: quay.io/bpfman-userspace/go-application-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-application-counter
+  newName: quay.io/bpfman-userspace/go-application-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: BpfApplication
-      name: go-application-counter-example
+- path: patch.yaml
+  target:
+    kind: BpfApplication
+    name: go-application-counter-example
 resources:
-  - ../../base/go-app-counter
+- ../../base/go-app-counter

--- a/examples/config/default/go-app-counter/kustomization.yaml
+++ b/examples/config/default/go-app-counter/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-application-counter
+    newName: quay.io/bpfman-userspace/go-application-counter
+    newTag: latest
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. Since this is being done with an environment
+# variable and using sed to replace, moved to patch.yaml.env which is
+# converted to patch.yaml using the sed command in Makefile.
+patches:
+  - path: patch.yaml
+    target:
+      kind: BpfApplication
+      name: go-application-counter-example
+resources:
+  - ../../base/go-app-counter

--- a/examples/config/default/go-app-counter/patch.yaml
+++ b/examples/config/default/go-app-counter/patch.yaml
@@ -1,3 +1,4 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace

--- a/examples/config/default/go-app-counter/patch.yaml
+++ b/examples/config/default/go-app-counter/patch.yaml
@@ -1,0 +1,5 @@
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-application-counter:latest

--- a/examples/config/default/go-app-counter/patch.yaml.env
+++ b/examples/config/default/go-app-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-app-counter/patch.yaml.env
+++ b/examples/config/default/go-app-counter/patch.yaml.env
@@ -1,0 +1,5 @@
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: "/spec/bytecode/image/url"
+  value: URL_BC

--- a/examples/go-app-counter/.gitignore
+++ b/examples/go-app-counter/.gitignore
@@ -1,1 +1,1 @@
-go-application-counter
+go-app-counter

--- a/examples/go-app-counter/.gitignore
+++ b/examples/go-app-counter/.gitignore
@@ -1,0 +1,1 @@
+go-application-counter

--- a/examples/go-app-counter/bpf/app_counter.c
+++ b/examples/go-app-counter/bpf/app_counter.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+#include "kprobe_counter.h"
+#include "tc_counter.h"
+#include "tracepoint_counter.h"
+#include "uprobe_counter.h"
+#include "xdp_counter.h"
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/examples/go-app-counter/bpf/kprobe_counter.h
+++ b/examples/go-app-counter/bpf/kprobe_counter.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <linux/types.h>
+#include <signal.h>
+
+#include <bpf/bpf_helpers.h>
+
+struct kprobedatarec {
+  __u64 counter;
+} kprobedatarec;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, kprobedatarec);
+  __uint(max_entries, 1);
+  __uint(pinning, LIBBPF_PIN_BY_NAME);
+} kprobe_stats_map SEC(".maps");
+
+SEC("kprobe/kprobe_counter")
+static __u32 kprobe_counter(struct pt_regs *ctx) {
+
+  __u32 index = 0;
+  struct kprobedatarec *rec = bpf_map_lookup_elem(&kprobe_stats_map, &index);
+  if (!rec)
+    return 1;
+
+  rec->counter++;
+  bpf_printk("kprobe called");
+
+  return 0;
+}

--- a/examples/go-app-counter/bpf/tc_counter.h
+++ b/examples/go-app-counter/bpf/tc_counter.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <linux/types.h>
+
+#include <bpf/bpf_helpers.h>
+
+// This counting program example was adapted from
+// https://github.com/xdp-project/xdp-tutorial/tree/master/basic03-map-counter
+
+/* This is the data record stored in the map */
+struct tcdatarec {
+  __u64 rx_packets;
+  __u64 rx_bytes;
+} tcdatarec;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, tcdatarec);
+  __uint(max_entries, TC_ACT_VALUE_MAX);
+  __uint(pinning, LIBBPF_PIN_BY_NAME);
+} tc_stats_map SEC(".maps");
+
+static __u32 tc_stats_record_action(struct __sk_buff *skb, __u32 action) {
+  void *data = (void *)(long)skb->data;
+  void *data_end = (void *)(long)skb->data_end;
+
+  if (data_end < data)
+    return TC_ACT_SHOT;
+
+  if (action >= TC_ACT_VALUE_MAX)
+    return TC_ACT_SHOT;
+
+  /* Lookup in kernel BPF-side return pointer to actual data record */
+  struct tcdatarec *rec = bpf_map_lookup_elem(&tc_stats_map, &action);
+  if (!rec)
+    return TC_ACT_SHOT;
+
+  /* Calculate packet length */
+  __u64 bytes = data_end - data;
+
+  rec->rx_packets++;
+  rec->rx_bytes += bytes;
+
+  return action;
+}
+
+SEC("classifier/stats")
+int stats(struct __sk_buff *skb) {
+  __u32 action = TC_ACT_OK;
+
+  return tc_stats_record_action(skb, action);
+}

--- a/examples/go-app-counter/bpf/tracepoint_counter.h
+++ b/examples/go-app-counter/bpf/tracepoint_counter.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <linux/types.h>
+#include <signal.h>
+
+#include <bpf/bpf_helpers.h>
+
+struct tracepointdatarec {
+  __u64 calls;
+} tracepointdatarec;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, tracepointdatarec);
+  __uint(max_entries, 8);
+  __uint(pinning, LIBBPF_PIN_BY_NAME);
+} tracepoint_stats_map SEC(".maps");
+
+struct kill_args {
+  long long pad;
+  long syscall_nr;
+  long pid;
+  long sig;
+};
+
+SEC("tracepoint/tracepoint_kill_recorder")
+static __u32 tracepoint_kill_recorder(struct kill_args *ctx) {
+  if (ctx->sig != SIGUSR1)
+    return 0;
+
+  __u32 index = 0;
+  struct tracepointdatarec *rec =
+      bpf_map_lookup_elem(&tracepoint_stats_map, &index);
+  if (!rec)
+    return 1;
+
+  rec->calls++;
+  bpf_printk("process received SIGUSR1");
+
+  return 0;
+}

--- a/examples/go-app-counter/bpf/uprobe_counter.h
+++ b/examples/go-app-counter/bpf/uprobe_counter.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <linux/types.h>
+#include <signal.h>
+
+#include <bpf/bpf_helpers.h>
+
+struct uprobedatarec {
+  __u64 counter;
+} uprobedatarec;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, uprobedatarec);
+  __uint(max_entries, 1);
+  __uint(pinning, LIBBPF_PIN_BY_NAME);
+} uprobe_stats_map SEC(".maps");
+
+SEC("uprobe/uprobe_counter")
+static __u32 uprobe_counter(struct pt_regs *ctx) {
+
+  __u32 index = 0;
+  struct uprobedatarec *rec = bpf_map_lookup_elem(&uprobe_stats_map, &index);
+  if (!rec)
+    return 1;
+
+  rec->counter++;
+  bpf_printk("uprobe called");
+
+  return 0;
+}

--- a/examples/go-app-counter/bpf/xdp_counter.h
+++ b/examples/go-app-counter/bpf/xdp_counter.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Modifications Copyright Authors of bpfman
+
+// Derived from:
+// https://github.com/xdp-project/xdp-tutorial/tree/master/basic03-map-counter
+
+#include <linux/bpf.h>
+
+#include <bpf/bpf_helpers.h>
+
+#define XDP_ACTION_MAX (XDP_REDIRECT + 1)
+
+/* This is the data record stored in the map */
+struct xdpdatarec {
+  __u64 rx_packets;
+  __u64 rx_bytes;
+} xdpdatarec;
+
+/* Lesson#1: See how a map is defined.
+ * - Here an array with XDP_ACTION_MAX (max_)entries are created.
+ * - The idea is to keep stats per (enum) xdp_action
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, xdpdatarec);
+  __uint(max_entries, XDP_ACTION_MAX);
+  __uint(pinning, LIBBPF_PIN_BY_NAME);
+} xdp_stats_map SEC(".maps");
+
+static __always_inline __u32 xdp_stats_record_action(struct xdp_md *ctx,
+                                                     __u32 action) {
+  void *data_end = (void *)(long)ctx->data_end;
+  void *data = (void *)(long)ctx->data;
+
+  if (action >= XDP_ACTION_MAX)
+    return XDP_ABORTED;
+
+  /* Lookup in kernel BPF-side return pointer to actual data record */
+  struct xdpdatarec *rec = bpf_map_lookup_elem(&xdp_stats_map, &action);
+  if (!rec)
+    return XDP_ABORTED;
+
+  /* Calculate packet length */
+  __u64 bytes = data_end - data;
+
+  /* BPF_MAP_TYPE_PERCPU_ARRAY returns a data record specific to current
+   * CPU and XDP hooks runs under Softirq, which makes it safe to update
+   * without atomic operations.
+   */
+  rec->rx_packets++;
+  rec->rx_bytes += bytes;
+
+  return action;
+}
+
+SEC("xdp")
+int xdp_stats(struct xdp_md *ctx) {
+  __u32 action = XDP_PASS; /* XDP_PASS = 2 */
+
+  return xdp_stats_record_action(ctx, action);
+}

--- a/examples/go-app-counter/container-deployment/Containerfile.go-application-counter
+++ b/examples/go-app-counter/container-deployment/Containerfile.go-application-counter
@@ -1,12 +1,16 @@
-FROM golang:1.21 as go-application-counter-build
+ARG BUILDPLATFORM=linux/amd64
+
+FROM --platform=$BUILDPLATFORM golang:1.22 as go-application-counter-build
+
+ARG BUILDPLATFORM
+
+# The following ARGs are set internally by docker or podman on multiarch builds
+ARG TARGETPLATFORM=linux/amd64
 
 RUN apt-get update && apt-get install -y \
     clang \
     gcc-multilib \
     libbpf-dev
-
-ARG CILIUMVERSION="v0.14.0"
-RUN go install github.com/cilium/ebpf/cmd/bpf2go@$CILIUMVERSION
 
 WORKDIR /usr/src/bpfman/
 COPY ./ /usr/src/bpfman/
@@ -14,9 +18,12 @@ COPY ./ /usr/src/bpfman/
 WORKDIR /usr/src/bpfman/examples/go-app-counter
 
 # Compile go-application-counter
-RUN go build
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build
 
-FROM registry.fedoraproject.org/fedora-minimal:latest
+
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora-minimal:latest
+
+ARG TARGETPLATFORM
 
 COPY --from=go-application-counter-build  /usr/src/bpfman/examples/go-app-counter/go-app-counter .
 

--- a/examples/go-app-counter/container-deployment/Containerfile.go-application-counter
+++ b/examples/go-app-counter/container-deployment/Containerfile.go-application-counter
@@ -1,0 +1,23 @@
+FROM golang:1.21 as go-application-counter-build
+
+RUN apt-get update && apt-get install -y \
+    clang \
+    gcc-multilib \
+    libbpf-dev
+
+ARG CILIUMVERSION="v0.14.0"
+RUN go install github.com/cilium/ebpf/cmd/bpf2go@$CILIUMVERSION
+
+WORKDIR /usr/src/bpfman/
+COPY ./ /usr/src/bpfman/
+
+WORKDIR /usr/src/bpfman/examples/go-app-counter
+
+# Compile go-application-counter
+RUN go build
+
+FROM registry.fedoraproject.org/fedora-minimal:latest
+
+COPY --from=go-application-counter-build  /usr/src/bpfman/examples/go-app-counter/go-app-counter .
+
+ENTRYPOINT ["./go-app-counter", "--crd"]

--- a/examples/go-app-counter/kprobe_main.go
+++ b/examples/go-app-counter/kprobe_main.go
@@ -29,6 +29,8 @@ type KprobeStats struct {
 
 func processKprobe(stop chan os.Signal) {
 
+	initMutex.Lock()
+
 	// pull the BPFMAN config management data to determine if we're running on a
 	// system with BPFMAN available.
 	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeKprobe, DefaultByteCodeFile)
@@ -157,6 +159,8 @@ func processKprobe(stop chan os.Signal) {
 		return
 	}
 
+	initMutex.Unlock()
+
 	// retrieve and report on the number of times the kprobe is executed.
 	index := uint32(0)
 	ticker := time.NewTicker(1 * time.Second)
@@ -174,7 +178,7 @@ func processKprobe(stop chan os.Signal) {
 				totalCount += stat.Counter
 			}
 
-			log.Printf("Kprobe count: %d\n", totalCount)
+			log.Printf("Kprobe: count: %d\n", totalCount)
 		}
 	}()
 

--- a/examples/go-app-counter/kprobe_main.go
+++ b/examples/go-app-counter/kprobe_main.go
@@ -1,0 +1,184 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	bpfmanHelpers "github.com/bpfman/bpfman/bpfman-operator/pkg/helpers"
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"github.com/cilium/ebpf"
+)
+
+const (
+	KprobeBpfProgramMapIndex = "kprobe_stats_map"
+
+	// KprobeMapsMountPoint is the "go-kprobe-counter-maps" volumeMount "mountPath" from "deployment.yaml"
+	KprobeMapsMountPoint = "/run/kprobe/maps"
+)
+
+type KprobeStats struct {
+	Counter uint64
+}
+
+func processKprobe(stop chan os.Signal) {
+
+	// pull the BPFMAN config management data to determine if we're running on a
+	// system with BPFMAN available.
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeKprobe, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	// determine the path to the kprobe_stats_map, whether provided via CRD
+	// or BPFMAN or otherwise.
+	var mapPath string
+	// If running in a Kubernetes deployment, the eBPF program is already loaded.
+	// Only need the map path, which is at a known location in the pod using VolumeMounts
+	// and the CSI Driver.
+	if paramData.CrdFlag {
+		// 3. Get access to our map
+		mapPath = fmt.Sprintf("%s/%s", KprobeMapsMountPoint, KprobeBpfProgramMapIndex)
+	} else { // if not on k8s, find the map path from the system
+		ctx := context.Background()
+
+		// connect to the BPFMAN server
+		conn, err := configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+
+		c := gobpfman.NewBpfmanClient(conn)
+
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequest *gobpfman.LoadRequest
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "kprobe_counter",
+					ProgramType: *bpfmanHelpers.Kprobe.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_KprobeAttachInfo{
+							KprobeAttachInfo: &gobpfman.KprobeAttachInfo{
+								FnName: "try_to_wake_up",
+							},
+						},
+					},
+					MapOwnerId: &mapOwnerId,
+				}
+			} else {
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "kprobe_counter",
+					ProgramType: *bpfmanHelpers.Kprobe.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_KprobeAttachInfo{
+							KprobeAttachInfo: &gobpfman.KprobeAttachInfo{
+								FnName: "try_to_wake_up",
+							},
+						},
+					},
+				}
+			}
+
+			// 1. Load Program using bpfman
+			var res *gobpfman.LoadResponse
+			res, err = c.Load(ctx, loadRequest)
+			if err != nil {
+				conn.Close()
+				log.Print(err)
+				return
+			}
+
+			kernelInfo := res.GetKernelInfo()
+			if kernelInfo != nil {
+				paramData.ProgId = uint(kernelInfo.GetId())
+			} else {
+				conn.Close()
+				log.Printf("kernelInfo not returned in LoadResponse")
+				return
+			}
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
+
+			// 2. Set up defer to unload program when this is closed
+			defer func(id uint) {
+				log.Printf("unloading program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
+				if err != nil {
+					conn.Close()
+					log.Print(err)
+					return
+				}
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.CalcMapPinPath(res.GetInfo(), "kprobe_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		} else {
+			// 2. Set up defer to close connection
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, "kprobe_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		}
+	}
+
+	// load the pinned stats map which is keeping count of kill -SIGUSR1 calls
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+	statsMap, err := ebpf.LoadPinnedMap(mapPath, opts)
+	if err != nil {
+		log.Printf("Failed to load pinned Map: %s\n", mapPath)
+		log.Print(err)
+		return
+	}
+
+	// retrieve and report on the number of times the kprobe is executed.
+	index := uint32(0)
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for range ticker.C {
+			var stats []KprobeStats
+			var totalCount uint64
+
+			if err := statsMap.Lookup(&index, &stats); err != nil {
+				log.Printf("map lookup failed: %v", err)
+				return
+			}
+
+			for _, stat := range stats {
+				totalCount += stat.Counter
+			}
+
+			log.Printf("Kprobe count: %d\n", totalCount)
+		}
+	}()
+
+	<-stop
+
+	log.Printf("Exiting Kprobe...\n")
+}

--- a/examples/go-app-counter/main.go
+++ b/examples/go-app-counter/main.go
@@ -1,0 +1,30 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+const (
+	DefaultByteCodeFile = "bpf_bpfel.o"
+)
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -no-strip -cflags "-O2 -g -Wall" bpf ./bpf/app_counter.c -- -I.:/usr/include/bpf:/usr/include/linux
+func main() {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	processKprobe(stop)
+
+	processTracepoint(stop)
+
+	processTC(stop)
+
+	processUprobe(stop)
+
+	processXdp(stop)
+}

--- a/examples/go-app-counter/main.go
+++ b/examples/go-app-counter/main.go
@@ -25,6 +25,8 @@ var appMutex = &sync.Mutex{}
 var c gobpfman.BpfmanClient
 var ctx context.Context
 
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -no-strip -cflags "-O2 -g -Wall" bpf ./bpf/app_counter.c -- -I.:/usr/include/bpf:/usr/include/linux
+
 func main() {
 	var conn *grpc.ClientConn
 

--- a/examples/go-app-counter/main.go
+++ b/examples/go-app-counter/main.go
@@ -4,37 +4,121 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"google.golang.org/grpc"
 )
 
 const (
-	DefaultByteCodeFile = "bpf_bpfel.o"
+	DefaultByteCodeFile       = "bpf_bpfel.o"
+	ApplicationMapsMountPoint = "/run/application/maps"
 )
 
-var initMutex = &sync.Mutex{}
+var appMutex = &sync.Mutex{}
+var c gobpfman.BpfmanClient
+var ctx context.Context
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -no-strip -cflags "-O2 -g -Wall" bpf ./bpf/app_counter.c -- -I.:/usr/include/bpf:/usr/include/linux
 func main() {
+	var conn *grpc.ClientConn
+
+	// pull the BPFMAN config management data to determine if we're running on a
+	// system with BPFMAN available.
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeApplication, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	// If not running on Kubernetes, create connection to bpfman
+	if !paramData.CrdFlag {
+		ctx = context.Background()
+
+		conn, err = configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+		defer conn.Close()
+		c = gobpfman.NewBpfmanClient(conn)
+	}
+
+	// Create a context that can be cancelled
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure we cancel when we're finished
+
+	// Create a wait group to wait for all goroutines to finish
+	var wg sync.WaitGroup
+
+	// Increment the wait group counter before starting each goroutine
+
+	// Start your goroutines, passing the cancellable context
+	wg.Add(1)
+	go func() {
+		defer wg.Done() // Decrement the wait group counter when the goroutine finishes
+		processKprobe(cancelCtx, &paramData)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		processTracepoint(cancelCtx, &paramData)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		processTC(cancelCtx, &paramData)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		processUprobe(cancelCtx, &paramData)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		processXdp(cancelCtx, &paramData)
+	}()
+
+	// Listen for interrupt signal to gracefully shut down the goroutines
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-
-	go processKprobe(stop)
-
-	go processTracepoint(stop)
-
-	go processTC(stop)
-
-	go processUprobe(stop)
-
-	go processXdp(stop)
-
-	//select {} // wait forever
-
 	<-stop
 
+	// Cancel the context, signaling all goroutines to stop
+	log.Printf("Calling cancel()...\n")
+	cancel()
+
+	// Wait for all goroutines to finish
+	log.Printf("Waiting for all goroutines to finish...\n")
+	wg.Wait()
+
 	log.Printf("Exiting go-app-counter...\n")
+}
+
+func getMapPinPath(progId uint, map_name string) (string, error) {
+	appMutex.Lock()
+	defer appMutex.Unlock()
+	return configMgmt.RetrieveMapPinPath(ctx, c, progId, map_name)
+}
+
+func loadBpfProgram(loadRequest *gobpfman.LoadRequest) (*gobpfman.LoadResponse, error) {
+	appMutex.Lock()
+	defer appMutex.Unlock()
+	return c.Load(ctx, loadRequest)
+}
+
+func unloadBpfProgram(id uint) (*gobpfman.UnloadResponse, error) {
+	appMutex.Lock()
+	defer appMutex.Unlock()
+	return c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
 }

--- a/examples/go-app-counter/tc_main.go
+++ b/examples/go-app-counter/tc_main.go
@@ -1,0 +1,202 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	bpfmanHelpers "github.com/bpfman/bpfman/bpfman-operator/pkg/helpers"
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"github.com/cilium/ebpf"
+)
+
+type TCStats struct {
+	Packets uint64
+	Bytes   uint64
+}
+
+const (
+	TCBpfProgramMapIndex = "tc_stats_map"
+
+	// TCMapsMountPoint is the "go-tc-counter-maps" volumeMount "mountPath" from "deployment.yaml"
+	TCMapsMountPoint = "/run/tc/maps"
+)
+
+const (
+	TC_ACT_OK = 0
+)
+
+func processTC(stop chan os.Signal) {
+
+	// Parse Input Parameters (CmdLine and Config File)
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeTc, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	var action string
+	var direction bpfmanHelpers.TcProgramDirection
+	if paramData.Direction == configMgmt.TcDirectionIngress {
+		action = "received"
+		direction = bpfmanHelpers.Ingress
+	} else {
+		action = "sent"
+		direction = bpfmanHelpers.Egress
+	}
+
+	var mapPath string
+
+	// If running in a Kubernetes deployment, the eBPF program is already loaded.
+	// Only need the map path, which is at a known location in the pod using VolumeMounts
+	// and the CSI Driver.
+	if paramData.CrdFlag {
+		// 3. Get access to our map
+		mapPath = fmt.Sprintf("%s/%s", TCMapsMountPoint, TCBpfProgramMapIndex)
+	} else {
+		ctx := context.Background()
+
+		// Set up a connection to the server.
+		conn, err := configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+		c := gobpfman.NewBpfmanClient(conn)
+
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequest *gobpfman.LoadRequest
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "stats",
+					ProgramType: *bpfmanHelpers.Tc.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_TcAttachInfo{
+							TcAttachInfo: &gobpfman.TCAttachInfo{
+								Priority:  int32(paramData.Priority),
+								Iface:     paramData.Iface,
+								Direction: direction.String(),
+							},
+						},
+					},
+					MapOwnerId: &mapOwnerId,
+				}
+			} else {
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "stats",
+					ProgramType: *bpfmanHelpers.Xdp.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_TcAttachInfo{
+							TcAttachInfo: &gobpfman.TCAttachInfo{
+								Priority:  int32(paramData.Priority),
+								Iface:     paramData.Iface,
+								Direction: direction.String(),
+							},
+						},
+					},
+				}
+			}
+
+			// 1. Load Program using bpfman
+			var res *gobpfman.LoadResponse
+			res, err = c.Load(ctx, loadRequest)
+			if err != nil {
+				conn.Close()
+				log.Print(err)
+				return
+			}
+
+			kernelInfo := res.GetKernelInfo()
+			if kernelInfo != nil {
+				paramData.ProgId = uint(kernelInfo.GetId())
+			} else {
+				conn.Close()
+				log.Printf("kernelInfo not returned in LoadResponse")
+				return
+			}
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
+
+			// 2. Set up defer to unload program when this is closed
+			defer func(id uint) {
+				log.Printf("Unloading Program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
+				if err != nil {
+					conn.Close()
+					log.Print(err)
+					return
+				}
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.CalcMapPinPath(res.GetInfo(), "tc_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		} else {
+			// 2. Set up defer to close connection
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, "tc_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		}
+	}
+
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+	statsMap, err := ebpf.LoadPinnedMap(mapPath, opts)
+	if err != nil {
+		log.Printf("Failed to load pinned Map: %s\n", mapPath)
+		log.Print(err)
+		return
+	}
+
+	ticker := time.NewTicker(3 * time.Second)
+	go func() {
+		for range ticker.C {
+			key := uint32(TC_ACT_OK)
+			var stats []TCStats
+			var totalPackets uint64
+			var totalBytes uint64
+
+			err := statsMap.Lookup(&key, &stats)
+			if err != nil {
+				log.Print(err)
+				return
+			}
+
+			for _, cpuStat := range stats {
+				totalPackets += cpuStat.Packets
+				totalBytes += cpuStat.Bytes
+			}
+
+			log.Printf("%d packets %s\n", totalPackets, action)
+			log.Printf("%d bytes %s\n\n", totalBytes, action)
+		}
+	}()
+
+	<-stop
+
+	log.Printf("Exiting TC ...\n")
+}

--- a/examples/go-app-counter/tc_main.go
+++ b/examples/go-app-counter/tc_main.go
@@ -34,6 +34,8 @@ const (
 
 func processTC(stop chan os.Signal) {
 
+	initMutex.Lock()
+
 	// Parse Input Parameters (CmdLine and Config File)
 	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeTc, DefaultByteCodeFile)
 	if err != nil {
@@ -172,6 +174,8 @@ func processTC(stop chan os.Signal) {
 		return
 	}
 
+	initMutex.Unlock()
+
 	ticker := time.NewTicker(3 * time.Second)
 	go func() {
 		for range ticker.C {
@@ -191,8 +195,8 @@ func processTC(stop chan os.Signal) {
 				totalBytes += cpuStat.Bytes
 			}
 
-			log.Printf("%d packets %s\n", totalPackets, action)
-			log.Printf("%d bytes %s\n\n", totalBytes, action)
+			log.Printf("TC: %d packets received %s\n", totalPackets, action)
+			log.Printf("TC: %d bytes received %s\n\n", totalBytes, action)
 		}
 	}()
 

--- a/examples/go-app-counter/tracepoint_main.go
+++ b/examples/go-app-counter/tracepoint_main.go
@@ -1,0 +1,198 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"time"
+
+	bpfmanHelpers "github.com/bpfman/bpfman/bpfman-operator/pkg/helpers"
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"github.com/cilium/ebpf"
+)
+
+const (
+	TPBpfProgramMapIndex = "tracepoint_stats_map"
+
+	// TPMapsMountPoint is the "go-tracepoint-counter-maps" volumeMount "mountPath" from "deployment.yaml"
+	TPMapsMountPoint = "/run/tracepoint/maps"
+)
+
+type TPStats struct {
+	Calls uint64
+}
+
+func processTracepoint(stop chan os.Signal) {
+	// pull the BPFMAN config management data to determine if we're running on a
+	// system with BPFMAN available.
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeTracepoint, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	// determine the path to the tracepoint_stats_map, whether provided via CRD
+	// or BPFMAN or otherwise.
+	var mapPath string
+	// If running in a Kubernetes deployment, the eBPF program is already loaded.
+	// Only need the map path, which is at a known location in the pod using VolumeMounts
+	// and the CSI Driver.
+	if paramData.CrdFlag {
+		// 3. Get access to our map
+		mapPath = fmt.Sprintf("%s/%s", TPMapsMountPoint, TPBpfProgramMapIndex)
+	} else { // if not on k8s, find the map path from the system
+		ctx := context.Background()
+
+		// connect to the BPFMAN server
+		conn, err := configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+
+		c := gobpfman.NewBpfmanClient(conn)
+
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequest *gobpfman.LoadRequest
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "tracepoint_kill_recorder",
+					ProgramType: *bpfmanHelpers.Tracepoint.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_TracepointAttachInfo{
+							TracepointAttachInfo: &gobpfman.TracepointAttachInfo{
+								Tracepoint: "syscalls/sys_enter_kill",
+							},
+						},
+					},
+					MapOwnerId: &mapOwnerId,
+				}
+			} else {
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "tracepoint_kill_recorder",
+					ProgramType: *bpfmanHelpers.Tracepoint.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_TracepointAttachInfo{
+							TracepointAttachInfo: &gobpfman.TracepointAttachInfo{
+								Tracepoint: "syscalls/sys_enter_kill",
+							},
+						},
+					},
+				}
+			}
+
+			// 1. Load Program using bpfman
+			var res *gobpfman.LoadResponse
+			res, err = c.Load(ctx, loadRequest)
+			if err != nil {
+				conn.Close()
+				log.Print(err)
+				return
+			}
+
+			kernelInfo := res.GetKernelInfo()
+			if kernelInfo != nil {
+				paramData.ProgId = uint(kernelInfo.GetId())
+			} else {
+				conn.Close()
+				log.Printf("kernelInfo not returned in LoadResponse")
+				return
+			}
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
+
+			// 2. Set up defer to unload program when this is closed
+			defer func(id uint) {
+				log.Printf("unloading program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
+				if err != nil {
+					conn.Close()
+					log.Print(err)
+					return
+				}
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.CalcMapPinPath(res.GetInfo(), "tracepoint_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		} else {
+			// 2. Set up defer to close connection
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, "tracepoint_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		}
+	}
+
+	// load the pinned stats map which is keeping count of kill -SIGUSR1 calls
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+	statsMap, err := ebpf.LoadPinnedMap(mapPath, opts)
+	if err != nil {
+		log.Printf("Failed to load pinned Map: %s\n", mapPath)
+		log.Print(err)
+		return
+	}
+
+	// send a SIGUSR1 signal to this program on repeat, which the BPF program
+	// will report on to the stats map.
+	go func() {
+		for {
+			err := syscall.Kill(os.Getpid(), syscall.SIGUSR1)
+			if err != nil {
+				log.Print("Failed to kill process with SIGUSR1:")
+				log.Print(err)
+				return
+			}
+			time.Sleep(time.Second * 1)
+		}
+	}()
+
+	// retrieve and report on the number of kill -SIGUSR1 calls
+	index := uint32(0)
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for range ticker.C {
+			var stats []TPStats
+			var totalCalls uint64
+
+			if err := statsMap.Lookup(&index, &stats); err != nil {
+				log.Printf("map lookup failed: %v", err)
+				return
+			}
+
+			for _, stat := range stats {
+				totalCalls += stat.Calls
+			}
+
+			log.Printf("SIGUSR1 signal count: %d\n", totalCalls)
+		}
+	}()
+
+	<-stop
+
+	log.Printf("Exiting Tracepoint...\n")
+}

--- a/examples/go-app-counter/tracepoint_main.go
+++ b/examples/go-app-counter/tracepoint_main.go
@@ -29,6 +29,9 @@ type TPStats struct {
 }
 
 func processTracepoint(stop chan os.Signal) {
+
+	initMutex.Lock()
+
 	// pull the BPFMAN config management data to determine if we're running on a
 	// system with BPFMAN available.
 	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeTracepoint, DefaultByteCodeFile)
@@ -171,6 +174,8 @@ func processTracepoint(stop chan os.Signal) {
 		}
 	}()
 
+	initMutex.Unlock()
+
 	// retrieve and report on the number of kill -SIGUSR1 calls
 	index := uint32(0)
 	ticker := time.NewTicker(1 * time.Second)
@@ -188,7 +193,7 @@ func processTracepoint(stop chan os.Signal) {
 				totalCalls += stat.Calls
 			}
 
-			log.Printf("SIGUSR1 signal count: %d\n", totalCalls)
+			log.Printf("Tracepoint: SIGUSR1 signal count: %d\n", totalCalls)
 		}
 	}()
 

--- a/examples/go-app-counter/uprobe_main.go
+++ b/examples/go-app-counter/uprobe_main.go
@@ -1,0 +1,187 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	bpfmanHelpers "github.com/bpfman/bpfman/bpfman-operator/pkg/helpers"
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"github.com/cilium/ebpf"
+)
+
+const (
+	UprobeBpfProgramMapIndex = "uprobe_stats_map"
+
+	// UprobeMapsMountPoint is the "go-uprobe-counter-maps" volumeMount "mountPath" from "deployment.yaml"
+	UprobeMapsMountPoint = "/run/uprobe/maps"
+)
+
+type Stats struct {
+	Counter uint64
+}
+
+func processUprobe(stop chan os.Signal) {
+	// pull the BPFMAN config management data to determine if we're running on a
+	// system with BPFMAN available.
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeUprobe, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	// determine the path to the uprobe_stats_map, whether provided via CRD
+	// or BPFMAN or otherwise.
+	var mapPath string
+	// If running in a Kubernetes deployment, the eBPF program is already loaded.
+	// Only need the map path, which is at a known location in the pod using VolumeMounts
+	// and the CSI Driver.
+	if paramData.CrdFlag {
+		// 3. Get access to our map
+		mapPath = fmt.Sprintf("%s/%s", UprobeMapsMountPoint, UprobeBpfProgramMapIndex)
+	} else { // if not on k8s, find the map path from the system
+		ctx := context.Background()
+
+		// connect to the BPFMAN server
+		conn, err := configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+
+		c := gobpfman.NewBpfmanClient(conn)
+
+		fnName := "malloc"
+
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequest *gobpfman.LoadRequest
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "uprobe_counter",
+					ProgramType: *bpfmanHelpers.Kprobe.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_UprobeAttachInfo{
+							UprobeAttachInfo: &gobpfman.UprobeAttachInfo{
+								FnName: &fnName,
+								Target: "libc",
+							},
+						},
+					},
+					MapOwnerId: &mapOwnerId,
+				}
+			} else {
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "uprobe_counter",
+					ProgramType: *bpfmanHelpers.Kprobe.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_UprobeAttachInfo{
+							UprobeAttachInfo: &gobpfman.UprobeAttachInfo{
+								FnName: &fnName,
+								Target: "libc",
+							},
+						},
+					},
+				}
+			}
+
+			// 1. Load Program using bpfman
+			var res *gobpfman.LoadResponse
+			res, err = c.Load(ctx, loadRequest)
+			if err != nil {
+				conn.Close()
+				log.Print(err)
+				return
+			}
+
+			kernelInfo := res.GetKernelInfo()
+			if kernelInfo != nil {
+				paramData.ProgId = uint(kernelInfo.GetId())
+			} else {
+				conn.Close()
+				log.Printf("kernelInfo not returned in LoadResponse")
+				return
+			}
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
+
+			// 2. Set up defer to unload program when this is closed
+			defer func(id uint) {
+				log.Printf("unloading program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
+				if err != nil {
+					conn.Close()
+					log.Print(err)
+					return
+				}
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.CalcMapPinPath(res.GetInfo(), "uprobe_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		} else {
+			// 2. Set up defer to close connection
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, "uprobe_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		}
+	}
+
+	// load the pinned stats map which is keeping count of uprobe hits
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+	statsMap, err := ebpf.LoadPinnedMap(mapPath, opts)
+	if err != nil {
+		log.Printf("Failed to load pinned Map: %s\n", mapPath)
+		log.Print(err)
+		return
+	}
+
+	// retrieve and report on the number of times the uprobe is executed.
+	index := uint32(0)
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for range ticker.C {
+			var stats []Stats
+			var totalCount uint64
+
+			if err := statsMap.Lookup(&index, &stats); err != nil {
+				log.Printf("map lookup failed: %v", err)
+				return
+			}
+
+			for _, stat := range stats {
+				totalCount += stat.Counter
+			}
+
+			log.Printf("Uprobe count: %d\n", totalCount)
+		}
+	}()
+
+	<-stop
+
+	log.Printf("Exiting...\n")
+}

--- a/examples/go-app-counter/uprobe_main.go
+++ b/examples/go-app-counter/uprobe_main.go
@@ -28,6 +28,9 @@ type Stats struct {
 }
 
 func processUprobe(stop chan os.Signal) {
+
+	initMutex.Lock()
+
 	// pull the BPFMAN config management data to determine if we're running on a
 	// system with BPFMAN available.
 	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeUprobe, DefaultByteCodeFile)
@@ -160,6 +163,8 @@ func processUprobe(stop chan os.Signal) {
 		return
 	}
 
+	initMutex.Unlock()
+
 	// retrieve and report on the number of times the uprobe is executed.
 	index := uint32(0)
 	ticker := time.NewTicker(1 * time.Second)
@@ -177,7 +182,7 @@ func processUprobe(stop chan os.Signal) {
 				totalCount += stat.Counter
 			}
 
-			log.Printf("Uprobe count: %d\n", totalCount)
+			log.Printf("Uprobe: count: %d\n", totalCount)
 		}
 	}()
 

--- a/examples/go-app-counter/xdp_main.go
+++ b/examples/go-app-counter/xdp_main.go
@@ -33,6 +33,9 @@ const (
 )
 
 func processXdp(stop chan os.Signal) {
+
+	initMutex.Lock()
+
 	// Parse Input Parameters (CmdLine and Config File)
 	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeXdp, DefaultByteCodeFile)
 	if err != nil {
@@ -159,6 +162,8 @@ func processXdp(stop chan os.Signal) {
 		return
 	}
 
+	initMutex.Unlock()
+
 	ticker := time.NewTicker(3 * time.Second)
 	go func() {
 		for range ticker.C {
@@ -178,8 +183,8 @@ func processXdp(stop chan os.Signal) {
 				totalBytes += cpuStat.Bytes
 			}
 
-			log.Printf("%d packets received\n", totalPackets)
-			log.Printf("%d bytes received\n\n", totalBytes)
+			log.Printf("XDP: %d packets received\n", totalPackets)
+			log.Printf("XDP: %d bytes received\n\n", totalBytes)
 		}
 	}()
 

--- a/examples/go-app-counter/xdp_main.go
+++ b/examples/go-app-counter/xdp_main.go
@@ -1,0 +1,189 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	bpfmanHelpers "github.com/bpfman/bpfman/bpfman-operator/pkg/helpers"
+	gobpfman "github.com/bpfman/bpfman/clients/gobpfman/v1"
+	configMgmt "github.com/bpfman/bpfman/examples/pkg/config-mgmt"
+	"github.com/cilium/ebpf"
+)
+
+type XdpStats struct {
+	Packets uint64
+	Bytes   uint64
+}
+
+const (
+	XDPBpfProgramMapIndex = "xdp_stats_map"
+
+	// XDPMapsMountPoint is the "go-xdp-counter-maps" volumeMount "mountPath" from "deployment.yaml"
+	XDPMapsMountPoint = "/run/xdp/maps"
+)
+
+const (
+	XDP_ACT_OK = 2
+)
+
+func processXdp(stop chan os.Signal) {
+	// Parse Input Parameters (CmdLine and Config File)
+	paramData, err := configMgmt.ParseParamData(configMgmt.ProgTypeXdp, DefaultByteCodeFile)
+	if err != nil {
+		log.Printf("error processing parameters: %v\n", err)
+		return
+	}
+
+	var mapPath string
+
+	// If running in a Kubernetes deployment, the eBPF program is already loaded.
+	// Only need the map path, which is at a known location in the pod using VolumeMounts
+	// and the CSI Driver.
+	if paramData.CrdFlag {
+		// 3. Get access to our map
+		mapPath = fmt.Sprintf("%s/%s", XDPMapsMountPoint, XDPBpfProgramMapIndex)
+	} else {
+		ctx := context.Background()
+
+		conn, err := configMgmt.CreateConnection(ctx)
+		if err != nil {
+			log.Printf("failed to create client connection: %v", err)
+			return
+		}
+
+		c := gobpfman.NewBpfmanClient(conn)
+
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequest *gobpfman.LoadRequest
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "xdp_stats",
+					ProgramType: *bpfmanHelpers.Xdp.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_XdpAttachInfo{
+							XdpAttachInfo: &gobpfman.XDPAttachInfo{
+								Priority: int32(paramData.Priority),
+								Iface:    paramData.Iface,
+							},
+						},
+					},
+					MapOwnerId: &mapOwnerId,
+				}
+			} else {
+				loadRequest = &gobpfman.LoadRequest{
+					Bytecode:    paramData.BytecodeSource,
+					Name:        "xdp_stats",
+					ProgramType: *bpfmanHelpers.Xdp.Uint32(),
+					Attach: &gobpfman.AttachInfo{
+						Info: &gobpfman.AttachInfo_XdpAttachInfo{
+							XdpAttachInfo: &gobpfman.XDPAttachInfo{
+								Priority: int32(paramData.Priority),
+								Iface:    paramData.Iface,
+							},
+						},
+					},
+				}
+			}
+
+			// 1. Load Program using bpfman
+			var res *gobpfman.LoadResponse
+			res, err = c.Load(ctx, loadRequest)
+			if err != nil {
+				conn.Close()
+				log.Print(err)
+				return
+			}
+
+			kernelInfo := res.GetKernelInfo()
+			if kernelInfo != nil {
+				paramData.ProgId = uint(kernelInfo.GetId())
+			} else {
+				conn.Close()
+				log.Printf("kernelInfo not returned in LoadResponse")
+				return
+			}
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
+
+			// 2. Set up defer to unload program when this is closed
+			defer func(id uint) {
+				log.Printf("Unloading Program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfman.UnloadRequest{Id: uint32(id)})
+				if err != nil {
+					conn.Close()
+					log.Print(err)
+					return
+				}
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.CalcMapPinPath(res.GetInfo(), "xdp_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		} else {
+			// 2. Set up defer to close connection
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
+				conn.Close()
+			}(paramData.ProgId)
+
+			// 3. Get access to our map
+			mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, "xdp_stats_map")
+			if err != nil {
+				log.Print(err)
+				return
+			}
+		}
+	}
+
+	opts := &ebpf.LoadPinOptions{
+		ReadOnly:  false,
+		WriteOnly: false,
+		Flags:     0,
+	}
+	statsMap, err := ebpf.LoadPinnedMap(mapPath, opts)
+	if err != nil {
+		log.Printf("Failed to load pinned Map: %s\n", mapPath)
+		log.Print(err)
+		return
+	}
+
+	ticker := time.NewTicker(3 * time.Second)
+	go func() {
+		for range ticker.C {
+			key := uint32(XDP_ACT_OK)
+			var stats []XdpStats
+			var totalPackets uint64
+			var totalBytes uint64
+
+			err := statsMap.Lookup(&key, &stats)
+			if err != nil {
+				log.Print(err)
+				return
+			}
+
+			for _, cpuStat := range stats {
+				totalPackets += cpuStat.Packets
+				totalBytes += cpuStat.Bytes
+			}
+
+			log.Printf("%d packets received\n", totalPackets)
+			log.Printf("%d bytes received\n\n", totalBytes)
+		}
+	}()
+
+	<-stop
+
+	log.Printf("Exiting XDP...\n")
+}

--- a/examples/pkg/config-mgmt/param.go
+++ b/examples/pkg/config-mgmt/param.go
@@ -46,10 +46,11 @@ const (
 	ProgTypeTracepoint
 	ProgTypeKprobe
 	ProgTypeUprobe
+	ProgTypeApplication
 )
 
 func (s ProgType) String() string {
-	return [...]string{"xdp", "tc", "tracepoint", "kprobe", "uprobe"}[s]
+	return [...]string{"xdp", "tc", "tracepoint", "kprobe", "uprobe", "application"}[s]
 }
 
 const (
@@ -78,7 +79,7 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	if progType == ProgTypeXdp || progType == ProgTypeTc {
+	if progType == ProgTypeXdp || progType == ProgTypeTc || progType == ProgTypeApplication {
 		flag.StringVar(&paramData.Iface, "iface", "eno3",
 			"Interface to load bytecode. Optional.")
 		flag.IntVar(&paramData.Priority, "priority", 50,
@@ -99,7 +100,7 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 		"Flag to indicate all attributes should be pulled from the BpfProgram CRD.\n"+
 			"Used in Kubernetes deployments and is mutually exclusive with all other\n"+
 			"parameters.")
-	if progType == ProgTypeTc {
+	if progType == ProgTypeTc || progType == ProgTypeApplication {
 		flag.StringVar(&direction_str, "direction", "ingress",
 			"Direction to apply program (ingress, egress). Optional.")
 	}
@@ -118,17 +119,15 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 
 	// "-iface" is the interface to run bpf program on. If not provided, error.
 	//    ./go-xdp-counter -iface eth0
-	if (progType == ProgTypeTc || progType == ProgTypeXdp) && len(paramData.Iface) == 0 {
+	if (progType == ProgTypeTc || progType == ProgTypeXdp || progType == ProgTypeApplication) &&
+		len(paramData.Iface) == 0 {
 		return paramData, fmt.Errorf("interface is required")
 	}
 
-	if progType == ProgTypeTc {
+	if progType == ProgTypeTc || progType == ProgTypeApplication {
 		// "-direction" is the direction in which to run the bpf program. Valid values
-		// are "ingress" and "egress". If not provided, error.
+		// are "ingress" and "egress". If not provided, defaults to "ingress".
 		//    ./go-tc-counter -iface eth0 -direction ingress
-		if len(direction_str) == 0 {
-			return paramData, fmt.Errorf("direction is required")
-		}
 
 		if direction_str == "ingress" {
 			paramData.Direction = TcDirectionIngress

--- a/examples/pkg/config-mgmt/param.go
+++ b/examples/pkg/config-mgmt/param.go
@@ -79,8 +79,8 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	if progType == ProgTypeXdp || progType == ProgTypeTc {
-		flag.StringVar(&paramData.Iface, "iface", "",
-			"Interface to load bytecode. Required.")
+		flag.StringVar(&paramData.Iface, "iface", "eno3",
+			"Interface to load bytecode. Optional.")
 		flag.IntVar(&paramData.Priority, "priority", 50,
 			"Priority to load program in bpfman. Optional.")
 	}
@@ -100,8 +100,8 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 			"Used in Kubernetes deployments and is mutually exclusive with all other\n"+
 			"parameters.")
 	if progType == ProgTypeTc {
-		flag.StringVar(&direction_str, "direction", "",
-			"Direction to apply program (ingress, egress). Required.")
+		flag.StringVar(&direction_str, "direction", "ingress",
+			"Direction to apply program (ingress, egress). Optional.")
 	}
 	flag.IntVar(&paramData.MapOwnerId, "map_owner_id", 0,
 		"Program Id of loaded eBPF program this eBPF program will share a map with.\n"+


### PR DESCRIPTION
Add application object example

```sh
make deploy-target
IMAGE_APP_BC="quay.io/mmahmoud/bpfman-bytecode/go-application-counter:all" make deploy-application

oc get bpfprograms
NAME                                                                                                            TYPE          STATUS         AGE
go-application-counter-example-kprobe-bpfman-deployment-control-plane-try-to-wake-up                            application   bpfmanLoaded   50s
go-application-counter-example-tc-bpfman-deployment-control-plane-eth0                                          application   bpfmanLoaded   40s
go-application-counter-example-tracepoint-bpfman-deployment-control-plane-syscalls-sys-enter-kill               application   bpfmanLoaded   45s
go-application-counter-example-uprobe-bpfman-deployment-control-plane--go-target-go-target-ds-psgp2-go-target   application   bpfmanLoaded   34s
go-application-counter-example-xdp-bpfman-deployment-control-plane-eth0                                         application   bpfmanLoaded   30s

```