### PR TITLE
Temporary work-around for multi-program container images

### DIFF
--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -12,7 +12,7 @@ use std::{
 use aya::programs::ProgramInfo as AyaProgInfo;
 use chrono::{prelude::DateTime, Local};
 use clap::ValueEnum;
-use log::{info, warn};
+use log::{debug, info, warn};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sled::Db;
@@ -628,10 +628,11 @@ impl ProgramData {
                         if provided_name.is_empty() {
                             self.set_name(&s)?;
                         } else if s != provided_name {
-                            return Err(BpfmanError::BytecodeMetaDataMismatch {
-                                image_prog_name: s,
-                                provided_prog_name: provided_name.to_string(),
-                            });
+                            debug!(
+                                "Bytecode image bpf function name: {} isn't equal to the provided bpf function name: {}",
+                                s,
+                                provided_name
+                            );
                         }
                     }
                     Location::File(l) => {


### PR DESCRIPTION
The BpfApplication CRD support is intended to allow an application to define a set of BPF programs required for operation.  This set of programs may included multiple types of BPF programs that are packaged in a single .o and single bytecode image file.  However, our currentl image spec is designed to support a single bpf program with a single type.

More importantly, the bpfman code has a check to validate that the name of program being loaded matches the name that is provided by the user.

As a temporary work-around, this pr just logs the mismatch and doesn't fail the load.

A more complete solution will be provided by pr #1141