### PR TITLE
examples: cleanup patch.yaml files

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -16,3 +16,5 @@ ignore:
   ## Kustomize automatically formats these incorrectly
   - bpfman-operator/config/bpfman-deployment/kustomization.yaml
   - bpfman-operator/config/bpfman-operator-deployment/kustomization.yaml
+  - examples/config/default/*/kustomization.yaml
+  - examples/config/selinux/*/kustomization.yaml

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,3 +6,6 @@ bin
 **/bpf_bpf*.o
 **/bpf_*_bpf*.go
 **/bpf_*_bpf*.o
+
+# Temporary patch files, generated from patch.yaml.env files using sed in Makefile
+**/patch.yaml

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -189,13 +189,15 @@ deploy-prog: kustomize
 ifndef TAG
 	sed 's@URL_BC@$(IMAGE_BC)@' config/$(CONFIG_DIR)/patch.yaml.env > config/$(CONFIG_DIR)/patch.yaml
 	cd config/$(CONFIG_DIR) && $(KUSTOMIZE) edit set image quay.io/bpfman-userspace/$(PROG_NAME)=${IMAGE_US}
+	$(eval KUST_DIR=$(CONFIG_DIR))
 else
-	$(eval KUST_DIR=$(TAG))
+	$(eval KUST_DIR=$(TAG)/$(PROG_NAME))
 endif
-	@if [ -f config/$(CONFIG_DIR)/kustomization.yaml ]; then \
-		$(KUSTOMIZE) build config/$(CONFIG_DIR) | kubectl apply -f - ; \
+	@if [ -f config/$(KUST_DIR)/kustomization.yaml ]; then \
+		echo "Using KUST_DIR=$(KUST_DIR)" ; \
+		$(KUSTOMIZE) build config/$(KUST_DIR) | kubectl apply -f - ; \
 	else \
-		echo "Manifests $(CONFIG_DIR) do not exist for program $(PROG_NAME)" ; \
+		echo "Manifests $(KUST_DIR) do not exist for program $(PROG_NAME)" ; \
 		exit 1 ; \
 	fi
 
@@ -205,13 +207,15 @@ undeploy-prog:
 ifndef TAG
 	sed 's@URL_BC@$(IMAGE_BC)@' config/$(CONFIG_DIR)/patch.yaml.env > config/$(CONFIG_DIR)/patch.yaml
 	cd config/$(CONFIG_DIR) && $(KUSTOMIZE) edit set image quay.io/bpfman-userspace/$(PROG_NAME)=${IMAGE_US}
+	$(eval KUST_DIR=$(CONFIG_DIR))
 else
-	$(eval CONFIG_DIR=$(TAG))
+	$(eval KUST_DIR=$(TAG)/$(PROG_NAME))
 endif
-	@if [ -f config/$(CONFIG_DIR)/kustomization.yaml ]; then \
-		$(KUSTOMIZE) build config/$(CONFIG_DIR) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -; \
+	@if [ -f config/$(KUST_DIR)/kustomization.yaml ]; then \
+		echo "Using KUST_DIR=$(KUST_DIR)" ; \
+		$(KUSTOMIZE) build config/$(KUST_DIR) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -; \
 	else \
-		echo "Manifests $(CONFIG_DIR) does not exist for program $(PROG_NAME)" ; \
+		echo "Manifests $(KUST_DIR) does not exist for program $(PROG_NAME)" ; \
 		exit 1 ; \
 	fi
 

--- a/examples/config/default/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/default/go-kprobe-counter/kustomization.yaml
@@ -3,17 +3,17 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-kprobe-counter
-    newName: quay.io/bpfman-userspace/go-kprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-kprobe-counter
+  newName: quay.io/bpfman-userspace/go-kprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: kprobeProgram
-      name: go-kprobe-counter-example
+- path: patch.yaml
+  target:
+    kind: kprobeProgram
+    name: go-kprobe-counter-example
 resources:
-  - ../../base/go-kprobe-counter
+- ../../base/go-kprobe-counter

--- a/examples/config/default/go-kprobe-counter/patch.yaml
+++ b/examples/config/default/go-kprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-kprobe-counter:latest

--- a/examples/config/default/go-kprobe-counter/patch.yaml.env
+++ b/examples/config/default/go-kprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-tc-counter/kustomization.yaml
+++ b/examples/config/default/go-tc-counter/kustomization.yaml
@@ -1,19 +1,19 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-tc-counter
-    newName: quay.io/bpfman-userspace/go-tc-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-tc-counter
+  newName: quay.io/bpfman-userspace/go-tc-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: TcProgram
-      name: go-tc-counter-example
-resources: [../../base/go-tc-counter]
+- path: patch.yaml
+  target:
+    kind: TcProgram
+    name: go-tc-counter-example
+resources:
+- ../../base/go-tc-counter

--- a/examples/config/default/go-tc-counter/patch.yaml
+++ b/examples/config/default/go-tc-counter/patch.yaml
@@ -1,6 +1,0 @@
----
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/default/go-tc-counter/patch.yaml.env
+++ b/examples/config/default/go-tc-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/default/go-tracepoint-counter/kustomization.yaml
@@ -1,19 +1,19 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-tracepoint-counter
-    newName: quay.io/bpfman-userspace/go-tracepoint-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-tracepoint-counter
+  newName: quay.io/bpfman-userspace/go-tracepoint-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: TracepointProgram
-      name: go-tracepoint-counter-example
-resources: [../../base/go-tracepoint-counter]
+- path: patch.yaml
+  target:
+    kind: TracepointProgram
+    name: go-tracepoint-counter-example
+resources:
+- ../../base/go-tracepoint-counter

--- a/examples/config/default/go-tracepoint-counter/patch.yaml
+++ b/examples/config/default/go-tracepoint-counter/patch.yaml
@@ -1,6 +1,0 @@
----
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tracepoint-counter:latest

--- a/examples/config/default/go-tracepoint-counter/patch.yaml.env
+++ b/examples/config/default/go-tracepoint-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/default/go-uprobe-counter/kustomization.yaml
@@ -3,17 +3,17 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-uprobe-counter
-    newName: quay.io/bpfman-userspace/go-uprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-uprobe-counter
+  newName: quay.io/bpfman-userspace/go-uprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: uprobeProgram
-      name: go-uprobe-counter-example
+- path: patch.yaml
+  target:
+    kind: uprobeProgram
+    name: go-uprobe-counter-example
 resources:
-  - ../../base/go-uprobe-counter
+- ../../base/go-uprobe-counter

--- a/examples/config/default/go-uprobe-counter/patch.yaml
+++ b/examples/config/default/go-uprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-uprobe-counter:latest

--- a/examples/config/default/go-uprobe-counter/patch.yaml.env
+++ b/examples/config/default/go-uprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/default/go-uretprobe-counter/kustomization.yaml
@@ -3,17 +3,17 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-uretprobe-counter
-    newName: quay.io/bpfman-userspace/go-uretprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-uretprobe-counter
+  newName: quay.io/bpfman-userspace/go-uretprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: uprobeProgram
-      name: go-uretprobe-counter-example
+- path: patch.yaml
+  target:
+    kind: uprobeProgram
+    name: go-uretprobe-counter-example
 resources:
-  - ../../base/go-uretprobe-counter
+- ../../base/go-uretprobe-counter

--- a/examples/config/default/go-uretprobe-counter/patch.yaml
+++ b/examples/config/default/go-uretprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-uretprobe-counter:latest

--- a/examples/config/default/go-uretprobe-counter/patch.yaml.env
+++ b/examples/config/default/go-uretprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/default/go-xdp-counter-sharing-map/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
@@ -6,12 +5,13 @@ kind: Kustomization
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: XdpProgram
-      name: go-xdp-counter-example
-resources: [../../base/go-xdp-counter-sharing-map]
+- path: patch.yaml
+  target:
+    kind: XdpProgram
+    name: go-xdp-counter-example
+resources:
+- ../../base/go-xdp-counter-sharing-map
 images:
-  - name: quay.io/bpfman-userspace/go-xdp-counter
-    newName: quay.io/bpfman-userspace/go-xdp-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-xdp-counter
+  newName: quay.io/bpfman-userspace/go-xdp-counter
+  newTag: latest

--- a/examples/config/default/go-xdp-counter-sharing-map/patch.yaml
+++ b/examples/config/default/go-xdp-counter-sharing-map/patch.yaml
@@ -1,6 +1,0 @@
----
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/default/go-xdp-counter-sharing-map/patch.yaml.env
+++ b/examples/config/default/go-xdp-counter-sharing-map/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/default/go-xdp-counter/kustomization.yaml
+++ b/examples/config/default/go-xdp-counter/kustomization.yaml
@@ -1,19 +1,19 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-xdp-counter
-    newName: quay.io/bpfman-userspace/go-xdp-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-xdp-counter
+  newName: quay.io/bpfman-userspace/go-xdp-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: XdpProgram
-      name: go-xdp-counter-example
-resources: [../../base/go-xdp-counter]
+- path: patch.yaml
+  target:
+    kind: XdpProgram
+    name: go-xdp-counter-example
+resources:
+- ../../base/go-xdp-counter

--- a/examples/config/default/go-xdp-counter/patch.yaml
+++ b/examples/config/default/go-xdp-counter/patch.yaml
@@ -1,6 +1,0 @@
----
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/default/go-xdp-counter/patch.yaml.env
+++ b/examples/config/default/go-xdp-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-kprobe-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-kprobe-counter
-    newName: quay.io/bpfman-userspace/go-kprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-kprobe-counter
+  newName: quay.io/bpfman-userspace/go-kprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: KprobeProgram
-      name: go-kprobe-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-kprobe-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-kprobe-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-kprobe-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-kprobe-counter-ds
+- path: patch.yaml
+  target:
+    kind: KprobeProgram
+    name: go-kprobe-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-kprobe-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-kprobe-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-kprobe-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-kprobe-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-kprobe-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-kprobe-counter

--- a/examples/config/selinux/go-kprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-kprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-kprobe-counter:latest

--- a/examples/config/selinux/go-kprobe-counter/patch.yaml.env
+++ b/examples/config/selinux/go-kprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-tc-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tc-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-tc-counter
-    newName: quay.io/bpfman-userspace/go-tc-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-tc-counter
+  newName: quay.io/bpfman-userspace/go-tc-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: TcProgram
-      name: go-tc-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-tc-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-tc-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tc-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-tc-counter-ds
+- path: patch.yaml
+  target:
+    kind: TcProgram
+    name: go-tc-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-tc-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-tc-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tc-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-tc-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-tc-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-tc-counter

--- a/examples/config/selinux/go-tc-counter/patch.yaml
+++ b/examples/config/selinux/go-tc-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/selinux/go-tc-counter/patch.yaml.env
+++ b/examples/config/selinux/go-tc-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-tracepoint-counter
-    newName: quay.io/bpfman-userspace/go-tracepoint-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-tracepoint-counter
+  newName: quay.io/bpfman-userspace/go-tracepoint-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: TracepointProgram
-      name: go-tracepoint-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-tracepoint-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-tracepoint-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tracepoint-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-tracepoint-counter-ds
+- path: patch.yaml
+  target:
+    kind: TracepointProgram
+    name: go-tracepoint-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-tracepoint-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-tracepoint-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tracepoint-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-tracepoint-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-tracepoint-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-tracepoint-counter

--- a/examples/config/selinux/go-tracepoint-counter/patch.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tracepoint-counter:latest

--- a/examples/config/selinux/go-tracepoint-counter/patch.yaml.env
+++ b/examples/config/selinux/go-tracepoint-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uprobe-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-uprobe-counter
-    newName: quay.io/bpfman-userspace/go-uprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-uprobe-counter
+  newName: quay.io/bpfman-userspace/go-uprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: UprobeProgram
-      name: go-uprobe-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-uprobe-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-uprobe-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uprobe-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-uprobe-counter-ds
+- path: patch.yaml
+  target:
+    kind: UprobeProgram
+    name: go-uprobe-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-uprobe-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-uprobe-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uprobe-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-uprobe-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-uprobe-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-uprobe-counter

--- a/examples/config/selinux/go-uprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-uprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-uprobe-counter:latest

--- a/examples/config/selinux/go-uprobe-counter/patch.yaml.env
+++ b/examples/config/selinux/go-uprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-uretprobe-counter
-    newName: quay.io/bpfman-userspace/go-uretprobe-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-uretprobe-counter
+  newName: quay.io/bpfman-userspace/go-uretprobe-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: UprobeProgram
-      name: go-uretprobe-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-uretprobe-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-uretprobe-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uretprobe-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-uretprobe-counter-ds
+- path: patch.yaml
+  target:
+    kind: UprobeProgram
+    name: go-uretprobe-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-uretprobe-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-uretprobe-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uretprobe-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-uretprobe-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-uretprobe-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-uretprobe-counter

--- a/examples/config/selinux/go-uretprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-uretprobe-counter:latest

--- a/examples/config/selinux/go-uretprobe-counter/patch.yaml.env
+++ b/examples/config/selinux/go-uretprobe-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
@@ -6,37 +5,37 @@ kind: Kustomization
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: XdpProgram
-      name: go-xdp-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-xdp-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-xdp-counter-ds
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions/type"
-        value:
-          bpfman-secure_go-xdp-counter.process
-    target:
-      kind: DaemonSet
-      name: go-xdp-counter-ds
+- path: patch.yaml
+  target:
+    kind: XdpProgram
+    name: go-xdp-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-xdp-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-xdp-counter-ds
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions/type"
+      value:
+        bpfman-secure_go-xdp-counter.process
+  target:
+    kind: DaemonSet
+    name: go-xdp-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-xdp-counter-sharing-map
+- selinux.yaml
+- binding.yaml
+- ../../base/go-xdp-counter-sharing-map
 images:
-  - name: quay.io/bpfman-userspace/go-xdp-counter
-    newName: quay.io/bpfman-userspace/go-xdp-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-xdp-counter
+  newName: quay.io/bpfman-userspace/go-xdp-counter
+  newTag: latest

--- a/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml
@@ -1,6 +1,0 @@
----
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml.env
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/selinux/go-xdp-counter/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter/kustomization.yaml
@@ -3,37 +3,37 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-  - name: quay.io/bpfman-userspace/go-xdp-counter
-    newName: quay.io/bpfman-userspace/go-xdp-counter
-    newTag: latest
+- name: quay.io/bpfman-userspace/go-xdp-counter
+  newName: quay.io/bpfman-userspace/go-xdp-counter
+  newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
 # variable and using sed to replace, moved to patch.yaml.env which is
 # converted to patch.yaml using the sed command in Makefile.
 patches:
-  - path: patch.yaml
-    target:
-      kind: XdpProgram
-      name: go-xdp-counter-example
-  - patch: |-
-      - op: add
-        path: "/metadata/labels"
-        value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
-    target:
-      kind: Namespace
-      name: go-xdp-counter
-  - patch: |-
-      - op: add
-        path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
-        value: {}
-    target:
-      kind: DaemonSet
-      name: go-xdp-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-xdp-counter.process"
-    target:
-      kind: DaemonSet
-      name: go-xdp-counter-ds
+- path: patch.yaml
+  target:
+    kind: XdpProgram
+    name: go-xdp-counter-example
+- patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value: {"pod-security.kubernetes.io/enforce":"privileged","pod-security.kubernetes.io/warn":"privileged"}
+  target:
+    kind: Namespace
+    name: go-xdp-counter
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions"
+      value: {}
+  target:
+    kind: DaemonSet
+    name: go-xdp-counter-ds
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-xdp-counter.process"
+  target:
+    kind: DaemonSet
+    name: go-xdp-counter-ds
 resources:
-  - selinux.yaml
-  - binding.yaml
-  - ../../base/go-xdp-counter
+- selinux.yaml
+- binding.yaml
+- ../../base/go-xdp-counter

--- a/examples/config/selinux/go-xdp-counter/patch.yaml
+++ b/examples/config/selinux/go-xdp-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/selinux/go-xdp-counter/patch.yaml.env
+++ b/examples/config/selinux/go-xdp-counter/patch.yaml.env
@@ -1,5 +1,6 @@
+---
 # Patch the bytecode.yaml to change image and tag on the "url" field
 # (which is an image) to new value.
 - op: replace
-  path: "/spec/bytecode/image/url"
+  path: /spec/bytecode/image/url
   value: URL_BC

--- a/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml
+++ b/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml.env
+++ b/examples/config/v0.3.1-ocp/go-tc-counter/patch.yaml.env
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: "/spec/bytecode/image/url"
-  value: URL_BC

--- a/examples/config/v0.4.0-ocp/go-tc-counter/patch.yaml
+++ b/examples/config/v0.4.0-ocp/go-tc-counter/patch.yaml
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/v0.4.0-ocp/go-tc-counter/patch.yaml.env
+++ b/examples/config/v0.4.0-ocp/go-tc-counter/patch.yaml.env
@@ -1,5 +1,0 @@
-# Patch the bytecode.yaml to change image and tag on the "url" field
-# (which is an image) to new value.
-- op: replace
-  path: "/spec/bytecode/image/url"
-  value: URL_BC


### PR DESCRIPTION
In the examples directory, the patch.yaml files were never meant to be checked in. They are generated from the patch.yam.env files in the Makefile when `make deploy` is called. They were inadvertently checked in as part of the rename from bpfd to bpfman where lots of files were modified.
    
Once they were checked in, a change was made to remove quotes around the path value and `---` added to the top of the file. So these changes were propagated to the patch.yaml.env file.
    
Makefile needed updates to load from tags.