### PR TITLE
cut release 0.5.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-log-exporter"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-metrics-exporter"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "aya",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-api"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-ns"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "aya",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "integration-test-macros"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "quote",
  "syn 2.0.65",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.1"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "bpfman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"
 repository = "https://github.com/bpfman/bpfman"
-version = "0.4.1"
+version = "0.5.0-rc1"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -28,8 +28,8 @@ async-trait = { version = "0.1", default-features = false }
 aya = { version = "0.12", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.22.0", default-features = false }
-bpfman = { version = "0.4.1", path = "./bpfman" }
-bpfman-api = { version = "0.4.1", path = "./bpfman-api" }
+bpfman = { version = "0.5.0-rc1", path = "./bpfman" }
+bpfman-api = { version = "0.5.0-rc1", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
 caps = { version = "0.5.4", default-features = false }
 cargo_metadata = { version = "0.18.0", default-features = false }

--- a/changelogs/CHANGELOG-v0.5.0-rc1.md
+++ b/changelogs/CHANGELOG-v0.5.0-rc1.md
@@ -1,0 +1,1 @@
+Pre-release 1 for 0.5.0


### PR DESCRIPTION
write changelog, bump necessary versions.

Depends on #1164 Since I don't think we should be packaging stale code into an actual release payload :/ 