### PR TITLE
cut a v0.4.2 patch release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,7 +445,7 @@ jobs:
           body_path: ./changelogs/CHANGELOG-${{ env.RELEASE_VERSION }}.md
           prerelease: ${{ env.PRE_RELEASE }}
           files: |
-            bpfman-${{ matrix.arch.filename }}.tar.gz
+            bpfman-linux-x86_64.tar.gz
 
       - name: publish bpfman crate
         run: cargo publish -p bpfman --token ${{ secrets.BPFMAN_DEV_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -185,7 +185,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -218,7 +218,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -249,7 +249,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -285,7 +285,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.32.2",
  "thiserror",
 ]
 
@@ -299,22 +299,22 @@ dependencies = [
  "core-error",
  "hashbrown 0.14.5",
  "log",
- "object",
+ "object 0.32.2",
  "thiserror",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.0",
  "rustc-demangle",
 ]
 
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-log-exporter"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-metrics-exporter"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aya",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "bpfman-ns"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aya",
@@ -587,9 +587,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "cesu8"
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.5"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2020fa13af48afc65a9a87335bda648309ab3d154cd03c7ff95b378c7ed39c4"
+checksum = "fbca90c87c2a04da41e95d1856e8bcd22f159bdbfa147314d2ce5218057b0e58"
 dependencies = [
  "clap",
 ]
@@ -737,14 +737,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clap_mangen"
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -870,7 +870,7 @@ dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "winapi",
 ]
 
@@ -923,16 +923,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -946,7 +945,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -961,12 +960,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -985,16 +984,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.65",
+ "strsim 0.11.1",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1010,13 +1009,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.9",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1052,7 +1051,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1098,17 +1097,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -1164,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elliptic-curve"
@@ -1213,7 +1201,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1404,7 +1392,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1472,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -1610,7 +1598,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand",
  "resolv-conf",
  "smallvec",
@@ -1711,12 +1699,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -1724,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1736,9 +1724,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1785,7 +1773,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1797,7 +1785,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1810,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1834,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1876,124 +1864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,14 +1881,12 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2055,16 +1923,16 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "integration-test"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2080,10 +1948,10 @@ dependencies = [
 
 [[package]]
 name = "integration-test-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2185,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "json-syntax"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe45447363747ecc18deb478f945df8482edafbae21e51bdc73eab76883c6a5"
+checksum = "ed6de1df37a464e0d1958ea233f2abe64b07558f27e718e2fcda04547dc7ae03"
 dependencies = [
  "decoded-char",
  "hashbrown 0.12.3",
@@ -2301,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -2331,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2348,15 +2216,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -2427,9 +2289,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -2464,9 +2326,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -2490,11 +2352,10 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -2729,6 +2590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oci-distribution"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,7 +2701,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2978,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.10",
@@ -3008,7 +2878,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -3092,7 +2962,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3152,12 +3022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3252,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3271,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
@@ -3286,7 +3150,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.67",
  "tempfile",
 ]
 
@@ -3300,7 +3164,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3314,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c92cea150e7e5501c3f01b90928d26566335e4681c79e0aead3be096bf5e2d4"
+checksum = "e6723502e9e30fcad6876200d3bdaf4ed36da8489053f7f261151843f8a45669"
 dependencies = [
  "hashbag",
  "rustdoc-types",
@@ -3396,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3417,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3428,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -3447,7 +3311,7 @@ dependencies = [
  "hickory-resolver",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -3463,7 +3327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3481,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3508,7 +3372,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3697,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3717,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -3904,7 +3768,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3945,7 +3809,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3993,10 +3857,10 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4080,9 +3944,9 @@ dependencies = [
  "pkcs8",
  "rand",
  "regex",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "rsa",
- "rustls-webpki 0.102.3",
+ "rustls-webpki 0.102.4",
  "scrypt",
  "serde",
  "serde_json",
@@ -4157,9 +4021,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+checksum = "418b8136fec49956eba89be7da2847ec1909df92a9ae4178b5ff0ff092c8d95e"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -4168,14 +4032,14 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+checksum = "1a4812a669da00d17d8266a0439eddcacbc88b17f732f927e52eeb9d196f7fb5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4211,12 +4075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,22 +4100,22 @@ checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -4272,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4288,15 +4146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
+name = "sync_wrapper"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -4374,7 +4227,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4406,16 +4259,6 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -4451,7 +4294,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4465,7 +4308,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4491,7 +4334,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4587,7 +4430,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4610,7 +4453,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4699,7 +4542,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4761,9 +4604,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "universal-hash"
@@ -4793,12 +4636,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.0",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -4810,28 +4653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8-decode"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4915,7 +4746,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -4949,7 +4780,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5259,9 +5090,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -5287,18 +5118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "bpfman",
@@ -5335,30 +5154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5375,35 +5170,14 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
- "synstructure",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -5416,27 +5190,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
+ "syn 2.0.67",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"
 repository = "https://github.com/bpfman/bpfman"
-version = "0.4.1"
+version = "0.4.2"
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -28,8 +28,8 @@ async-trait = { version = "0.1", default-features = false }
 aya = { version = "0.12", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.22.0", default-features = false }
-bpfman = { version = "0.4.1", path = "./bpfman" }
-bpfman-api = { version = "0.4.1", path = "./bpfman-api" }
+bpfman = { version = "0.4.2", path = "./bpfman" }
+bpfman-api = { version = "0.4.2", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
 caps = { version = "0.5.4", default-features = false }
 cargo_metadata = { version = "0.18.0", default-features = false }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,7 +67,7 @@ A release for the bpfman project is comprised of the following major components:
 ### Overview
 
 Each new release of bpfman is defined with a "bundle version" that
-represents the Git tag of a release, such as `v0.4.1`. This contains the
+represents the Git tag of a release, such as `v0.4.2`. This contains the
 components described above
 
 #### Kubernetes API Versions (e.g. v1alpha2, v1beta1)

--- a/bpfman-operator/Makefile
+++ b/bpfman-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.4.1
+VERSION ?= 0.4.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/changelogs/CHANGELOG-v0.4.2.md
+++ b/changelogs/CHANGELOG-v0.4.2.md
@@ -1,0 +1,29 @@
+The v0.4.2 release is a patch release which is mainly cut pull in some OLM bundle
+fixes for the bpfman-operator OLM manifest deployment.
+
+## What's Changed
+* build(deps): bump tokio-util from 0.7.10 to 0.7.11 in the production-dependencies group by @dependabot in https://github.com/bpfman/bpfman/pull/1122
+* docs: cleanup documentation nits for v0.4.1 release by @Billy99 in https://github.com/bpfman/bpfman/pull/1123
+* build(deps): bump golangci/golangci-lint-action from 5 to 6 in the production-dependencies group by @dependabot in https://github.com/bpfman/bpfman/pull/1135
+* build(deps): bump the production-dependencies group with 5 updates by @dependabot in https://github.com/bpfman/bpfman/pull/1136
+* RPM fixes  by @astoycos in https://github.com/bpfman/bpfman/pull/1134
+* build(deps): bump the production-dependencies group with 7 updates by @dependabot in https://github.com/bpfman/bpfman/pull/1144
+* bpfman: don't panic if DatabaseLockError occurred by @ZhangShuaiyi in https://github.com/bpfman/bpfman/pull/1140
+* Make DatabaseConfig max_retries work as defined. by @anfredette in https://github.com/bpfman/bpfman/pull/1147
+* Have systemd-rpm-macros use bpfman service by @danielmellado in https://github.com/bpfman/bpfman/pull/1146
+* docs: update the RPM uninstall process by @Billy99 in https://github.com/bpfman/bpfman/pull/1148
+* build(deps): bump serde from 1.0.202 to 1.0.203 in the production-dependencies group by @dependabot in https://github.com/bpfman/bpfman/pull/1149
+* build(deps): bump tokio from 1.37.0 to 1.38.0 in the production-dependencies group by @dependabot in https://github.com/bpfman/bpfman/pull/1151
+* fix public-api check by @astoycos in https://github.com/bpfman/bpfman/pull/1152
+* build(deps): bump the production-dependencies group with 6 updates by @dependabot in https://github.com/bpfman/bpfman/pull/1153
+* Temporary work-around for multi-program container images by @anfredette in https://github.com/bpfman/bpfman/pull/1155
+* bpfman: add multiarch builds for bpfman binaries by @Billy99 in https://github.com/bpfman/bpfman/pull/1150
+* build(deps): bump the production-dependencies group with 2 updates by @dependabot in https://github.com/bpfman/bpfman/pull/1160
+* build(deps): bump the production-dependencies group with 2 updates by @dependabot in https://github.com/bpfman/bpfman/pull/1159
+* multiarch: Move multiarch building to bpfman-operator repo by @Billy99 in https://github.com/bpfman/bpfman/pull/1158
+* examples: cleanup patch.yaml files by @Billy99 in https://github.com/bpfman/bpfman/pull/1161
+
+## New Contributors
+* @ZhangShuaiyi made their first contribution in https://github.com/bpfman/bpfman/pull/1140
+
+**Full Changelog**: https://github.com/bpfman/bpfman/compare/v0.4.1...v0.4.2

--- a/docs/getting-started/running-release.md
+++ b/docs/getting-started/running-release.md
@@ -7,7 +7,7 @@ releases.
 > **Note:** Instructions for interacting with bpfman change from release to release, so reference
 > release specific documentation. For example:
 >
->    [https://bpfman.io/v0.4.1/getting-started/running-release/](https://bpfman.io/v0.4.1/getting-started/running-release/)
+>    [https://bpfman.io/v0.4.2/getting-started/running-release/](https://bpfman.io/v0.4.2/getting-started/running-release/)
 
 Jump to the [Setup and Building bpfman](./building-bpfman.md) section
 for help building from the latest code or building from a release branch.
@@ -30,7 +30,7 @@ links above for further information on how to test and interact with `bpfman`.
 ## Run as a Long Lived Process
 
 ```console
-export BPFMAN_REL=0.4.1
+export BPFMAN_REL=0.4.2
 mkdir -p $HOME/src/bpfman-${BPFMAN_REL}/; cd $HOME/src/bpfman-${BPFMAN_REL}/
 wget https://github.com/bpfman/bpfman/releases/download/v${BPFMAN_REL}/bpfman-linux-x86_64.tar.gz
 tar -xzvf bpfman-linux-x86_64.tar.gz; rm bpfman-linux-x86_64.tar.gz
@@ -77,7 +77,7 @@ kind create cluster --name=test-bpfman
 Next, deploy the bpfman CRDs:
 
 ```console
-export BPFMAN_REL=0.4.1
+export BPFMAN_REL=0.4.2
 kubectl apply -f  https://github.com/bpfman/bpfman/releases/download/v${BPFMAN_REL}/bpfman-crds-install.yaml
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ sudo dnf info bpfman
 Last metadata expiration check: 0:03:10 ago on Mon 06 May 2024 10:37:37 AM EDT.
 Available Packages
 Name         : bpfman
-Version      : 0.4.1
+Version      : 0.4.2
 Release      : 1.fc39
 Architecture : src
 Size         : 41 M
@@ -45,11 +45,11 @@ License      : Apache-2.0
 Description  : An eBPF Program Manager.
 
 Name         : bpfman
-Version      : 0.4.1
+Version      : 0.4.2
 Release      : 1.fc39
 Architecture : x86_64
 Size         : 9.7 M
-Source       : bpfman-0.4.1-1.fc39.src.rpm
+Source       : bpfman-0.4.2-1.fc39.src.rpm
 Repository   : copr:copr.fedorainfracloud.org:group_ebpf-sig:bpfman
 Summary      : An eBPF program manager
 URL          : https://bpfman.io
@@ -93,7 +93,7 @@ When ready to uninstall, determine the RPM that is currently loaded:
 
 ```console
 $ sudo rpm -qa | grep bpfman
-bpfman-0.4.1-1.fc39.x86_64
+bpfman-0.4.2-1.fc39.x86_64
 ```
 
 To stop bpfman and uninstall the RPM:
@@ -102,7 +102,7 @@ To stop bpfman and uninstall the RPM:
 sudo systemctl stop bpfman.socket
 sudo systemctl disable bpfman.socket
 
-sudo dnf erase -y bpfman-0.4.1-1.fc39.x86_64
+sudo dnf erase -y bpfman-0.4.2-1.fc39.x86_64
 
 sudo systemctl daemon-reload
 ```
@@ -119,7 +119,7 @@ kind create cluster --name=test-bpfman
 Next, deploy the bpfman CRDs:
 
 ```console
-export BPFMAN_REL=0.4.1
+export BPFMAN_REL=0.4.2
 kubectl apply -f  https://github.com/bpfman/bpfman/releases/download/v${BPFMAN_REL}/bpfman-crds-install.yaml
 ```
 

--- a/examples/config/v0.4.2-selinux/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-kprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: KprobeProgram
+      name: go-kprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-kprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-kprobe-counter
+    newName: quay.io/bpfman-userspace/go-kprobe-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-kprobe-counter]

--- a/examples/config/v0.4.2-selinux/go-target/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-target/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-target
+    newName: quay.io/bpfman-userspace/go-target
+    newTag: v0.4.2
+resources: [../../selinux/go-target]

--- a/examples/config/v0.4.2-selinux/go-tc-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-tc-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: TcProgram
+      name: go-tc-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-tc-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-tc-counter
+    newName: quay.io/bpfman-userspace/go-tc-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-tc-counter]

--- a/examples/config/v0.4.2-selinux/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-tracepoint-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: TracepointProgram
+      name: go-tracepoint-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-tracepoint-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-tracepoint-counter
+    newName: quay.io/bpfman-userspace/go-tracepoint-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-tracepoint-counter]

--- a/examples/config/v0.4.2-selinux/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-uprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: UprobeProgram
+      name: go-uprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-uprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-uprobe-counter
+    newName: quay.io/bpfman-userspace/go-uprobe-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-uprobe-counter]

--- a/examples/config/v0.4.2-selinux/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-uretprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: UprobeProgram
+      name: go-uretprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-uretprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-uretprobe-counter
+    newName: quay.io/bpfman-userspace/go-uretprobe-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-uretprobe-counter]

--- a/examples/config/v0.4.2-selinux/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-xdp-counter-sharing-map/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: XdpProgram
+      name: go-xdp-counter-sharing-map-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-xdp-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-xdp-counter
+    newName: quay.io/bpfman-userspace/go-xdp-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-xdp-counter-sharing-map]

--- a/examples/config/v0.4.2-selinux/go-xdp-counter/kustomization.yaml
+++ b/examples/config/v0.4.2-selinux/go-xdp-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: XdpProgram
+      name: go-xdp-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-xdp-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-xdp-counter
+    newName: quay.io/bpfman-userspace/go-xdp-counter
+    newTag: v0.4.2
+resources: [../../selinux/go-xdp-counter]

--- a/examples/config/v0.4.2/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-kprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: KprobeProgram
+      name: go-kprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-kprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-kprobe-counter
+    newName: quay.io/bpfman-userspace/go-kprobe-counter
+    newTag: v0.4.2
+resources: [../../base/go-kprobe-counter]

--- a/examples/config/v0.4.2/go-target/kustomization.yaml
+++ b/examples/config/v0.4.2/go-target/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-target
+    newName: quay.io/bpfman-userspace/go-target
+    newTag: v0.4.2
+resources: [../../base/go-target]

--- a/examples/config/v0.4.2/go-tc-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-tc-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: TcProgram
+      name: go-tc-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-tc-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-tc-counter
+    newName: quay.io/bpfman-userspace/go-tc-counter
+    newTag: v0.4.2
+resources: [../../base/go-tc-counter]

--- a/examples/config/v0.4.2/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-tracepoint-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: TracepointProgram
+      name: go-tracepoint-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-tracepoint-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-tracepoint-counter
+    newName: quay.io/bpfman-userspace/go-tracepoint-counter
+    newTag: v0.4.2
+resources: [../../base/go-tracepoint-counter]

--- a/examples/config/v0.4.2/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-uprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: UprobeProgram
+      name: go-uprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-uprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-uprobe-counter
+    newName: quay.io/bpfman-userspace/go-uprobe-counter
+    newTag: v0.4.2
+resources: [../../base/go-uprobe-counter]

--- a/examples/config/v0.4.2/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-uretprobe-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: UprobeProgram
+      name: go-uretprobe-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-uretprobe-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-uretprobe-counter
+    newName: quay.io/bpfman-userspace/go-uretprobe-counter
+    newTag: v0.4.2
+resources: [../../base/go-uretprobe-counter]

--- a/examples/config/v0.4.2/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/v0.4.2/go-xdp-counter-sharing-map/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: XdpProgram
+      name: go-xdp-counter-sharing-map-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-xdp-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-xdp-counter
+    newName: quay.io/bpfman-userspace/go-xdp-counter
+    newTag: v0.4.2
+resources: [../../base/go-xdp-counter-sharing-map]

--- a/examples/config/v0.4.2/go-xdp-counter/kustomization.yaml
+++ b/examples/config/v0.4.2/go-xdp-counter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Patch the bytecode.yaml to change tag on the "url" field (which is an
+# image) to new value. This actually overwrites the image with the same value.
+patches:
+  - target:
+      kind: XdpProgram
+      name: go-xdp-counter-example
+    patch: |-
+      - op: replace
+        path: "/spec/bytecode/image/url"
+        value: quay.io/bpfman-bytecode/go-xdp-counter:v0.4.2
+# Patch the deployment.yaml to change container image in Daemonset
+# to new tag on the image.
+images:
+  - name: quay.io/bpfman-userspace/go-xdp-counter
+    newName: quay.io/bpfman-userspace/go-xdp-counter
+    newTag: v0.4.2
+resources: [../../base/go-xdp-counter]

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -77,14 +77,12 @@ pub unsafe fn bpfman::errors::BpfmanError::deref<'a>(ptr: usize) -> &'a T
 pub unsafe fn bpfman::errors::BpfmanError::deref_mut<'a>(ptr: usize) -> &'a mut T
 pub unsafe fn bpfman::errors::BpfmanError::drop(ptr: usize)
 pub unsafe fn bpfman::errors::BpfmanError::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
-impl<T> icu_provider::any::MaybeSendSync for bpfman::errors::BpfmanError
 impl<T> snafu::AsErrorSource for bpfman::errors::BpfmanError where T: core::error::Error + 'static
 pub fn bpfman::errors::BpfmanError::as_error_source(&self) -> &(dyn core::error::Error + 'static)
 impl<T> tracing::instrument::Instrument for bpfman::errors::BpfmanError
 impl<T> tracing::instrument::WithSubscriber for bpfman::errors::BpfmanError
 impl<T> typenum::type_operators::Same for bpfman::errors::BpfmanError
 pub type bpfman::errors::BpfmanError::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::errors::BpfmanError where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::errors::BpfmanError where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::errors::BpfmanError::vzip(self) -> V
 pub enum bpfman::errors::ParseError
@@ -143,14 +141,12 @@ pub unsafe fn bpfman::errors::ParseError::deref<'a>(ptr: usize) -> &'a T
 pub unsafe fn bpfman::errors::ParseError::deref_mut<'a>(ptr: usize) -> &'a mut T
 pub unsafe fn bpfman::errors::ParseError::drop(ptr: usize)
 pub unsafe fn bpfman::errors::ParseError::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
-impl<T> icu_provider::any::MaybeSendSync for bpfman::errors::ParseError
 impl<T> snafu::AsErrorSource for bpfman::errors::ParseError where T: core::error::Error + 'static
 pub fn bpfman::errors::ParseError::as_error_source(&self) -> &(dyn core::error::Error + 'static)
 impl<T> tracing::instrument::Instrument for bpfman::errors::ParseError
 impl<T> tracing::instrument::WithSubscriber for bpfman::errors::ParseError
 impl<T> typenum::type_operators::Same for bpfman::errors::ParseError
 pub type bpfman::errors::ParseError::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::errors::ParseError where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::errors::ParseError where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::errors::ParseError::vzip(self) -> V
 pub mod bpfman::types
@@ -223,7 +219,6 @@ pub unsafe fn bpfman::types::Direction::drop(ptr: usize)
 pub unsafe fn bpfman::types::Direction::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::Direction where T: core::clone::Clone
 pub fn bpfman::types::Direction::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::Direction
 impl<T> jwt::FromBase64 for bpfman::types::Direction where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::Direction::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::Direction where T: serde::ser::Serialize
@@ -233,7 +228,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::Direction
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::Direction
 impl<T> typenum::type_operators::Same for bpfman::types::Direction
 pub type bpfman::types::Direction::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::Direction where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Direction where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::Direction::vzip(self) -> V
 pub enum bpfman::types::ImagePullPolicy
@@ -297,7 +291,6 @@ pub unsafe fn bpfman::types::ImagePullPolicy::drop(ptr: usize)
 pub unsafe fn bpfman::types::ImagePullPolicy::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::ImagePullPolicy where T: core::clone::Clone
 pub fn bpfman::types::ImagePullPolicy::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::ImagePullPolicy
 impl<T> jwt::FromBase64 for bpfman::types::ImagePullPolicy where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::ImagePullPolicy::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::ImagePullPolicy where T: serde::ser::Serialize
@@ -307,7 +300,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::ImagePullPolicy
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::ImagePullPolicy
 impl<T> typenum::type_operators::Same for bpfman::types::ImagePullPolicy
 pub type bpfman::types::ImagePullPolicy::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::ImagePullPolicy where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ImagePullPolicy where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::ImagePullPolicy::vzip(self) -> V
 pub enum bpfman::types::Location
@@ -362,7 +354,6 @@ pub unsafe fn bpfman::types::Location::drop(ptr: usize)
 pub unsafe fn bpfman::types::Location::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::Location where T: core::clone::Clone
 pub fn bpfman::types::Location::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::Location
 impl<T> jwt::FromBase64 for bpfman::types::Location where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::Location::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::Location where T: serde::ser::Serialize
@@ -372,7 +363,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::Location
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::Location
 impl<T> typenum::type_operators::Same for bpfman::types::Location
 pub type bpfman::types::Location::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::Location where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Location where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::Location::vzip(self) -> V
 pub enum bpfman::types::ProbeType
@@ -443,7 +433,6 @@ pub unsafe fn bpfman::types::ProbeType::drop(ptr: usize)
 pub unsafe fn bpfman::types::ProbeType::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::ProbeType where T: core::clone::Clone
 pub fn bpfman::types::ProbeType::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::ProbeType
 impl<T> jwt::FromBase64 for bpfman::types::ProbeType where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::ProbeType::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::ProbeType where T: serde::ser::Serialize
@@ -453,7 +442,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::ProbeType
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProbeType
 impl<T> typenum::type_operators::Same for bpfman::types::ProbeType
 pub type bpfman::types::ProbeType::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::ProbeType where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProbeType where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::ProbeType::vzip(self) -> V
 pub enum bpfman::types::Program
@@ -507,12 +495,10 @@ pub unsafe fn bpfman::types::Program::drop(ptr: usize)
 pub unsafe fn bpfman::types::Program::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::Program where T: core::clone::Clone
 pub fn bpfman::types::Program::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::Program
 impl<T> tracing::instrument::Instrument for bpfman::types::Program
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::Program
 impl<T> typenum::type_operators::Same for bpfman::types::Program
 pub type bpfman::types::Program::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::Program where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::Program where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::Program::vzip(self) -> V
 pub enum bpfman::types::ProgramType
@@ -617,7 +603,6 @@ pub unsafe fn bpfman::types::ProgramType::drop(ptr: usize)
 pub unsafe fn bpfman::types::ProgramType::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::ProgramType where T: core::clone::Clone
 pub fn bpfman::types::ProgramType::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::ProgramType
 impl<T> jwt::FromBase64 for bpfman::types::ProgramType where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::ProgramType::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::ProgramType where T: serde::ser::Serialize
@@ -627,7 +612,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::ProgramType
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProgramType
 impl<T> typenum::type_operators::Same for bpfman::types::ProgramType
 pub type bpfman::types::ProgramType::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::ProgramType where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProgramType where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::ProgramType::vzip(self) -> V
 pub enum bpfman::types::TcProceedOnEntry
@@ -700,7 +684,6 @@ pub unsafe fn bpfman::types::TcProceedOnEntry::drop(ptr: usize)
 pub unsafe fn bpfman::types::TcProceedOnEntry::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::TcProceedOnEntry where T: core::clone::Clone
 pub fn bpfman::types::TcProceedOnEntry::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::TcProceedOnEntry
 impl<T> jwt::FromBase64 for bpfman::types::TcProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::TcProceedOnEntry::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::TcProceedOnEntry where T: serde::ser::Serialize
@@ -710,7 +693,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::TcProceedOnEntry
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProceedOnEntry
 impl<T> typenum::type_operators::Same for bpfman::types::TcProceedOnEntry
 pub type bpfman::types::TcProceedOnEntry::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::TcProceedOnEntry where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProceedOnEntry where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::TcProceedOnEntry::vzip(self) -> V
 pub enum bpfman::types::XdpProceedOnEntry
@@ -778,7 +760,6 @@ pub unsafe fn bpfman::types::XdpProceedOnEntry::drop(ptr: usize)
 pub unsafe fn bpfman::types::XdpProceedOnEntry::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::XdpProceedOnEntry where T: core::clone::Clone
 pub fn bpfman::types::XdpProceedOnEntry::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::XdpProceedOnEntry
 impl<T> jwt::FromBase64 for bpfman::types::XdpProceedOnEntry where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::XdpProceedOnEntry::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::XdpProceedOnEntry where T: serde::ser::Serialize
@@ -788,7 +769,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::XdpProceedOnEntry
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProceedOnEntry
 impl<T> typenum::type_operators::Same for bpfman::types::XdpProceedOnEntry
 pub type bpfman::types::XdpProceedOnEntry::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::XdpProceedOnEntry where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProceedOnEntry where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::XdpProceedOnEntry::vzip(self) -> V
 pub struct bpfman::types::BytecodeImage
@@ -845,7 +825,6 @@ pub unsafe fn bpfman::types::BytecodeImage::drop(ptr: usize)
 pub unsafe fn bpfman::types::BytecodeImage::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::BytecodeImage where T: core::clone::Clone
 pub fn bpfman::types::BytecodeImage::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::BytecodeImage
 impl<T> jwt::FromBase64 for bpfman::types::BytecodeImage where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::BytecodeImage::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::BytecodeImage where T: serde::ser::Serialize
@@ -855,7 +834,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::BytecodeImage
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::BytecodeImage
 impl<T> typenum::type_operators::Same for bpfman::types::BytecodeImage
 pub type bpfman::types::BytecodeImage::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::BytecodeImage where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::BytecodeImage where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::BytecodeImage::vzip(self) -> V
 pub struct bpfman::types::FentryProgram
@@ -901,12 +879,10 @@ pub unsafe fn bpfman::types::FentryProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::FentryProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::FentryProgram where T: core::clone::Clone
 pub fn bpfman::types::FentryProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::FentryProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::FentryProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::FentryProgram
 impl<T> typenum::type_operators::Same for bpfman::types::FentryProgram
 pub type bpfman::types::FentryProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::FentryProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::FentryProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::FentryProgram::vzip(self) -> V
 pub struct bpfman::types::FexitProgram
@@ -952,12 +928,10 @@ pub unsafe fn bpfman::types::FexitProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::FexitProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::FexitProgram where T: core::clone::Clone
 pub fn bpfman::types::FexitProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::FexitProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::FexitProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::FexitProgram
 impl<T> typenum::type_operators::Same for bpfman::types::FexitProgram
 pub type bpfman::types::FexitProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::FexitProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::FexitProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::FexitProgram::vzip(self) -> V
 pub struct bpfman::types::KprobeProgram
@@ -1006,12 +980,10 @@ pub unsafe fn bpfman::types::KprobeProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::KprobeProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::KprobeProgram where T: core::clone::Clone
 pub fn bpfman::types::KprobeProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::KprobeProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::KprobeProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::KprobeProgram
 impl<T> typenum::type_operators::Same for bpfman::types::KprobeProgram
 pub type bpfman::types::KprobeProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::KprobeProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::KprobeProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::KprobeProgram::vzip(self) -> V
 pub struct bpfman::types::ListFilter
@@ -1058,12 +1030,10 @@ pub unsafe fn bpfman::types::ListFilter::drop(ptr: usize)
 pub unsafe fn bpfman::types::ListFilter::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::ListFilter where T: core::clone::Clone
 pub fn bpfman::types::ListFilter::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::ListFilter
 impl<T> tracing::instrument::Instrument for bpfman::types::ListFilter
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::ListFilter
 impl<T> typenum::type_operators::Same for bpfman::types::ListFilter
 pub type bpfman::types::ListFilter::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::ListFilter where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ListFilter where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::ListFilter::vzip(self) -> V
 pub struct bpfman::types::ProgramData
@@ -1129,12 +1099,10 @@ pub unsafe fn bpfman::types::ProgramData::drop(ptr: usize)
 pub unsafe fn bpfman::types::ProgramData::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::ProgramData where T: core::clone::Clone
 pub fn bpfman::types::ProgramData::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::ProgramData
 impl<T> tracing::instrument::Instrument for bpfman::types::ProgramData
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::ProgramData
 impl<T> typenum::type_operators::Same for bpfman::types::ProgramData
 pub type bpfman::types::ProgramData::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::ProgramData where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::ProgramData where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::ProgramData::vzip(self) -> V
 pub struct bpfman::types::TcProceedOn(_)
@@ -1197,7 +1165,6 @@ pub unsafe fn bpfman::types::TcProceedOn::drop(ptr: usize)
 pub unsafe fn bpfman::types::TcProceedOn::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::TcProceedOn where T: core::clone::Clone
 pub fn bpfman::types::TcProceedOn::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::TcProceedOn
 impl<T> jwt::FromBase64 for bpfman::types::TcProceedOn where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::TcProceedOn::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::TcProceedOn where T: serde::ser::Serialize
@@ -1207,7 +1174,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::TcProceedOn
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProceedOn
 impl<T> typenum::type_operators::Same for bpfman::types::TcProceedOn
 pub type bpfman::types::TcProceedOn::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::TcProceedOn where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProceedOn where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::TcProceedOn::vzip(self) -> V
 pub struct bpfman::types::TcProgram
@@ -1259,12 +1225,10 @@ pub unsafe fn bpfman::types::TcProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::TcProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::TcProgram where T: core::clone::Clone
 pub fn bpfman::types::TcProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::TcProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::TcProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::TcProgram
 impl<T> typenum::type_operators::Same for bpfman::types::TcProgram
 pub type bpfman::types::TcProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::TcProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TcProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::TcProgram::vzip(self) -> V
 pub struct bpfman::types::TracepointProgram
@@ -1310,12 +1274,10 @@ pub unsafe fn bpfman::types::TracepointProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::TracepointProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::TracepointProgram where T: core::clone::Clone
 pub fn bpfman::types::TracepointProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::TracepointProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::TracepointProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::TracepointProgram
 impl<T> typenum::type_operators::Same for bpfman::types::TracepointProgram
 pub type bpfman::types::TracepointProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::TracepointProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::TracepointProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::TracepointProgram::vzip(self) -> V
 pub struct bpfman::types::UprobeProgram
@@ -1366,12 +1328,10 @@ pub unsafe fn bpfman::types::UprobeProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::UprobeProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::UprobeProgram where T: core::clone::Clone
 pub fn bpfman::types::UprobeProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::UprobeProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::UprobeProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::UprobeProgram
 impl<T> typenum::type_operators::Same for bpfman::types::UprobeProgram
 pub type bpfman::types::UprobeProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::UprobeProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::UprobeProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::UprobeProgram::vzip(self) -> V
 pub struct bpfman::types::XdpProceedOn(_)
@@ -1433,7 +1393,6 @@ pub unsafe fn bpfman::types::XdpProceedOn::drop(ptr: usize)
 pub unsafe fn bpfman::types::XdpProceedOn::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::XdpProceedOn where T: core::clone::Clone
 pub fn bpfman::types::XdpProceedOn::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::XdpProceedOn
 impl<T> jwt::FromBase64 for bpfman::types::XdpProceedOn where T: for<'de> serde::de::Deserialize<'de>
 pub fn bpfman::types::XdpProceedOn::from_base64<Input>(raw: &Input) -> core::result::Result<T, jwt::error::Error> where Input: core::convert::AsRef<[u8]> + core::marker::Sized
 impl<T> jwt::ToBase64 for bpfman::types::XdpProceedOn where T: serde::ser::Serialize
@@ -1443,7 +1402,6 @@ impl<T> tracing::instrument::Instrument for bpfman::types::XdpProceedOn
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProceedOn
 impl<T> typenum::type_operators::Same for bpfman::types::XdpProceedOn
 pub type bpfman::types::XdpProceedOn::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::XdpProceedOn where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProceedOn where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::XdpProceedOn::vzip(self) -> V
 pub struct bpfman::types::XdpProgram
@@ -1494,16 +1452,14 @@ pub unsafe fn bpfman::types::XdpProgram::drop(ptr: usize)
 pub unsafe fn bpfman::types::XdpProgram::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
 impl<T> dyn_clone::DynClone for bpfman::types::XdpProgram where T: core::clone::Clone
 pub fn bpfman::types::XdpProgram::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> icu_provider::any::MaybeSendSync for bpfman::types::XdpProgram
 impl<T> tracing::instrument::Instrument for bpfman::types::XdpProgram
 impl<T> tracing::instrument::WithSubscriber for bpfman::types::XdpProgram
 impl<T> typenum::type_operators::Same for bpfman::types::XdpProgram
 pub type bpfman::types::XdpProgram::Output = T
-impl<T> yoke::erased::ErasedDestructor for bpfman::types::XdpProgram where T: 'static
 impl<V, T> ppv_lite86::types::VZip<V> for bpfman::types::XdpProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bpfman::types::XdpProgram::vzip(self) -> V
 pub mod bpfman::utils
-pub const bpfman::utils::SOCK_MODE: u32 = 432u32
+pub const bpfman::utils::SOCK_MODE: u32
 pub fn bpfman::utils::create_bpffs(directory: &str) -> anyhow::Result<()>
 pub fn bpfman::utils::set_dir_permissions(directory: &str, mode: u32)
 pub fn bpfman::utils::set_file_permissions(path: &std::path::Path, mode: u32)


### PR DESCRIPTION
Cut a patch release to pull in some operator-olm
fixes (not shown here), prior to merging the bpf-application changes which will require a 0.5.0 release