### PR TITLE
examples: Add patch.yaml file back

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,6 +6,3 @@ bin
 **/bpf_bpf*.o
 **/bpf_*_bpf*.go
 **/bpf_*_bpf*.o
-
-# Temporary patch files, generated from patch.yaml.env files using sed in Makefile
-**/patch.yaml

--- a/examples/config/default/go-kprobe-counter/patch.yaml
+++ b/examples/config/default/go-kprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-kprobe-counter:latest

--- a/examples/config/default/go-tc-counter/patch.yaml
+++ b/examples/config/default/go-tc-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/default/go-tracepoint-counter/patch.yaml
+++ b/examples/config/default/go-tracepoint-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-tracepoint-counter:latest

--- a/examples/config/default/go-uprobe-counter/patch.yaml
+++ b/examples/config/default/go-uprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-uprobe-counter:latest

--- a/examples/config/default/go-uretprobe-counter/patch.yaml
+++ b/examples/config/default/go-uretprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-uretprobe-counter:latest

--- a/examples/config/default/go-xdp-counter-sharing-map/patch.yaml
+++ b/examples/config/default/go-xdp-counter-sharing-map/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/default/go-xdp-counter/patch.yaml
+++ b/examples/config/default/go-xdp-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/selinux/go-kprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-kprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-kprobe-counter:latest

--- a/examples/config/selinux/go-tc-counter/patch.yaml
+++ b/examples/config/selinux/go-tc-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-tc-counter:latest

--- a/examples/config/selinux/go-tracepoint-counter/patch.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-tracepoint-counter:latest

--- a/examples/config/selinux/go-uprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-uprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-uprobe-counter:latest

--- a/examples/config/selinux/go-uretprobe-counter/patch.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-uretprobe-counter:latest

--- a/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-xdp-counter:latest

--- a/examples/config/selinux/go-xdp-counter/patch.yaml
+++ b/examples/config/selinux/go-xdp-counter/patch.yaml
@@ -1,0 +1,6 @@
+---
+# Patch the bytecode.yaml to change image and tag on the "url" field
+# (which is an image) to new value.
+- op: replace
+  path: /spec/bytecode/image/url
+  value: quay.io/bpfman-bytecode/go-xdp-counter:latest


### PR DESCRIPTION
The patch.yaml files were removed from the examples/config directory in PR#1161. They were removed because they are generated by the Makefile. However, bpfman-operator/tests/integration calls Kustomize directly and is not going through the Makefile. So add them back.