### PR TITLE
rename application counter bin/ds/namespace to app

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -138,7 +138,7 @@ jobs:
             repository: bpfman-userspace
             image: go-app-counter
             context: .
-            dockerfile: ./examples/go-app-counter/container-deployment/Containerfile.go-application-counter
+            dockerfile: ./examples/go-app-counter/container-deployment/Containerfile.go-app-counter
             tags: |
               type=ref,event=branch
               type=ref,event=tag

--- a/docs/getting-started/example-bpf.md
+++ b/docs/getting-started/example-bpf.md
@@ -195,7 +195,7 @@ Pre-built eBPF container images for the examples can be loaded from:
 - `quay.io/bpfman-bytecode/go-uprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-uretprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-xdp-counter:latest`
-- `quay.io/bpfman-bytecode/go-application-counter:latest`
+- `quay.io/bpfman-bytecode/go-app-counter:latest`
 
 To build the example eBPF bytecode container images, run the build commands below (the `go generate`
 requires the [Prerequisites](#prerequisites) described above):

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -24,6 +24,7 @@
 ##     quay.io/bpfman-userspace/go-tracepoint-counter:v0.1.0
 ##     quay.io/bpfman-bytecode/go-xdp-counter:v0.1.0
 ##     quay.io/bpfman-userspace/go-xdp-counter:v0.1.0
+##     quay.io/bpfman-userspace/go-app-counter:v0.1.0
 ##
 
 .DEFAULT_GOAL := help
@@ -121,7 +122,7 @@ build-us-images: build ## Build all example userspace images
 	docker buildx build -t ${IMAGE_UP_US} --platform ${PLATFORM} --load -f ./go-uprobe-counter/container-deployment/Containerfile.go-uprobe-counter ../
 	docker buildx build -t ${IMAGE_URP_US} --platform ${PLATFORM} --load -f ./go-uretprobe-counter/container-deployment/Containerfile.go-uretprobe-counter ../
 	docker buildx build -t ${IMAGE_GT_US} --platform ${PLATFORM} --load -f ./go-target/container-deployment/Containerfile.go-target ../
-	docker buildx build -t ${IMAGE_GT_US} --platform ${PLATFORM} --load  -f ./go-app-counter/container-deployment/Containerfile.go-application-counter ../
+	docker buildx build -t ${IMAGE_APP_US} --platform ${PLATFORM} --load  -f ./go-app-counter/container-deployment/Containerfile.go-app-counter ../
 
 .PHONY: build-bc-images
 build-bc-images: generate ## Build bytecode example userspace images
@@ -169,8 +170,8 @@ IMAGE_UP_BC: ## Uprobe Bytecode image. Example: make deploy-uprobe IMAGE_UP_BC=q
 IMAGE_UP_US: ## Uprobe Userspace image. Example: make deploy-uprobe IMAGE_UP_US=quay.io/user1/go-uprobe-counter-userspace:test
 IMAGE_URP_BC: ## URetprobe Userspace image. Example: make deploy-uretprobe IMAGE_URP_BC=quay.io/user1/go-uretprobe-counter-bytecode:test
 IMAGE_URP_US: ## URetprobe Userspace image. Example: make deploy-uretprobe IMAGE_URP_US=quay.io/user1/go-uretprobe-counter-userspace:test
-IMAGE_APP_BC: ## Application Userspace image. Example: make deploy-application IMAGE_URP_BC=quay.io/user1/go-application-counter-bytecode:test
-IMAGE_APP_US: ## Application Userspace image. Example: make deploy-application IMAGE_URP_US=quay.io/user1/go-application-counter-userspace:test
+IMAGE_APP_BC: ## Application Userspace image. Example: make deploy-app IMAGE_URP_BC=quay.io/user1/go-app-counter-bytecode:test
+IMAGE_APP_US: ## Application Userspace image. Example: make deploy-app IMAGE_URP_US=quay.io/user1/go-app-counter-userspace:test
 IMAGE_GT_US: ## Uprobe Userspace target. Example: make deploy-target IMAGE_GT_US=quay.io/user1/go-target-userspace:test
 KIND_CLUSTER_NAME: ## Name of the deployed cluster to load example images to, defaults to `bpfman-deployment`
 ignore-not-found: ## For any undeploy command, set to true to ignore resource not found errors during deletion. Example: make undeploy ignore-not-found=true
@@ -188,8 +189,8 @@ IMAGE_UP_BC ?= quay.io/bpfman-bytecode/go-uprobe-counter:latest
 IMAGE_UP_US ?= quay.io/bpfman-userspace/go-uprobe-counter:latest
 IMAGE_URP_BC ?= quay.io/bpfman-bytecode/go-uretprobe-counter:latest
 IMAGE_URP_US ?= quay.io/bpfman-userspace/go-uretprobe-counter:latest
-IMAGE_APP_BC ?= quay.io/bpfman-bytecode/go-application-counter:latest
-IMAGE_APP_US ?= quay.io/bpfman-userspace/go-application-counter:latest
+IMAGE_APP_BC ?= quay.io/bpfman-bytecode/go-app-counter:latest
+IMAGE_APP_US ?= quay.io/bpfman-userspace/go-app-counter:latest
 IMAGE_GT_US ?= quay.io/bpfman-userspace/go-target:latest
 KIND_CLUSTER_NAME ?= bpfman-deployment
 
@@ -332,19 +333,19 @@ undeploy-uretprobe: IMAGE_BC=$(IMAGE_URP_BC)
 undeploy-uretprobe: IMAGE_US=$(IMAGE_URP_US)
 undeploy-uretprobe: undeploy-prog ## Undeploy go-uretprobe-counter from the cluster specified in ~/.kube/config.
 
-.PHONY: deploy-application
-deploy-application: PROG_NAME=go-application-counter
-deploy-application: CONFIG_DIR=default/go-app-counter
-deploy-application: IMAGE_BC=$(IMAGE_APP_BC)
-deploy-application: IMAGE_US=$(IMAGE_APP_US)
-deploy-application: deploy-prog ## Deploy go-application-counter to the cluster specified in ~/.kube/config.
+.PHONY: deploy-app
+deploy-app: PROG_NAME=go-app-counter
+deploy-app: CONFIG_DIR=default/go-app-counter
+deploy-app: IMAGE_BC=$(IMAGE_APP_BC)
+deploy-app: IMAGE_US=$(IMAGE_APP_US)
+deploy-app: deploy-prog ## Deploy go-app-counter to the cluster specified in ~/.kube/config.
 
-.PHONY: undeploy-application
-undeploy-application: PROG_NAME=go-application-counter
-undeploy-application: CONFIG_DIR=default/go-app-counter
-undeploy-application: IMAGE_BC=$(IMAGE_APP_BC)
-undeploy-application: IMAGE_US=$(IMAGE_APP_US)
-undeploy-application: undeploy-prog ## Undeploy go-application-counter from the cluster specified in ~/.kube/config.
+.PHONY: undeploy-app
+undeploy-app: PROG_NAME=go-app-counter
+undeploy-app: CONFIG_DIR=default/go-app-counter
+undeploy-app: IMAGE_BC=$(IMAGE_APP_BC)
+undeploy-app: IMAGE_US=$(IMAGE_APP_US)
+undeploy-app: undeploy-prog ## Undeploy go-app-counter from the cluster specified in ~/.kube/config.
 
 .PHONY: deploy-tc-selinux
 deploy-tc-selinux: PROG_NAME=go-tc-counter
@@ -449,19 +450,19 @@ undeploy-uretprobe-selinux: IMAGE_BC=$(IMAGE_URP_BC)
 undeploy-uretprobe-selinux: IMAGE_US=$(IMAGE_URP_US)
 undeploy-uretprobe-selinux: undeploy-prog ## Undeploy go-uretprobe-counter from the cluster specified in ~/.kube/config.
 
-.PHONY: deploy-application-selinux
-deploy-application-selinux: PROG_NAME=go-application-counter
-deploy-application-selinux: CONFIG_DIR=selinux/go-app-counter
-deploy-application-selinux: IMAGE_BC=$(IMAGE_APP_BC)
-deploy-application-selinux: IMAGE_US=$(IMAGE_APP_US)
-deploy-application-selinux: deploy-prog ## Deploy go-application-counter to the cluster specified in ~/.kube/config.
+.PHONY: deploy-app-selinux
+deploy-app-selinux: PROG_NAME=go-app-counter
+deploy-app-selinux: CONFIG_DIR=selinux/go-app-counter
+deploy-app-selinux: IMAGE_BC=$(IMAGE_APP_BC)
+deploy-app-selinux: IMAGE_US=$(IMAGE_APP_US)
+deploy-app-selinux: deploy-prog ## Deploy go-app-counter to the cluster specified in ~/.kube/config.
 
-.PHONY: undeploy-application-selinux
-undeploy-application-selinux: PROG_NAME=go-application-counter
-undeploy-application-selinux: CONFIG_DIR=selinux/go-app-counter
-undeploy-application-selinux: IMAGE_BC=$(IMAGE_APP_BC)
-undeploy-application-selinux: IMAGE_US=$(IMAGE_APP_US)
-undeploy-application-selinux: undeploy-prog ## Undeploy go-application-counter from the cluster specified in ~/.kube/config.
+.PHONY: undeploy-app-selinux
+undeploy-app-selinux: PROG_NAME=go-app-counter
+undeploy-app-selinux: CONFIG_DIR=selinux/go-app-counter
+undeploy-app-selinux: IMAGE_BC=$(IMAGE_APP_BC)
+undeploy-app-selinux: IMAGE_US=$(IMAGE_APP_US)
+undeploy-app-selinux: undeploy-prog ## Undeploy go-app-counter from the cluster specified in ~/.kube/config.
 
 .PHONY: deploy-target
 deploy-target: ## Deploy go-target to the cluster specified in ~/.kube/config.
@@ -471,7 +472,7 @@ deploy-target: ## Deploy go-target to the cluster specified in ~/.kube/config.
 undeploy-target: ## Undeploy go-target from the cluster specified in ~/.kube/config.
 	kubectl delete -f config/base/go-target/deployment.yaml
 
-DEPLOY_TARGETS = deploy-tc deploy-tracepoint deploy-xdp deploy-xdp-ms deploy-kprobe deploy-target deploy-uprobe deploy-uretprobe deploy-application
+DEPLOY_TARGETS = deploy-tc deploy-tracepoint deploy-xdp deploy-xdp-ms deploy-kprobe deploy-target deploy-uprobe deploy-uretprobe deploy-app
 
 .PHONY: deploy
 deploy: ## Deploy all examples to the cluster specified in ~/.kube/config.
@@ -482,7 +483,7 @@ endif
 		$(MAKE) $$target $(TAG_COMMAND) || true; \
 	done
 
-UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp-ms undeploy-xdp undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target undeploy-application
+UNDEPLOY_TARGETS = undeploy-tc undeploy-tracepoint undeploy-xdp-ms undeploy-xdp undeploy-kprobe undeploy-uprobe undeploy-uretprobe undeploy-target undeploy-app
 
 .PHONY: undeploy
 undeploy: ## Undeploy all examples to the cluster specified in ~/.kube/config.

--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -10,7 +10,7 @@ spec:
   nodeselector: {}
   bytecode:
     image:
-      url: quay.io/bpfman-bytecode/go-application-counter:latest
+      url: quay.io/bpfman-bytecode/go-app-counter:latest
       imagepullpolicy: Always
   programs:
     - type: Kprobe

--- a/examples/config/base/go-app-counter/deployment.yaml
+++ b/examples/config/base/go-app-counter/deployment.yaml
@@ -2,33 +2,33 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: go-application-counter
+  name: go-app-counter
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: bpfman-app-go-application-counter
-  namespace: go-application-counter
+  name: bpfman-app-go-app-counter
+  namespace: go-app-counter
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: go-application-counter-ds
-  namespace: go-application-counter
+  name: go-app-counter-ds
+  namespace: go-app-counter
   labels:
-    k8s-app: go-application-counter
+    k8s-app: go-app-counter
 spec:
   selector:
     matchLabels:
-      name: go-application-counter
+      name: go-app-counter
   template:
     metadata:
       labels:
-        name: go-application-counter
+        name: go-app-counter
     spec:
       nodeSelector: {}
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccountName: bpfman-app-go-application-counter
+      serviceAccountName: bpfman-app-go-app-counter
       securityContext:
         runAsNonRoot: true
         fsGroup: 65534
@@ -42,8 +42,8 @@ spec:
           operator: Exists
           effect: NoSchedule
       containers:
-        - name: go-application-counter
-          image: quay.io/bpfman-userspace/go-application-counter:latest
+        - name: go-app-counter
+          image: quay.io/bpfman-userspace/go-app-counter:latest
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -57,11 +57,11 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: go-application-counter-maps
-              mountPath: /run/application/maps
+            - name: go-app-counter-maps
+              mountPath: /run/app/maps
               readOnly: true
       volumes:
-        - name: go-application-counter-maps
+        - name: go-app-counter-maps
           csi:
             driver: csi.bpfman.io
             volumeAttributes:

--- a/examples/config/default/go-app-counter/kustomization.yaml
+++ b/examples/config/default/go-app-counter/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 # Patch the deployment.yaml to change container image in Daemonset
 # to new tag on the image.
 images:
-- name: quay.io/bpfman-userspace/go-application-counter
-  newName: quay.io/bpfman-userspace/go-application-counter
+- name: quay.io/bpfman-userspace/go-app-counter
+  newName: quay.io/bpfman-userspace/go-app-counter
   newTag: latest
 # Patch the bytecode.yaml to change tag on the "url" field (which is an
 # image) to new value. Since this is being done with an environment
@@ -14,6 +14,6 @@ patches:
 - path: patch.yaml
   target:
     kind: BpfApplication
-    name: go-application-counter-example
+    name: go-app-counter-example
 resources:
 - ../../base/go-app-counter

--- a/examples/config/default/go-app-counter/patch.yaml
+++ b/examples/config/default/go-app-counter/patch.yaml
@@ -3,4 +3,4 @@
 # (which is an image) to new value.
 - op: replace
   path: /spec/bytecode/image/url
-  value: quay.io/bpfman-bytecode/go-application-counter:latest
+  value: quay.io/bpfman-bytecode/go-app-counter:latest

--- a/examples/go-app-counter/container-deployment/Containerfile.go-app-counter
+++ b/examples/go-app-counter/container-deployment/Containerfile.go-app-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-application-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 as go-app-counter-build
 
 ARG BUILDPLATFORM
 
@@ -17,7 +17,7 @@ COPY ./ /usr/src/bpfman/
 
 WORKDIR /usr/src/bpfman/examples/go-app-counter
 
-# Compile go-application-counter
+# Compile go-app-counter
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build
 
 
@@ -25,6 +25,6 @@ FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora-minimal:latest
 
 ARG TARGETPLATFORM
 
-COPY --from=go-application-counter-build  /usr/src/bpfman/examples/go-app-counter/go-app-counter .
+COPY --from=go-app-counter-build  /usr/src/bpfman/examples/go-app-counter/go-app-counter .
 
 ENTRYPOINT ["./go-app-counter", "--crd"]

--- a/examples/go-app-counter/main.go
+++ b/examples/go-app-counter/main.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	DefaultByteCodeFile       = "bpf_bpfel.o"
-	ApplicationMapsMountPoint = "/run/application/maps"
+	ApplicationMapsMountPoint = "/run/app/maps"
 )
 
 var appMutex = &sync.Mutex{}

--- a/examples/pkg/config-mgmt/param.go
+++ b/examples/pkg/config-mgmt/param.go
@@ -50,7 +50,7 @@ const (
 )
 
 func (s ProgType) String() string {
-	return [...]string{"xdp", "tc", "tracepoint", "kprobe", "uprobe", "application"}[s]
+	return [...]string{"xdp", "tc", "tracepoint", "kprobe", "uprobe", "app"}[s]
 }
 
 const (


### PR DESCRIPTION
```sh
oc get pods -n go-app-counter
NAME                      READY   STATUS    RESTARTS   AGE
go-app-counter-ds-cv5wc   1/1     Running   0          35s


oc describe pods -n go-app-counter
Name:             go-app-counter-ds-cv5wc
Namespace:        go-app-counter
Priority:         0
Service Account:  bpfman-app-go-app-counter
Node:             bpfman-deployment-control-plane/172.18.0.2
Start Time:       Mon, 01 Jul 2024 15:06:11 -0400
Labels:           controller-revision-hash=6c8785d589
                  name=go-app-counter
                  pod-template-generation=1
Annotations:      <none>
Status:           Running
IP:               10.244.0.6
IPs:
  IP:           10.244.0.6
Controlled By:  DaemonSet/go-app-counter-ds
Containers:
  go-app-counter:
    Container ID:   containerd://b9a608b9d05e98ba47b99dad50ed201422ea81ba79a4bb5e0502ee82c10245ec
    Image:          quay.io/bpfman-userspace/go-app-counter:latest
    Image ID:       quay.io/bpfman-userspace/go-app-counter@sha256:341614fa1da204747aacac4c0347c5e5f5083ba23cbb6e3b7fc9d2d41bf2c3c2
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Mon, 01 Jul 2024 15:06:34 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      NODENAME:   (v1:spec.nodeName)
    Mounts:
      /run/app/maps from go-app-counter-maps (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-knhx4 (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  go-app-counter-maps:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.bpfman.io
    FSType:            
    ReadOnly:          false
    VolumeAttributes:      csi.bpfman.io/maps=kprobe_stats_map,tracepoint_stats_map,tc_stats_map,uprobe_stats_map,xdp_stats_map
                           csi.bpfman.io/program=app-counter
  kube-api-access-knhx4:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node-role.kubernetes.io/control-plane:NoSchedule op=Exists
                             node-role.kubernetes.io/master:NoSchedule op=Exists
                             node.kubernetes.io/disk-pressure:NoSchedule op=Exists
                             node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists
                             node.kubernetes.io/pid-pressure:NoSchedule op=Exists
                             node.kubernetes.io/unreachable:NoExecute op=Exists
                             node.kubernetes.io/unschedulable:NoSchedule op=Exists
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  2m26s  default-scheduler  Successfully assigned go-app-counter/go-app-counter-ds-cv5wc to bpfman-deployment-control-plane
  Normal  Pulling    2m6s   kubelet            Pulling image "quay.io/bpfman-userspace/go-app-counter:latest"
  Normal  Pulled     2m3s   kubelet            Successfully pulled image "quay.io/bpfman-userspace/go-app-counter:latest" in 3.175250774s (3.175258771s including waiting)
  Normal  Created    2m3s   kubelet            Created container go-app-counter
  Normal  Started    2m3s   kubelet            Started container go-app-counter


```