### PR TITLE
only push dispatcher tag when building from main

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -561,8 +561,11 @@ jobs:
             context: .
             dockerfile: ./Containerfile.xdp_dispatcher_v1
             tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
               type=sha,format=long
-              type=raw,value=v1,enable=true
+              type=raw,value=v1,enable={{is_default_branch}}
 
           - registry: quay.io
             build_language: rust
@@ -572,8 +575,11 @@ jobs:
             context: .
             dockerfile: ./Containerfile.xdp_dispatcher_v2
             tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
               type=sha,format=long
-              type=raw,value=v2,enable=true
+              type=raw,value=v2,enable={{is_default_branch}}
 
           - registry: quay.io
             build_language: rust
@@ -583,8 +589,11 @@ jobs:
             context: .
             dockerfile: ./Containerfile.tc_dispatcher
             tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
               type=sha,format=long
-              type=raw,value=v1,enable=true
+              type=raw,value=v1,enable={{is_default_branch}}
 
     name: Build eBPF Image (${{ matrix.image.image }})
     steps:


### PR DESCRIPTION
Before this was always building/pushing the dispatcher image tags regardless of the branch. This change makes sure we only update the main tags when building from main.