### PR TITLE
bpfman/lib: add function documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,12 @@ jobs:
         if: ${{ matrix.arch.arch == 'amd64' }}
         run: cargo xtask public-api --target ${{ matrix.arch.rust-target }}
 
+      - name: Run documentation tests
+        # Only need to run once
+        if: ${{ matrix.arch.arch == 'amd64' }}
+        run: |
+          cargo test --doc --all-features
+
       - name: Build
         run: |
           ${{ matrix.arch.command }} build --verbose --target ${{ matrix.arch.rust-target }}

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -298,6 +298,50 @@ pub struct ProgramData {
 }
 
 impl ProgramData {
+    /// Creates a new `ProgramData` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `location` - The location of the BPF program (file or image).
+    /// * `name` - The name of the BPF program.
+    /// * `metadata` - Metadata associated with the BPF program.
+    /// * `global_data` - Global data required by the BPF program.
+    /// * `map_owner_id` - Optional owner ID of the map.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Self, BpfmanError>` - An instance of `ProgramData` or a `BpfmanError`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The temporary database cannot be opened.
+    /// - The program database tree cannot be opened.
+    /// - Any of the subsequent setting operations fail (ID, location, name, metadata, global data, map owner ID).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bpfman::types::{Location, ProgramData};
+    /// use bpfman::errors::BpfmanError;
+    /// use std::collections::HashMap;
+    ///
+    /// fn main() -> Result<(), BpfmanError> {
+    ///     let location = Location::File(String::from("kprobe.o"));
+    ///     let metadata = HashMap::new();
+    ///     let global_data = HashMap::new();
+    ///     let map_owner_id = None;
+    ///     let program_data = ProgramData::new(
+    ///         location,
+    ///         String::from("kprobe_do_sys_open"),
+    ///         metadata,
+    ///         global_data,
+    ///         map_owner_id
+    ///     )?;
+    ///     println!("program_data: {:?}", program_data);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn new(
         location: Location,
         name: String,
@@ -398,6 +442,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the kind of program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Option<ProgramType>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kind from the database.
     pub fn get_kind(&self) -> Result<Option<ProgramType>, BpfmanError> {
         sled_get_option(&self.db_tree, KIND).map(|v| v.map(|v| bytes_to_u32(v).try_into().unwrap()))
     }
@@ -406,6 +460,16 @@ impl ProgramData {
         sled_insert(&self.db_tree, NAME, name.as_bytes())
     }
 
+    /// Retrieves the name of the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<String, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the name from the database.
     pub fn get_name(&self) -> Result<String, BpfmanError> {
         sled_get(&self.db_tree, NAME).map(|v| bytes_to_string(&v))
     }
@@ -414,6 +478,16 @@ impl ProgramData {
         sled_insert(&self.db_tree, ID, &id.to_ne_bytes())
     }
 
+    /// Retrieves the ID of the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the ID from the database.
     pub fn get_id(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, ID).map(bytes_to_u32)
     }
@@ -449,6 +523,16 @@ impl ProgramData {
         })
     }
 
+    /// Retrieves the location of the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Location, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the location from the database.
     pub fn get_location(&self) -> Result<Location, BpfmanError> {
         if let Ok(l) = sled_get(&self.db_tree, LOCATION_FILENAME) {
             Ok(Location::File(bytes_to_string(&l).to_string()))
@@ -484,6 +568,16 @@ impl ProgramData {
         })
     }
 
+    /// Retrieves the global data of the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<HashMap<String, Vec<u8>>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the global data from the database.
     pub fn get_global_data(&self) -> Result<HashMap<String, Vec<u8>>, BpfmanError> {
         self.db_tree
             .scan_prefix(PREFIX_GLOBAL_DATA)
@@ -522,6 +616,16 @@ impl ProgramData {
         })
     }
 
+    /// Retrieves the metadata of the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<HashMap<String, String>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the metadata from the database.
     pub fn get_metadata(&self) -> Result<HashMap<String, String>, BpfmanError> {
         self.db_tree
             .scan_prefix(PREFIX_METADATA)
@@ -548,6 +652,16 @@ impl ProgramData {
         sled_insert(&self.db_tree, MAP_OWNER_ID, &id.to_ne_bytes())
     }
 
+    /// Retrieves the owner ID of the map.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Option<u32>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the map owner ID from the database.
     pub fn get_map_owner_id(&self) -> Result<Option<u32>, BpfmanError> {
         sled_get_option(&self.db_tree, MAP_OWNER_ID).map(|v| v.map(bytes_to_u32))
     }
@@ -560,6 +674,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the map pin path.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Option<PathBuf>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the map pin path from the database.
     pub fn get_map_pin_path(&self) -> Result<Option<PathBuf>, BpfmanError> {
         sled_get_option(&self.db_tree, MAP_PIN_PATH)
             .map(|v| v.map(|f| PathBuf::from(bytes_to_string(&f))))
@@ -578,6 +702,16 @@ impl ProgramData {
         })
     }
 
+    /// Retrieves the IDs of maps used by the program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Vec<u32>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the maps used by from the database.
     pub fn get_maps_used_by(&self) -> Result<Vec<u32>, BpfmanError> {
         self.db_tree
             .scan_prefix(PREFIX_MAPS_USED_BY)
@@ -651,6 +785,16 @@ impl ProgramData {
      * Methods for setting and getting kernel information.
      */
 
+    /// Retrieves the name of the kernel.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<String, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel name from the database.
     pub fn get_kernel_name(&self) -> Result<String, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_NAME).map(|n| bytes_to_string(&n))
     }
@@ -659,6 +803,16 @@ impl ProgramData {
         sled_insert(&self.db_tree, KERNEL_NAME, name.as_bytes())
     }
 
+    /// Retrieves the kernel program type.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel program type from the database.
     pub fn get_kernel_program_type(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_PROGRAM_TYPE).map(bytes_to_u32)
     }
@@ -671,6 +825,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the kernel loaded timestamp.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<String, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel loaded timestamp from the database.
     pub fn get_kernel_loaded_at(&self) -> Result<String, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_LOADED_AT).map(|n| bytes_to_string(&n))
     }
@@ -689,6 +853,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the kernel tag.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<String, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel tag from the database.
     pub fn get_kernel_tag(&self) -> Result<String, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_TAG).map(|n| bytes_to_string(&n))
     }
@@ -712,10 +886,30 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves whether the kernel is GPL compatible.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<bool, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel GPL compatibility status from the database.
     pub fn get_kernel_gpl_compatible(&self) -> Result<bool, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_GPL_COMPATIBLE).map(bytes_to_bool)
     }
 
+    /// Retrieves the IDs of kernel maps.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<Vec<u32>, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel map IDs from the database.
     pub fn get_kernel_map_ids(&self) -> Result<Vec<u32>, BpfmanError> {
         self.db_tree
             .scan_prefix(PREFIX_KERNEL_MAP_IDS.as_bytes())
@@ -740,6 +934,16 @@ impl ProgramData {
         })
     }
 
+    /// Retrieves the BTF ID of the kernel.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel BTF ID from the database.
     pub fn get_kernel_btf_id(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_BTF_ID).map(bytes_to_u32)
     }
@@ -748,6 +952,16 @@ impl ProgramData {
         sled_insert(&self.db_tree, KERNEL_BTF_ID, &btf_id.to_ne_bytes())
     }
 
+    /// Retrieves the translated bytes of the kernel program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel translated bytes from the database.
     pub fn get_kernel_bytes_xlated(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_BYTES_XLATED).map(bytes_to_u32)
     }
@@ -760,6 +974,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves whether the kernel program is JIT compiled.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<bool, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel JIT status from the database.
     pub fn get_kernel_jited(&self) -> Result<bool, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_JITED).map(bytes_to_bool)
     }
@@ -772,6 +996,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the JIT compiled bytes of the kernel program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel JIT compiled bytes from the database.
     pub fn get_kernel_bytes_jited(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_BYTES_JITED).map(bytes_to_u32)
     }
@@ -784,6 +1018,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the memory lock bytes of the kernel program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel memory lock bytes from the database.
     pub fn get_kernel_bytes_memlock(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_BYTES_MEMLOCK).map(bytes_to_u32)
     }
@@ -799,6 +1043,16 @@ impl ProgramData {
         )
     }
 
+    /// Retrieves the number of verified instructions of the kernel program.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Result<u32, BpfmanError>`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - There is an issue fetching the kernel verified instructions count from the database.
     pub fn get_kernel_verified_insns(&self) -> Result<u32, BpfmanError> {
         sled_get(&self.db_tree, KERNEL_VERIFIED_INSNS).map(bytes_to_u32)
     }

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -201,15 +201,64 @@ impl ListFilter {
     }
 }
 
+/// `Program` represents various types of eBPF programs that are
+/// supported by bpfman.
 #[derive(Debug, Clone)]
 pub enum Program {
+    /// An XDP (Express Data Path) program.
+    ///
+    /// XDP programs are attached to network interfaces and can
+    /// process packets at a very early stage in the network stack,
+    /// providing high-performance packet processing.
     Xdp(XdpProgram),
+
+    /// A TC (Traffic Control) program.
+    ///
+    /// TC programs are used for controlling network traffic. They can
+    /// be attached to various hooks in the Linux Traffic Control (tc)
+    /// subsystem.
     Tc(TcProgram),
+
+    /// A Tracepoint program.
+    ///
+    /// Tracepoint programs are used for tracing specific events in
+    /// the kernel, providing insights into kernel behaviour and
+    /// performance.
     Tracepoint(TracepointProgram),
+
+    /// A Kprobe (Kernel Probe) program.
+    ///
+    /// Kprobe programs are used to dynamically trace and instrument
+    /// kernel functions. They can be attached to almost any function
+    /// in the kernel.
     Kprobe(KprobeProgram),
+
+    /// A Uprobe (User-space Probe) program.
+    ///
+    /// Uprobe programs are similar to Kprobe programs but are used to
+    /// trace user-space applications. They can be attached to
+    /// functions in user-space binaries.
     Uprobe(UprobeProgram),
+
+    /// An Fentry (Function Entry) program.
+    ///
+    /// Fentry programs are a type of BPF program that are attached to
+    /// the entry points of functions, providing a mechanism to trace
+    /// and instrument the beginning of function execution.
     Fentry(FentryProgram),
+
+    /// An Fexit (Function Exit) program.
+    ///
+    /// Fexit programs are a type of BPF program that are attached to
+    /// the exit points of functions, providing a mechanism to trace
+    /// and instrument the end of function execution.
     Fexit(FexitProgram),
+
+    /// An unsupported BPF program type.
+    ///
+    /// This variant is used to represent BPF programs that are not
+    /// supported by bpfman. It contains the raw `ProgramData` for the
+    /// unsupported program.
     Unsupported(ProgramData),
 }
 
@@ -442,7 +491,8 @@ impl ProgramData {
         )
     }
 
-    /// Retrieves the kind of program.
+    /// Retrieves the kind of program, which is represented by the
+    /// [`ProgramType`] structure.
     ///
     /// # Returns
     ///
@@ -478,7 +528,7 @@ impl ProgramData {
         sled_insert(&self.db_tree, ID, &id.to_ne_bytes())
     }
 
-    /// Retrieves the ID of the program.
+    /// Retrieves the kernel ID of the program.
     ///
     /// # Returns
     ///
@@ -785,7 +835,7 @@ impl ProgramData {
      * Methods for setting and getting kernel information.
      */
 
-    /// Retrieves the name of the kernel.
+    /// Retrieves the name of the program.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
This pull request documents several functions in the bpfman crate, with examples marked with `rust,no_run` to ensure proper compilation without execution.

Fixes: https://github.com/bpfman/bpfman/issues/1050


#### Rationale for `rust,no_run` Attribute

- **Compile-Time Checks**: By using `rust,no_run`, the examples are still compiled when running `cargo test --doc`. This ensures that the code snippets are syntactically correct and that any changes to the API will be caught at compile time.
- **Avoiding Runtime Dependencies**: The examples often require a running instance of `bpfman` and specific system conditions (e.g., loaded eBPF programs). These conditions are not guaranteed in a typical documentation test environment. Using `rust,no_run` prevents these examples from failing due to unmet runtime dependencies.
- **Safety and Stability**: Some functions can have side effects or require specific system states. By preventing the execution of these examples, we avoid potential issues such as modifying system state, interfering with running services, or causing unintended side effects during testing.
- **Focus on Usage Clarity**: The examples are intended to illustrate how to use the functions correctly. Using `rust,no_run` ensures that the focus remains on demonstrating the correct usage patterns without the need for setting up the entire runtime environment required for execution.

By compiling but not running the examples, we strike a balance between ensuring code correctness and avoiding the complexity and potential instability of executing environment-dependent code during documentation tests.

Tested with:

```sh
% cargo test --doc
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
   Doc-tests bpfman

running 6 tests
test bpfman/src/lib.rs - pull_bytecode (line 633) - compile ... ok
test bpfman/src/lib.rs - remove_program (line 316) - compile ... ok
test bpfman/src/lib.rs - add_program (line 132) - compile ... ok
test bpfman/src/lib.rs - get_program (line 549) - compile ... ok
test bpfman/src/lib.rs - list_programs (line 439) - compile ... ok
test bpfman/src/types.rs - types::ProgramData::new (line 373) ... ok
```

### CI Integration
Documentation examples are now compiled in CI to ensure syntax correctness and catch API changes early.

