### PR TITLE
bpfman: XDP Mode Updates

### DIFF
--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -47,7 +47,7 @@ impl Dispatcher {
         let xdp_mode = if let Some(c) = config {
             c.xdp_mode()
         } else {
-            &XdpMode::Skb
+            &XdpMode::Drv
         };
         let d = match p.kind() {
             ProgramType::Xdp => {

--- a/docs/developer-guide/configuration.md
+++ b/docs/developer-guide/configuration.md
@@ -8,8 +8,8 @@ There is an example at `scripts/bpfman.toml`, similar to:
 
 ```toml
 [interfaces]
-  [interface.eth0]
-  xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
+  [interfaces.eth0]
+  xdp_mode = "drv" # Valid xdp modes are "hw", "skb" and "drv". Default: "drv", but will fall back to "skb" on failure.
 
 [signing]
 allow_unsigned = true

--- a/scripts/bpfman.toml
+++ b/scripts/bpfman.toml
@@ -1,6 +1,6 @@
 [interfaces]
-[interface.eth0]
-xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
+[interfaces.eth0]
+xdp_mode = "drv" # Valid xdp modes are "hw", "skb" and "drv". Default: "drv", but will fall back to "skb" on failure.
 
 [signing]
 allow_unsigned = true


### PR DESCRIPTION
Based on the Ingress Node Firewall integration with bpfman, if was found that the XDP Mode handling was not ideal. For context, the valid values are HW, DRV and SKB. HW is really only applicable for Netronome hardware.

Adding the following changes:
* The config file examples (bpfman.toml) for xdp_mode were invalid. Needed an `s` on interface.eth0.
* If config file value for a given interface is not entered, SKB was the default. Changing it to DRV and and retrying as SKB if DRV or HW fail.