### PR TITLE
Fix FromAsCasing warnings in container files

### DIFF
--- a/Containerfile.bpfman
+++ b/Containerfile.bpfman
@@ -1,7 +1,7 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM rust:1 as bpfman-build
+FROM --platform=$BUILDPLATFORM rust:1 AS bpfman-build
 
 ARG BUILDPLATFORM
 

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -1,6 +1,6 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between
 ## builds, dramatically speeding up the local development process.
-FROM rust:1 as bpfman-build
+FROM rust:1 AS bpfman-build
 
 RUN apt-get update && apt-get install -y\
     gcc-multilib\

--- a/examples/go-app-counter/container-deployment/Containerfile.go-app-counter
+++ b/examples/go-app-counter/container-deployment/Containerfile.go-app-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-app-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-app-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-kprobe-counter/container-deployment/Containerfile.go-kprobe-counter
+++ b/examples/go-kprobe-counter/container-deployment/Containerfile.go-kprobe-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-kprobe-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-kprobe-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-target/container-deployment/Containerfile.go-target
+++ b/examples/go-target/container-deployment/Containerfile.go-target
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-target-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-target-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-tc-counter/container-deployment/Containerfile.go-tc-counter
+++ b/examples/go-tc-counter/container-deployment/Containerfile.go-tc-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-tc-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-tc-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-tracepoint-counter/container-deployment/Containerfile.go-tracepoint-counter
+++ b/examples/go-tracepoint-counter/container-deployment/Containerfile.go-tracepoint-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-tracepoint-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-tracepoint-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-uprobe-counter/container-deployment/Containerfile.go-uprobe-counter
+++ b/examples/go-uprobe-counter/container-deployment/Containerfile.go-uprobe-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-uprobe-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-uprobe-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-uretprobe-counter/container-deployment/Containerfile.go-uretprobe-counter
+++ b/examples/go-uretprobe-counter/container-deployment/Containerfile.go-uretprobe-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as go-uretprobe-counter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS go-uretprobe-counter-build
 
 ARG BUILDPLATFORM
 

--- a/examples/go-xdp-counter/container-deployment/Containerfile.go-xdp-counter
+++ b/examples/go-xdp-counter/container-deployment/Containerfile.go-xdp-counter
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.22 as gocounter-build
+FROM --platform=$BUILDPLATFORM golang:1.22 AS gocounter-build
 
 ARG BUILDPLATFORM
 


### PR DESCRIPTION
This change addresses the FromAsCasing warnings issued by Docker during the build process by ensuring that 'as' is converted to 'AS' in the FROM directives.

Warnings observed:
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)

Reference: https://docs.docker.com/reference/build-checks/from-as-casing/
