### PR TITLE
bpfman: dispatcher should point to release tag

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -517,28 +517,13 @@ jobs:
             image: xdp-dispatcher
             context: .
             dockerfile: ./Containerfile.bytecode.multi.arch
-            bytecode_dir: ./.output/xdp_dispatcher_v1.bpf
-            tags: |
-              type=ref,event=branch
-              type=ref,event=tag
-              type=ref,event=pr
-              type=sha,format=long
-              type=raw,value=v1,enable={{is_default_branch}}
-
-          - registry: quay.io
-            build_language: rust
-            bpf_build_wrapper: rust
-            repository: bpfman
-            image: xdp-dispatcher
-            context: .
-            dockerfile: ./Containerfile.bytecode.multi.arch
             bytecode_dir: ./.output/xdp_dispatcher_v2.bpf
             tags: |
               type=ref,event=branch
               type=ref,event=tag
               type=ref,event=pr
               type=sha,format=long
-              type=raw,value=v2,enable={{is_default_branch}}
+              type=raw,value=latest,enable={{is_default_branch}}
 
           - registry: quay.io
             build_language: rust
@@ -553,7 +538,7 @@ jobs:
               type=ref,event=tag
               type=ref,event=pr
               type=sha,format=long
-              type=raw,value=v1,enable={{is_default_branch}}
+              type=raw,value=latest,enable={{is_default_branch}}
 
     name: Build eBPF Image (${{ matrix.image.image }})
     steps:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -206,12 +206,14 @@ Once these steps are completed:
     - Updates the bpfman-operator version in it's [Makefile](https://github.com/bpfman/bpfman/blob/main/bpfman-operator/Makefile):
         - `VERSION ?= x.x.x`
     - Runs `make bundle` from the bpfman-operator directory to update the bundle version.
-    - Adds a new `examples` config directory for the release version
+    - Adds a new `examples` config directory for the release version.
+    - Modify the tag for `XDP_DISPATCHER_IMAGE` and `TC_DISPATCHER_IMAGE` in `bpfman/src/lib.rs` from `latest` to the
+      new release tag.
 - Make sure CI is green and merge the update PR.
 - Create a tag using the `HEAD` of the `main` branch. This can be done using the `git` CLI or
   Github's [release][release] page.
 - Tag the release using the commit on `main` where the changelog update merged.
-  This can  be done using the `git` CLI or Github's [release][release]
+  This can be done using the `git` CLI or Github's [release][release]
   page.
 - The Release will be automatically created, after that is complete do the following:
     - run `make build-release-yamls` and attach the yamls for the version to the release. These will include:

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -148,7 +148,7 @@ pub async fn add_program(mut program: Program) -> Result<Program, BpfmanError> {
             // Cleanup any directories associated with the map_pin_path.
             // map_pin_path may or may not exist depending on where the original
             // error occured, so don't error if not there and preserve original error.
-            if let Some(pin_path) = program.get_data().get_map_pin_path()? {
+            if let Ok(Some(pin_path)) = program.get_data().get_map_pin_path() {
                 let _ = cleanup_map_pin_path(&pin_path, map_owner_id);
             }
 

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -52,6 +52,10 @@ const MAP_PREFIX: &str = "map_";
 const MAPS_USED_BY_PREFIX: &str = "map_used_by_";
 
 pub(crate) mod directories {
+    // When release is made, the dispatcher images should point to the release tag, for example v0.5.1.
+    pub(crate) const XDP_DISPATCHER_IMAGE: &str = "quay.io/bpfman/xdp-dispatcher:latest";
+    pub(crate) const TC_DISPATCHER_IMAGE: &str = "quay.io/bpfman/tc-dispatcher:latest";
+
     // The following directories are used by bpfman. They should be created by bpfman service
     // via the bpfman.service settings. They will be manually created in the case where bpfman
     // is not being run as a service.

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -122,7 +122,7 @@ impl TcDispatcher {
 
         debug!("tc dispatcher config: {:?}", config);
         let image = BytecodeImage::new(
-            "quay.io/bpfman/tc-dispatcher:v1".to_string(),
+            TC_DISPATCHER_IMAGE.to_string(),
             ImagePullPolicy::IfNotPresent as i32,
             None,
             None,

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -118,7 +118,7 @@ impl XdpDispatcher {
 
         debug!("xdp dispatcher config: {:?}", config);
         let image = BytecodeImage::new(
-            "quay.io/bpfman/xdp-dispatcher:v2".to_string(),
+            XDP_DISPATCHER_IMAGE.to_string(),
             ImagePullPolicy::IfNotPresent as i32,
             None,
             None,


### PR DESCRIPTION
When a release is created, XDP and TC code should use the dispatcher from image based on a release tag, not a latest (today they always point to "quay.io/bpfman/xdp-dispatcher:v2" and "quay.io/bpfman/tc-dispatcher:v1" which are essentially "latest"). Move both image strings to a common location for easier updating and update the release doc to indication they should be updated.
    
Also deprecated "quay.io/bpfman/xdp-dispatcher:v1". Left the source file in place, but no longer build it automatically. Also deprecated the tags v1 and v2 in quay and now just use latest.