### PR TITLE
bpfman: Failed dispatcher load corrupts DB

### DIFF
--- a/bpfman/src/errors.rs
+++ b/bpfman/src/errors.rs
@@ -69,6 +69,8 @@ pub enum BpfmanError {
     BtfError(#[from] aya::BtfError),
     #[error("Failed to acquire database lock, please try again later")]
     DatabaseLockError,
+    #[error("dispatcher failed to load. {0}")]
+    DispatcherLoadError(String),
 }
 
 #[derive(Error, Debug)]

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -54,8 +54,13 @@ impl Dispatcher {
                 let mut x =
                     XdpDispatcher::new(root_db, xdp_mode, if_index, if_name.to_string(), revision)?;
 
-                x.load(root_db, programs, old_dispatcher, image_manager)
-                    .await?;
+                if let Err(res) = x
+                    .load(root_db, programs, old_dispatcher, image_manager)
+                    .await
+                {
+                    let _ = x.delete(root_db, true);
+                    return Err(res);
+                }
                 Dispatcher::Xdp(x)
             }
             ProgramType::Tc => {
@@ -67,8 +72,13 @@ impl Dispatcher {
                     revision,
                 )?;
 
-                t.load(root_db, programs, old_dispatcher, image_manager)
-                    .await?;
+                if let Err(res) = t
+                    .load(root_db, programs, old_dispatcher, image_manager)
+                    .await
+                {
+                    let _ = t.delete(root_db, true);
+                    return Err(res);
+                }
                 Dispatcher::Tc(t)
             }
             _ => return Err(BpfmanError::DispatcherNotRequired),

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -16,6 +16,7 @@ pub bpfman::errors::BpfmanError::ContainerAttachError::container_pid: i32
 pub bpfman::errors::BpfmanError::ContainerAttachError::program_type: alloc::string::String
 pub bpfman::errors::BpfmanError::DatabaseError(alloc::string::String, alloc::string::String)
 pub bpfman::errors::BpfmanError::DatabaseLockError
+pub bpfman::errors::BpfmanError::DispatcherLoadError(alloc::string::String)
 pub bpfman::errors::BpfmanError::DispatcherNotRequired
 pub bpfman::errors::BpfmanError::Error(alloc::string::String)
 pub bpfman::errors::BpfmanError::InternalError(alloc::string::String)


### PR DESCRIPTION
If the TC or XDP dispatcher fails to load, subsequent load commands fail with a panic in bpfman. To fix, removed an unwrap(), add a dispatcher delete in the Dispatcher.new() function when an error occurs, and mapped some errors to new BpfmanError for dispatcher failures instead of just returning lower level error.

Resolves: #1221 