### PR TITLE
bpfman-cli: bpfman get of non-bpfman loaded prog fails

### DIFF
--- a/bpfman/src/bin/cli/get.rs
+++ b/bpfman/src/bin/cli/get.rs
@@ -9,7 +9,9 @@ use crate::{args::GetArgs, table::ProgTable};
 pub(crate) async fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
     match get_program(args.program_id).await {
         Ok(program) => {
-            ProgTable::new_program(&program)?.print();
+            if let Ok(p) = ProgTable::new_program(&program) {
+                p.print();
+            }
             ProgTable::new_kernel_info(&program)?.print();
             Ok(())
         }


### PR DESCRIPTION
Using bpfman CLI, trying to use `bpfman get` on a program not loaded by bpfman fails.

```
$ sudo bpfman list --all
 Program ID  Name             Type           Load Time
 2           hid_tail_call    tracing        2024-01-03T10:38:37-0500
 470         dump_bpf_map     tracing        2024-01-03T14:32:18-0500
 471         dump_bpf_prog    tracing        2024-01-03T14:32:18-0500
 28184                        cgroup_device  2024-02-02T10:51:40-0500
:

$ sudo bpfman get 28184
Error: get error: Database entry name does not exist in tree "28184"
```