### PR TITLE
Move Fedora back to release 40 in Containerfile.bpfman.local

### DIFF
--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
     cp /usr/src/bpfman/target/release/bpfman-rpc ./bpfman/
 
 ## Image for Local testing is much more of a debug image, give it bpftool and tcpdump
-FROM fedora:41
+FROM fedora:40
 
 RUN dnf makecache --refresh && dnf -y install bpftool tcpdump
 


### PR DESCRIPTION
This was bumped up to 41 by Kustomize.  However, 41 isn't released yet, and there's no good reason to use an unreleased version.