### PR TITLE
bpfman: Make whether to use cosign configurable

### DIFF
--- a/bpfman/src/config.rs
+++ b/bpfman/src/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::ParseError;
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub(crate) struct Config {
     interfaces: Option<HashMap<String, InterfaceConfig>>,
     #[serde(default)]
@@ -21,24 +21,51 @@ impl Config {
         &self.interfaces
     }
 
+    pub(crate) fn set_signing(&mut self, signing: SigningConfig) {
+        self.signing = Some(signing);
+    }
+
     pub(crate) fn signing(&self) -> &Option<SigningConfig> {
         &self.signing
+    }
+
+    pub(crate) fn set_database(&mut self, database: DatabaseConfig) {
+        self.database = Some(database);
     }
 
     pub(crate) fn database(&self) -> &Option<DatabaseConfig> {
         &self.database
     }
 }
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            interfaces: None,
+            signing: Some(SigningConfig::default()),
+            database: Some(DatabaseConfig::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct SigningConfig {
-    pub allow_unsigned: bool,
+    pub allow_unsigned: bool, // Allow unsigned programs
+    pub verify_enabled: bool, // Enable verification of signed programs
 }
 
 impl Default for SigningConfig {
     fn default() -> Self {
         Self {
-            // Allow unsigned programs by default
+            // Whether to allow unsigned programs by default
             allow_unsigned: true,
+            // Whether the signing of programs should be verified by default
+            //
+            // TODO: Since verifying signatures is a security feature it should
+            // be enabled by default, but it is currently disabled due to the
+            // the TUF issue (https://github.com/bpfman/bpfman/issues/1241).
+            // This should be set back to true once the issue is resolved.
+            verify_enabled: false,
         }
     }
 }

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -657,8 +657,8 @@ pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanE
 // explicitly control when bpfman blocks for network calls to both sigstore's
 // cosign tuf registries and container registries.
 pub(crate) async fn init_image_manager() -> ImageManager {
-    let config = open_config_file();
-    ImageManager::new(config.signing().as_ref().map_or(true, |s| s.allow_unsigned))
+    let signing_config = open_config_file().signing().to_owned().unwrap_or_default();
+    ImageManager::new(signing_config.verify_enabled, signing_config.allow_unsigned)
         .await
         .expect("failed to initialize image manager")
 }

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -208,10 +208,20 @@ pub(crate) fn get_error_msg_from_stderr(stderr: &[u8]) -> String {
 
 pub(crate) fn open_config_file() -> Config {
     if let Ok(c) = std::fs::read_to_string(CFGPATH_BPFMAN_CONFIG) {
-        c.parse().unwrap_or_else(|_| {
+        if let Ok(mut config) = c.parse::<Config>() {
+            if config.signing().is_none() {
+                debug!("No signing configuration found in config file.  using defaults");
+                config.set_signing(Default::default());
+            }
+            if config.database().is_none() {
+                debug!("No database configuration found in config file.  using defaults");
+                config.set_database(Default::default());
+            }
+            config
+        } else {
             warn!("Unable to parse config file, using defaults");
             Config::default()
-        })
+        }
     } else {
         debug!("Unable to read config file, using defaults");
         Config::default()

--- a/docs/developer-guide/configuration.md
+++ b/docs/developer-guide/configuration.md
@@ -13,6 +13,7 @@ There is an example at `scripts/bpfman.toml`, similar to:
 
 [signing]
 allow_unsigned = true
+verify_enabled = true
 
 [database]
 max_retries = 10
@@ -41,16 +42,21 @@ Valid fields:
 
 ### Config Section: [signing]
 
-This section of the configuration file allows control over whether OCI packaged eBPF
-bytecode as container images are required to be signed via
-[cosign](https://docs.sigstore.dev/signing/overview/) or not.
-By default, unsigned images are allowed.
-See [eBPF Bytecode Image Specifications](./shipping-bytecode.md) for more details on
+This section of the configuration file allows control over whether signatures on
+OCI packaged eBPF bytecode as container images are verified, and whether they
+are required to be signed via
+[cosign](https://docs.sigstore.dev/signing/overview/).
+
+By default, images are verified, and unsigned images are allowed. See [eBPF
+Bytecode Image Specifications](./shipping-bytecode.md) for more details on
 building and shipping bytecode in a container image.
 
 Valid fields:
 
-- **allow_unsigned**: Flag indicating whether unsigned images are allowed or not.
+- **allow_unsigned**: Flag indicating whether unsigned images are allowed.
+  Valid values: ["true"|"false"]
+
+- **verify_enabled**: Flag indicating whether signatures should be verified.
   Valid values: ["true"|"false"]
 
 ### Config Section: [database]

--- a/scripts/bpfman.toml
+++ b/scripts/bpfman.toml
@@ -4,6 +4,7 @@ xdp_mode = "drv" # Valid xdp modes are "hw", "skb" and "drv". Default: "drv", bu
 
 [signing]
 allow_unsigned = true
+verify_enabled = true
 
 [database]
 max_retries = 10


### PR DESCRIPTION
This pr adds an option to the `Config.signing`  called `verify_enabled` that
controls whether bpfman checks the signatures on images.

`verify_enabled` is currently defaulted to `false`, due to the current issue
with TUF (https://github.com/bpfman/bpfman/issues/1241).  It should be defaulted to 
`true` after the issue is resolved.

Reading the config and setting defaults is cleaned up as well.

Fixes: https://github.com/bpfman/bpfman/issues/1239