### PR TITLE
ci: pin rust to nightly-2024-09-09 until public-api fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ matrix.arch.arch == 'amd64' }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-09
           components: rustfmt, clippy, rust-src
           override: false
 
@@ -152,13 +152,13 @@ jobs:
         # Only need to run once
         if: ${{ matrix.arch.arch == 'amd64' }}
         run: |
-          cargo +nightly fmt --all -- --check
+          cargo +nightly-2024-09-09 fmt --all -- --check
 
       - name: Run clippy
         # Only need to run once
         if: ${{ matrix.arch.arch == 'amd64' }}
         run: |
-          cargo +nightly clippy --all -- --deny warnings
+          cargo +nightly-2024-09-09 clippy --all -- --deny warnings
 
       - name: Check public API
         # Only need to run once

--- a/xtask/src/public_api.rs
+++ b/xtask/src/public_api.rs
@@ -23,7 +23,7 @@ pub struct Options {
 }
 
 pub fn public_api(options: Options, metadata: Metadata) -> Result<()> {
-    let toolchain = "nightly";
+    let toolchain = "nightly-2024-09-09";
     let Options { bless, target } = options;
 
     if !rustup_toolchain::is_installed(toolchain)? {


### PR DESCRIPTION
The public-api (cargo xtask public-api) is failing with the latest rust nightly package. Temporarily pin nightly to last known working version until source of the issue can be resolved.