### PR TITLE
Set proper cargo config for aya

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,13 @@
 [alias]
 xtask = "run --package xtask --"
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source."https://github.com/aya-rs/aya"]
+git = "https://github.com/aya-rs/aya"
+rev = "ab5e688fd49fcfb402ad47d51cb445437fbd8cb7"
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"


### PR DESCRIPTION
This commit sets up cargo to vendor the specific aya commit so builds work
without trying to fetch it from github repo. While this may work locally
with Cargo build it'll break all rpm builds on offloine mode.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
