### PR TITLE
ci: run image-build.yaml when Containerfiles are updated

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -6,7 +6,11 @@ on: # yamllint disable-line rule:truthy
     tags:
       - v*
   pull_request:
-    paths: [.github/workflows/image-build.yaml]
+    paths:
+      - .github/workflows/image-build.yaml
+      - Containerfile.bpfman.multi.arch
+      - Containerfile.bytecode.multi.arch
+      - examples/**/container-deployment/Containerfile**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Currently, image-build.yaml, which is used to build and push all bpfman related container images to quay.io, is run when PR is merged or a PR is updated and image-build.yaml file itself is modified. A new rule needs to be added such that image-build.yaml is run when a PR is updated and one of the Containerfile files is modified.