### PR TITLE
ci: Move clippy to a code scanning action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.NIGHTLY_VERSION }}
-          components: rustfmt, clippy, rust-src
+          components: rustfmt, rust-src
           override: false
 
       # Only install cross if we need it
@@ -157,12 +157,6 @@ jobs:
         if: ${{ matrix.arch.arch == 'amd64' }}
         run: |
           cargo +${{ env.NIGHTLY_VERSION }} fmt --all -- --check
-
-      - name: Run clippy
-        # Only need to run once
-        if: ${{ matrix.arch.arch == 'amd64' }}
-        run: |
-          cargo +${{ env.NIGHTLY_VERSION }} clippy --all -- --deny warnings
 
       - name: Check public API
         # Only need to run once

--- a/.github/workflows/rust-clippy.yaml
+++ b/.github/workflows/rust-clippy.yaml
@@ -1,0 +1,54 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# rust-clippy is a tool that runs a bunch of lints to catch common
+# mistakes in your Rust code and help improve your Rust code.
+# More details at https://github.com/rust-lang/rust-clippy
+# and https://rust-lang.github.io/rust-clippy/
+
+name: rust-clippy analyze
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+  schedule:
+    - cron: 15 17 * * 4
+
+jobs:
+  rust-clippy-analyze:
+    name: Run rust-clippy analyzing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # @v1
+        with:
+          profile: minimal
+          toolchain: nightly-2024-09-24
+          components: clippy
+          override: true
+
+      - name: Install required cargo
+        run: cargo install clippy-sarif sarif-fmt
+
+      - name: Run rust-clippy
+        run: cargo clippy
+          --all-features
+          --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
There's support for clippy -> sarif and therefore integration into the GitHub Code Scanning infrastructure. Let's try this out.