### PR TITLE
Restore the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License][apache2-badge]][apache2-url]
 [![License][bsd2-badge]][bsd2-url]
 [![License][gpl-badge]][gpl-url]
-[![Build status]][build-badge]
+![Build status][build-badge]
 [![Book][book-badge]][book-url]
 [![Netlify Status][netlify-badge]][netlify-url]
 [![Copr build status][copr-badge]][copr-url]


### PR DESCRIPTION
The previous change didn't render right.  All the other badges have a link, but the build status doesn't.