### PR TITLE
Allow the scorecard workflow to be manually triggered

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,7 @@ on: # yamllint disable-line rule:truthy
     - cron: 31 23 * * 2
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Add `workflow_dispatch` to the scorecard workflow so it can be manually triggered as needed while we try to improve the score.