### PR TITLE
Upgrade to aya version 0.13.0 and aya-obj version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,28 +271,30 @@ dependencies = [
 
 [[package]]
 name = "aya"
-version = "0.12.0"
-source = "git+https://github.com/aya-rs/aya?rev=ab5e688fd49fcfb402ad47d51cb445437fbd8cb7#ab5e688fd49fcfb402ad47d51cb445437fbd8cb7"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7127cbe933572dfabb7a87d2c740f5b720c3e19b4d2b8c99a262ffa35c8761ff"
 dependencies = [
  "assert_matches",
  "aya-obj",
  "bitflags 2.6.0",
  "bytes",
- "lazy_static",
  "libc",
  "log",
  "object",
+ "once_cell",
  "thiserror",
 ]
 
 [[package]]
 name = "aya-obj"
-version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya?rev=ab5e688fd49fcfb402ad47d51cb445437fbd8cb7#ab5e688fd49fcfb402ad47d51cb445437fbd8cb7"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e133d505de14d5948a312060b8b12752c22a965632cc57da12f5db653de4c0"
 dependencies = [
  "bytes",
  "core-error",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "log",
  "object",
  "thiserror",
@@ -1506,6 +1508,8 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2528,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ anyhow = { version = "1", default-features = false }
 assert_cmd = { version = "2", default-features = false }
 assert_matches = { version = "1", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-aya = { version = "0.12", default-features = false }
-aya-obj = { version = "0.1.0", default-features = false }
+aya = { version = "0.13", default-features = false }
+aya-obj = { version = "0.2.0", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
 base64 = { version = "0.22.0", default-features = false }
 bpfman = { version = "0.5.1", path = "./bpfman" }
@@ -99,7 +99,3 @@ platforms = [
     "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
 ]
-
-[patch.crates-io]
-aya = { git = "https://github.com/aya-rs/aya", rev = "ab5e688fd49fcfb402ad47d51cb445437fbd8cb7" }
-aya-obj = { git = "https://github.com/aya-rs/aya", rev = "ab5e688fd49fcfb402ad47d51cb445437fbd8cb7" }

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -6,7 +6,7 @@ use std::{fs, mem};
 use aya::{
     programs::{
         links::FdLink,
-        tc::{self, SchedClassifierLink, TcOptions},
+        tc::{self, NlOptions, SchedClassifierLink, TcAttachOptions},
         Extension, Link, SchedClassifier, TcAttachType,
     },
     Ebpf, EbpfLoader,
@@ -255,14 +255,14 @@ impl TcDispatcher {
         let link_id = new_dispatcher.attach_with_options(
             &iface,
             attach_type,
-            TcOptions {
+            TcAttachOptions::Netlink(NlOptions {
                 priority,
                 ..Default::default()
-            },
+            }),
         )?;
 
         let link = new_dispatcher.take_link(link_id)?;
-        self.set_handle(link.handle())?;
+        self.set_handle(link.handle()?)?;
         mem::forget(link);
 
         if let Some(Dispatcher::Tc(mut d)) = old_dispatcher {

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -417,6 +417,8 @@ pub bpfman::types::MapType::TaskStorage
 pub bpfman::types::MapType::Unspec
 pub bpfman::types::MapType::UserRingbuf
 pub bpfman::types::MapType::Xskmap
+impl core::convert::From<aya::maps::info::MapType> for bpfman::types::MapType
+pub fn bpfman::types::MapType::from(val: aya::maps::info::MapType) -> Self
 impl core::convert::From<u32> for bpfman::types::MapType
 pub fn bpfman::types::MapType::from(value: u32) -> Self
 impl core::fmt::Debug for bpfman::types::MapType
@@ -617,6 +619,7 @@ pub bpfman::types::ProgramType::LwtIn
 pub bpfman::types::ProgramType::LwtOut
 pub bpfman::types::ProgramType::LwtSeg6Local
 pub bpfman::types::ProgramType::LwtXmit
+pub bpfman::types::ProgramType::Netfilter
 pub bpfman::types::ProgramType::PerfEvent
 pub bpfman::types::ProgramType::Probe
 pub bpfman::types::ProgramType::RawTracepoint
@@ -643,6 +646,8 @@ pub fn bpfman::types::ProgramType::clone(&self) -> bpfman::types::ProgramType
 impl core::cmp::Eq for bpfman::types::ProgramType
 impl core::cmp::PartialEq for bpfman::types::ProgramType
 pub fn bpfman::types::ProgramType::eq(&self, other: &bpfman::types::ProgramType) -> bool
+impl core::convert::From<aya::programs::info::ProgramType> for bpfman::types::ProgramType
+pub fn bpfman::types::ProgramType::from(val: aya::programs::info::ProgramType) -> Self
 impl core::convert::From<aya_obj::obj::ProgramSection> for bpfman::types::ProgramType
 pub fn bpfman::types::ProgramType::from(value: aya_obj::obj::ProgramSection) -> Self
 impl core::convert::From<bpfman::types::ProgramType> for u32


### PR DESCRIPTION
Changes include:
- Update bpfman TC code to new Aya APIs
- The new Aya release now returns Aya enums for ProgramType and MapType
  instead of u32. Added code to convert these enums back to u32 values 
  to reduce change in the bpfman code.
- Added an enum for the new Netfilter program type introduced in Aya.