### PR TITLE
Remove executable bit from vendored lib.rs

### DIFF
--- a/bpfman.spec
+++ b/bpfman.spec
@@ -45,6 +45,10 @@ An eBPF Program Manager.}
 
 # Source1 is vendored dependencies
 tar -xoaf %{SOURCE1}
+
+# Remove the executable bit from lib.rs as it affects brp_mange_shebangs
+chmod -x ./vendor/typed-path/src/lib.rs
+
 # Let the macros setup Cargo.toml to use vendored sources
 %cargo_prep -v vendor
 %cargo_license_summary


### PR DESCRIPTION
This commit removes the executable bit from the vendored lib.rs in the
bpfman specfile as it messes up with the brp-mangle-shebangs script, which is
being run on executable files.

Resolves https://github.com/bpfman/bpfman/issues/1303

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
