### PR TITLE
image: bpfman image build needs same build and base image

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,7 @@ jobs:
   # "build-and-push-bytecode-images" step. It will be used to generate
   # build args with the "bpfman image generate-build-args" command.
   build-bpfman-for-build-arg-gen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -48,7 +48,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -334,7 +334,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
bpfman images are built in github actions. The binary is built using .github/wokflows/image-build.yml which is currently using ubuntu:latest. Then the image is build by copoying the binary into a container. The base image for the container is redhat/ubi9-minimal, which used glibc 2.34. Recently, ubuntu:latest change from ubuntu 22.04 (glibc 2.34) to ubuntu 24.04 (glibc 2.39). So now bpfman won't run in a redhat/ubi9-minimal base image.

This PR moves the build image back to ubuntu 22.04 (glibc 2.34). A follow-up PR #1253 will change how this works and use the same build and base images.