### PR TITLE
correct file extension for CI workflow configuration

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -7,7 +7,7 @@ on: # yamllint disable-line rule:truthy
       - v*
   pull_request:
     paths:
-      - .github/workflows/image-build.yaml
+      - .github/workflows/image-build.yml
       - Containerfile.bpfman.multi.arch
       - Containerfile.bytecode.multi.arch
       - examples/**/container-deployment/Containerfile**

--- a/docs/developer-guide/image-build.md
+++ b/docs/developer-guide/image-build.md
@@ -266,7 +266,7 @@ integration tests, several steps need to be performed.
     * Make the new image public.
     * On the image, provide `Write` access to the `bpfman+github_actions` robot account.
 * Add the new image to the
-  [bpfman/.github/workflows/image-build.yaml](https://github.com/bpfman/bpfman/blob/main/.github/workflows/image-build.yaml)
+  [bpfman/.github/workflows/image-build.yml](https://github.com/bpfman/bpfman/blob/main/.github/workflows/image-build.yml)
   so the image is built and pushed on each PR merge.
 * For examples, update the `examples/Makefile` to build the new images.
 


### PR DESCRIPTION
# PR Summary
Commit e2816aae46f0536c9145ec17f37d019ae7af1eca renamed `.github/workflows/image-build.yaml` to be `.github/workflows/image-build.yml`. This PR adjusts sources to changes.