### PR TITLE
Use Ubuntu 24.04 everywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   check-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -26,7 +26,7 @@ jobs:
         uses: apache/skywalking-eyes@cd7b195c51fd3d6ad52afceb760719ddc6b3ee91
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -286,7 +286,7 @@ jobs:
             filename: linux-ppc64le
           - arch: s390x
             filename: linux-s390x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     name: Build Go Modules (${{ matrix.arch.arch }})
     steps:
@@ -323,7 +323,7 @@ jobs:
           GOARCH=${{ matrix.arch.arch }} make build
 
   basic-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build, build-go]
     steps:
       - name: Set up environment for running integration tests from manual trigger
@@ -421,7 +421,7 @@ jobs:
         run: cargo xtask integration-test
 
   build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -439,7 +439,7 @@ jobs:
 
   coverage:
     needs: [build, build-go]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download rust coverage artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # @v4
@@ -459,7 +459,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build]
     environment: crates.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -512,7 +512,7 @@ jobs:
         coverage,
         basic-integration-tests,
       ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Build Complete
         run: echo "Build Complete"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,7 +8,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,7 @@ jobs:
   # "build-and-push-bytecode-images" step. It will be used to generate
   # build args with the "bpfman image generate-build-args" command.
   build-bpfman-for-build-arg-gen:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -48,7 +48,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -334,7 +334,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust-clippy.yaml
+++ b/.github/workflows/rust-clippy.yaml
@@ -21,7 +21,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   rust-clippy-analyze:
     name: Run rust-clippy analyzing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/Containerfile.bpfman.multi.arch
+++ b/Containerfile.bpfman.multi.arch
@@ -1,7 +1,7 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM redhat/ubi9-minimal AS bpfman-build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS bpfman-build
 
 ARG BUILDPLATFORM
 
@@ -34,7 +34,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       cp target/s390x-unknown-linux-gnu/release/bpfman-rpc bin/.; \
     fi
 
-FROM redhat/ubi9-minimal
+FROM ubuntu:24.04
 
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman .
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman-ns .


### PR DESCRIPTION
We need kernel version 6.6 or greater to build the tcx test container images and also to run tcx integration tests.

We also have potential incompatibilies because redhat/ubi9-minimal is being used in Containerfile.bpfman.multi.arch, but ubuntu is being used to build the executables in image-build.yml.

Using Ubuntu-latest also has the potential to change versions without our knowing so we should pin down the version.

Using Ubuntu 24.04 for the bpfman image build and container can be revisited if we move to the approach in https://github.com/bpfman/bpfman/pull/1253.