### PR TITLE
Move bpfman container back to redhat/ubi9-minimal

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,7 @@ jobs:
   # "build-and-push-bytecode-images" step. It will be used to generate
   # build args with the "bpfman image generate-build-args" command.
   build-bpfman-for-build-arg-gen:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -48,7 +48,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -348,7 +348,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/Containerfile.bpfman.multi.arch
+++ b/Containerfile.bpfman.multi.arch
@@ -1,7 +1,7 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS bpfman-build
+FROM --platform=$BUILDPLATFORM redhat/ubi9-minimal AS bpfman-build
 
 ARG BUILDPLATFORM
 
@@ -34,7 +34,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       cp target/s390x-unknown-linux-gnu/release/bpfman-rpc bin/.; \
     fi
 
-FROM ubuntu:24.04
+FROM redhat/ubi9-minimal
 
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman .
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman-ns .

--- a/examples/go-app-counter/bpf/tcx_counter.h
+++ b/examples/go-app-counter/bpf/tcx_counter.h
@@ -7,6 +7,8 @@
 
 #include <bpf/bpf_helpers.h>
 
+#define TCX_NEXT -1
+
 /* This is the data record stored in the map */
 struct datarec {
   __u64 rx_packets;

--- a/examples/go-tcx-counter/bpf/tcx_counter.c
+++ b/examples/go-tcx-counter/bpf/tcx_counter.c
@@ -7,6 +7,8 @@
 
 #include <bpf/bpf_helpers.h>
 
+#define TCX_NEXT -1
+
 /* This is the data record stored in the map */
 struct datarec {
   __u64 rx_packets;

--- a/tests/integration-test/bpf/tcx_test.bpf.c
+++ b/tests/integration-test/bpf/tcx_test.bpf.c
@@ -7,6 +7,11 @@
 #include <bpf/bpf_helpers.h>
 // clang-format on
 
+#define TCX_NEXT -1
+#define TCX_PASS 0
+#define TCX_DROP 2
+#define TCX_REDIRECT 7
+
 volatile const __u8 GLOBAL_u8 = 0;
 volatile const __u32 GLOBAL_u32 = 0;
 


### PR DESCRIPTION
We're having failures in pulling/loading bpf programs with the new image.  It's not fully debugged, but this is the likely change.