### PR TITLE
image: Move bpfman container back to Ubuntu 24.04

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,7 @@ jobs:
   # "build-and-push-bytecode-images" step. It will be used to generate
   # build args with the "bpfman image generate-build-args" command.
   build-bpfman-for-build-arg-gen:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
@@ -48,7 +48,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -348,7 +348,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -1,10 +1,24 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between
 ## builds, dramatically speeding up the local development process.
-FROM rust:1 AS bpfman-build
+
+# Move to Ubunutu 24.04 to track how images are built in github and Containerfile.bpfman.multi.arch.
+# This is a short term fix and will be moving to ubi9minimal as soon as possible. So try to keep
+# keep Ubuntu specifics on their own lines.
+#FROM rust:1 AS bpfman-build
+FROM ubuntu:24.04 AS bpfman-build
+
+# Packages need to build on Ubuntu
+RUN apt-get update && apt-get install -y\
+    pkg-config\
+    curl
 
 RUN apt-get update && apt-get install -y\
     gcc-multilib\
     libssl-dev
+
+# Get Rust for Ubuntu base build
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
 
 WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
@@ -23,10 +37,15 @@ RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
 RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
     cp /usr/src/bpfman/target/release/bpfman-rpc ./bpfman/
 
-## Image for Local testing is much more of a debug image, give it bpftool and tcpdump
-FROM fedora:40
+#FROM fedora:40
+FROM ubuntu:24.04
 
-RUN dnf makecache --refresh && dnf -y install bpftool tcpdump
+## Image for Local testing is much more of a debug image, give it bpftool and tcpdump
+# RUN dnf makecache --refresh && dnf -y install bpftool tcpdump
+RUN apt-get update && \
+    apt-get -y install linux-tools-common tcpdump ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/\* /tmp/\* /var/tmp/*
 
 COPY --from=bpfman-build  ./usr/src/bpfman/bpfman .
 

--- a/Containerfile.bpfman.multi.arch
+++ b/Containerfile.bpfman.multi.arch
@@ -1,7 +1,7 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM redhat/ubi9-minimal AS bpfman-build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS bpfman-build
 
 ARG BUILDPLATFORM
 
@@ -34,7 +34,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
       cp target/s390x-unknown-linux-gnu/release/bpfman-rpc bin/.; \
     fi
 
-FROM redhat/ubi9-minimal
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get -y install ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/\* /tmp/\* /var/tmp/*
 
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman .
 COPY --from=bpfman-build  /usr/src/bpfman/bin/bpfman-ns .

--- a/examples/go-app-counter/bpf/tcx_counter.h
+++ b/examples/go-app-counter/bpf/tcx_counter.h
@@ -7,8 +7,6 @@
 
 #include <bpf/bpf_helpers.h>
 
-#define TCX_NEXT -1
-
 /* This is the data record stored in the map */
 struct datarec {
   __u64 rx_packets;

--- a/examples/go-tcx-counter/bpf/tcx_counter.c
+++ b/examples/go-tcx-counter/bpf/tcx_counter.c
@@ -7,8 +7,6 @@
 
 #include <bpf/bpf_helpers.h>
 
-#define TCX_NEXT -1
-
 /* This is the data record stored in the map */
 struct datarec {
   __u64 rx_packets;

--- a/tests/integration-test/bpf/tcx_test.bpf.c
+++ b/tests/integration-test/bpf/tcx_test.bpf.c
@@ -7,11 +7,6 @@
 #include <bpf/bpf_helpers.h>
 // clang-format on
 
-#define TCX_NEXT -1
-#define TCX_PASS 0
-#define TCX_DROP 2
-#define TCX_REDIRECT 7
-
 volatile const __u8 GLOBAL_u8 = 0;
 volatile const __u32 GLOBAL_u32 = 0;
 


### PR DESCRIPTION
Backout #1325, which moved image building from Ubuntu 24.04 (which is needed for TCX) to ubi9-minimal. #1325 was needed because images originally built with Ubuntu 24.04 were failing to load eBPF programs because of Cosign failures. Turns out that those failures were due to ca-certicates not being installed in Ubunut 24.04 base images. So this PR also adds ca-certicates to the bpfman base image.

To allow local building of bpfman images that are consistent with github built images, this PR also moves Containerfile.bpfman.local to build with Ubuntu 24.04.