### PR TITLE
doc: update example building to use bpfman image build

### DIFF
--- a/bpfman/src/bin/cli/args.rs
+++ b/bpfman/src/bin/cli/args.rs
@@ -50,7 +50,7 @@ pub(crate) enum LoadSubcommand {
 #[derive(Args, Debug)]
 pub(crate) struct LoadFileArgs {
     /// Required: Location of local bytecode file
-    /// Example: --path /run/bpfman/examples/go-xdp-counter/bpf_bpfel.o
+    /// Example: --path /run/bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o
     #[clap(short, long, verbatim_doc_comment)]
     pub(crate) path: String,
 

--- a/docs/getting-started/cli-guide.md
+++ b/docs/getting-started/cli-guide.md
@@ -812,9 +812,11 @@ bpfman image build -f Containerfile.bytecode.multi.arch -t quay.io/$QUAY_USER/go
 
 The `bpfman image generate-build-args` command is a utility command that generates the labels used
 to package eBPF program bytecode in a OCI container image.
-The eBPF program bytecode must already be generated.
+It is recommended to use the `bpfman image build` command to package the eBPF program in a OCI
+container image, but an alternative is to generate the labels then build the container image with
+`docker` or `podman`.
 
-This command requires the bytecode to package that would be packaged in a OCI container image.
+The eBPF program bytecode must already be generated.
 The bytecode can take several forms, but at least one must be provided:
 
 * `--bytecode` or `-b`: Use this option for a single bytecode object file built for the host architecture.
@@ -932,4 +934,16 @@ BC_PPC64LE_EL=./examples/go-xdp-counter/bpf_powerpc_bpfel.o
 BC_S390X_EB=./examples/go-xdp-counter/bpf_s390_bpfeb.o
 PROGRAMS={"xdp_stats":"xdp"}
 MAPS={"xdp_stats_map":"per_cpu_array"}
+```
+
+Once the labels are generated, the eBPF program can be packaged in a OCI
+container image using `docker` or `podman` by passing the generated labels
+as `build-arg` parameters:
+
+```console
+docker build \
+  --build-arg BYTECODE_FILE=./examples/go-xdp-counter/bpf_x86_bpfel.o \
+  --build-arg PROGRAMS={"xdp_stats":"xdp"} \
+  --build-arg MAPS={"xdp_stats_map":"per_cpu_array"} \
+  -f Containerfile.bytecode . -t quay.io/$USER/go-xdp-counter-bytecode:test
 ```

--- a/docs/getting-started/example-bpf-local.md
+++ b/docs/getting-started/example-bpf-local.md
@@ -20,7 +20,7 @@ Following the diagram (Purple numbers):
 
 1. When `go-xdp-counter` userspace is started, it will send a gRPC request over unix
    socket to `bpfman-rpc` requesting `bpfman` to load the `go-xdp-counter` eBPF bytecode located
-   on disk at `bpfman/examples/go-xdp-counter/bpf_bpfel.o` at a priority of 50 and on interface `eno3`.
+   on disk at `bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o` at a priority of 50 and on interface `eno3`.
    These values are configurable as we will see later, but for now we will use the defaults
    (except interface, which is required to be entered).
 2. `bpfman` will load it's `dispatcher` eBPF program, which links to the `go-xdp-counter` eBPF program
@@ -53,7 +53,7 @@ interface as shown below:
 cd bpfman/examples/go-xdp-counter/
 
 go run -exec sudo . --iface eno3
-2023/07/17 17:43:58 Using Input: Interface=eno3 Priority=50 Source=/home/$USER/src/bpfman/examples/go-xdp-counter/bpf_bpfel.o
+2023/07/17 17:43:58 Using Input: Interface=eno3 Priority=50 Source=/home/$USER/src/bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o
 2023/07/17 17:43:58 Program registered with id 6211
 2023/07/17 17:44:01 4 packets received
 2023/07/17 17:44:01 580 bytes received

--- a/docs/getting-started/example-bpf.md
+++ b/docs/getting-started/example-bpf.md
@@ -1,31 +1,34 @@
 # Example eBPF Programs
 
 Example applications that use the `bpfman-go` bindings can be found in the
-[examples/](https://github.com/bpfman/bpfman/tree/main/examples/) directory.
+[bpfman/examples/](https://github.com/bpfman/bpfman/tree/main/examples/) directory.
 Current examples include:
 
-* [examples/go-kprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter)
-* [examples/go-tc-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-tc-counter)
-* [examples/go-tracepoint-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-tracepoint-counter)
-* [examples/go-uprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-uprobe-counter)
-* [examples/go-uretprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-uretprobe-counter)
-* [examples/go-target/](https://github.com/bpfman/bpfman/tree/main/examples/go-target)
-* [examples/go-xdp-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-xdp-counter)
-* [examples/go-app-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-app-counter)
+* [bpfman/examples/go-app-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-app-counter)
+* [bpfman/examples/go-kprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter)
+* [bpfman/examples/go-target/](https://github.com/bpfman/bpfman/tree/main/examples/go-target)
+* [bpfman/examples/go-tc-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-tc-counter)
+* [bpfman/examples/go-tcx-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-tcx-counter)
+* [bpfman/examples/go-tracepoint-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-tracepoint-counter)
+* [bpfman/examples/go-uprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-uprobe-counter)
+* [bpfman/examples/go-uretprobe-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-uretprobe-counter)
+* [bpfman/examples/go-xdp-counter/](https://github.com/bpfman/bpfman/tree/main/examples/go-xdp-counter)
 
 ## Example Code Breakdown
 
 These examples and the associated documentation are intended to provide the basics on how to deploy
 and manage an eBPF program using bpfman. Each of the examples contains an eBPF Program(s) written in C
-([kprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter/bpf/kprobe_counter.c),
+([app_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-app-counter/bpf/app_counter.c),
+[kprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter/bpf/kprobe_counter.c),
 [tc_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tc-counter/bpf/tc_counter.c),
-[tracepoint_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tracepoint-counter/bpf/tracepoint_counter.c) 
+[tcx_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tcx-counter/bpf/tcx_counter.c),
+[tracepoint_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-tracepoint-counter/bpf/tracepoint_counter.c),
 [uprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-uprobe-counter/bpf/uprobe_counter.c),
 [uretprobe_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-uretprobe-counter/bpf/uretprobe_counter.c),
 and
 [xdp_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-xdp-counter/bpf/xdp_counter.c))
-([app_counter.c](https://github.com/bpfman/bpfman/tree/main/examples/go-kprobe-counter/bpf/app_counter.c),
-that is compiled into eBPF bytecode (bpf_bpfel.o).
+that is compiled into eBPF bytecode for each supported architecture (bpf_arm64_bpfel.o, bpf_powerpc_bpfel.o,
+bpf_s390_bpfeb.o and bpf_x86_bpfel.o).
 Each time the eBPF program is called, it increments the packet and byte counts in a map that is accessible
 by the userspace portion.
 
@@ -44,7 +47,7 @@ dictate the deployment method.
 ### Examples in Local Deployment
 
 When run locally, the userspace program makes gRPC calls to `bpfman-rpc` requesting `bpfman` to load
-the eBPF program at the requested hook point (XDP hook point, TC hook point, Tracepoint, etc).
+the eBPF program at the requested hook point (TC hook point, Tracepoint, XDP hook point, etc).
 Data sent in the RPC request is either defaulted or passed in via input parameters.
 To make the examples as simple as possible to run, all input data is defaulted (except the interface
 TC and XDP programs need to attach to) but can be overwritten if desired. All example programs have
@@ -56,29 +59,29 @@ cd bpfman/examples/go-kprobe-counter/
 ./go-kprobe-counter --help
 Usage of ./go-kprobe-counter:
   -crd
-    	Flag to indicate all attributes should be pulled from the BpfProgram CRD.
-    	Used in Kubernetes deployments and is mutually exclusive with all other
-    	parameters.
+      Flag to indicate all attributes should be pulled from the BpfProgram CRD.
+      Used in Kubernetes deployments and is mutually exclusive with all other
+      parameters.
   -file string
-    	File path of bytecode source. "file" and "image"/"id" are mutually exclusive.
-    	Example: -file /home/$USER/src/bpfman/examples/go-kprobe-counter/bpf_bpfel.o
+      File path of bytecode source. "file" and "image"/"id" are mutually exclusive.
+      Example: -file /home/$USER/src/bpfman/examples/go-kprobe-counter/bpf_x86_bpfel.o
   -id uint
-    	Optional Program ID of bytecode that has already been loaded. "id" and
-    	"file"/"image" are mutually exclusive.
-    	Example: -id 28341
+      Optional Program ID of bytecode that has already been loaded. "id" and
+      "file"/"image" are mutually exclusive.
+      Example: -id 28341
   -image string
-    	Image repository URL of bytecode source. "image" and "file"/"id" are
-    	mutually exclusive.
-    	Example: -image quay.io/bpfman-bytecode/go-kprobe-counter:latest
+      Image repository URL of bytecode source. "image" and "file"/"id" are
+      mutually exclusive.
+      Example: -image quay.io/bpfman-bytecode/go-kprobe-counter:latest
   -map_owner_id int
-    	Program Id of loaded eBPF program this eBPF program will share a map with.
-    	Example: -map_owner_id 9785
+      Program Id of loaded eBPF program this eBPF program will share a map with.
+      Example: -map_owner_id 9785
 ```
 
 The location of the eBPF bytecode can be provided four different ways:
 
 * Defaulted: If nothing is passed in, the code scans the local directory for
-  a `bpf_bpfel.o` file. If found, that is used. If not, it errors out.
+  a `bpf_x86_bpfel.o` file. If found, that is used. If not, it errors out.
 * **file**: Fully qualified path of the bytecode object file.
 * **image**: Image repository URL of bytecode source.
 * **id**: Kernel program Id of a bytecode that has already been loaded. This
@@ -170,12 +173,6 @@ make build
 To build only a single example:
 
 ```console
-cd bpfman/examples/go-tc-counter/
-go generate
-go build
-```
-
-```console
 cd bpfman/examples/go-tracepoint-counter/
 go generate
 go build
@@ -189,75 +186,61 @@ _Other program types are the same._
 instructions on building and shipping bytecode in a container image.
 Pre-built eBPF container images for the examples can be loaded from:
 
+- `quay.io/bpfman-bytecode/go-app-counter:latest`
 - `quay.io/bpfman-bytecode/go-kprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-tc-counter:latest`
+- `quay.io/bpfman-bytecode/go-tcx-counter:latest`
 - `quay.io/bpfman-bytecode/go-tracepoint-counter:latest`
 - `quay.io/bpfman-bytecode/go-uprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-uretprobe-counter:latest`
 - `quay.io/bpfman-bytecode/go-xdp-counter:latest`
-- `quay.io/bpfman-bytecode/go-app-counter:latest`
 
-To build the example eBPF bytecode container images, run the build commands below (the `go generate`
-requires the [Prerequisites](#prerequisites) described above):
+To build the example eBPF bytecode container images, first generate the bytecode (the `generate`
+commands require the [Prerequisites](#prerequisites) described above in the
+[Building Locally](#building-locally) section).
+
+To generate the bytecode for all the examples:
+
+```console
+cd bpfman/examples/
+make generate
+```
+
+OR to generate the bytecode for a single example (XDP in this case):
 
 ```console
 cd bpfman/examples/go-xdp-counter/
 go generate
-
-docker build \
-  --build-arg PROGRAM_NAME=go-xdp-counter \
-  --build-arg BPF_FUNCTION_NAME=xdp_stats \
-  --build-arg PROGRAM_TYPE=xdp \
-  --build-arg BYTECODE_FILENAME=bpf_bpfel.o \
-  --build-arg KERNEL_COMPILE_VER=$(uname -r) \
-  -f ../../Containerfile.bytecode . -t quay.io/$USER/go-xdp-counter-bytecode:latest
 ```
 
-and
+The preferred method for building the container image is to use the `bpfman image build`
+command.
+See [bpfman image build](./cli-guide.md#bpfman-image-build) in the CLI Guide for more details.
 
 ```console
-cd bpfman/examples/go-tc-counter/
-go generate
-
-docker build \
-  --build-arg PROGRAM_NAME=go-tc-counter \
-  --build-arg BPF_FUNCTION_NAME=stats \
-  --build-arg PROGRAM_TYPE=tc \
-  --build-arg BYTECODE_FILENAME=bpf_bpfel.o \
-  --build-arg KERNEL_COMPILE_VER=$(uname -r) \
-  -f ../../Containerfile.bytecode . -t quay.io/$USER/go-tc-counter-bytecode:latest
+cd bpfman/examples/go-xdp-counter/
+bpfman image build -f ../../Containerfile.bytecode -t quay.io/$QUAY_USER/go-xdp-counter-bytecode:test -b bpf_x86_bpfel.o
 ```
 
-_Other program types are the same._
+The examples [Makefile](https://github.com/bpfman/bpfman/blob/main/examples/Makefile) has
+commands to build all the example images if needed.
+See [Locally Build Example Container Images](../developer-guide/image-build.md#locally-build-example-container-images)
+for more details.
 
 `bpfman` currently does not provide a method for pre-loading bytecode images
-(see [issue #603](https://github.com/bpfman/bpfman/issues/603)), so push the bytecode image to a remote
+(see [issue #603](https://github.com/bpfman/bpfman/issues/603)), so push the bytecode image to an image
 repository.
+
 For example:
 
 ```console
 docker login quay.io
-docker push quay.io/$USER/go-xdp-counter-bytecode:latest
-docker push quay.io/$USER/go-tc-counter-bytecode:latest
-```
-
-Then run with the privately built bytecode container image:
-
-```console
-sudo ./go-tc-counter -iface ens3 -direction ingress -image quay.io/$USER/go-tc-counter-bytecode:latest
-2022/12/02 16:38:44 Using Input: Interface=ens3 Priority=50 Source=quay.io/$USER/go-tc-counter-bytecode:latest
-2022/12/02 16:38:45 Program registered with id 6225
-2022/12/02 16:38:48 4 packets received
-2022/12/02 16:38:48 580 bytes received
-
-2022/12/02 16:38:51 4 packets received
-2022/12/02 16:38:51 580 bytes received
-
-^C2022/12/02 16:38:51 Exiting...
-2022/12/02 16:38:51 Unloading Program: 6225
+docker push quay.io/$QUAY_USER/go-xdp-counter-bytecode:test
 ```
 
 ## Running Examples
+
+Below are some examples of how to run the bpfman examples on a host where bpfman is already installed.
 
 ```console
 cd bpfman/examples/go-xdp-counter/
@@ -284,8 +267,8 @@ bpfman can load eBPF bytecode from a container image built following the spec de
 To use the container image, pass the URL to the userspace program:
 
 ```console
-sudo ./go-xdp-counter -iface ens3 -image quay.io/bpfman-bytecode/go-xdp-counter:latest
-2022/12/02 16:28:32 Using Input: Interface=ens3 Priority=50 Source=quay.io/bpfman-bytecode/go-xdp-counter:latest
+sudo ./go-xdp-counter -iface eno3 -image quay.io/bpfman-bytecode/go-xdp-counter:latest
+2022/12/02 16:28:32 Using Input: Interface=eno3 Priority=50 Source=quay.io/bpfman-bytecode/go-xdp-counter:latest
 2022/12/02 16:28:34 Program registered with id 6223
 2022/12/02 16:28:37 4 packets received
 2022/12/02 16:28:37 580 bytes received
@@ -295,4 +278,20 @@ sudo ./go-xdp-counter -iface ens3 -image quay.io/bpfman-bytecode/go-xdp-counter:
 
 ^C2022/12/02 16:28:42 Exiting...
 2022/12/02 16:28:42 Unloading Program: 6223
+```
+
+Or to run with the privately built bytecode container image:
+
+```console
+sudo ./go-xdp-counter -iface eno3 -image quay.io/$QUAY_USER/go-xdp-counter-bytecode:test
+2022/12/02 16:38:44 Using Input: Interface=eno3 Priority=50 Source=quay.io/$QUAY_USER/go-xdp-counter-bytecode:test
+2022/12/02 16:38:45 Program registered with id 6225
+2022/12/02 16:38:48 4 packets received
+2022/12/02 16:38:48 580 bytes received
+
+2022/12/02 16:38:51 4 packets received
+2022/12/02 16:38:51 580 bytes received
+
+^C2022/12/02 16:38:51 Exiting...
+2022/12/02 16:38:51 Unloading Program: 6225
 ```

--- a/examples/pkg/config-mgmt/param.go
+++ b/examples/pkg/config-mgmt/param.go
@@ -95,7 +95,7 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 			"Example: -image quay.io/bpfman-bytecode/go-"+progType.String()+"-counter:latest")
 	flag.StringVar(&cmdlineFile, "file", "",
 		"File path of bytecode source. \"file\" and \"image\"/\"id\" are mutually exclusive.\n"+
-			"Example: -file /home/$USER/src/bpfman/examples/go-"+progType.String()+"-counter/bpf_bpfel.o")
+			"Example: -file /home/$USER/src/bpfman/examples/go-"+progType.String()+"-counter/bpf_x86_bpfel.o")
 	flag.BoolVar(&paramData.CrdFlag, "crd", false,
 		"Flag to indicate all attributes should be pulled from the BpfProgram CRD.\n"+
 			"Used in Kubernetes deployments and is mutually exclusive with all other\n"+
@@ -150,7 +150,7 @@ func ParseParamData(progType ProgType, bytecodeFile string) (ParameterData, erro
 	//    ./go-xdp-counter -iface eth0 -id 23415
 	if paramData.ProgId == UnusedProgramId {
 		// "-path" is a file path for the bytecode source. If not provided, check toml file.
-		//    ./go-xdp-counter -iface eth0 -path /var/bpfman/bytecode/bpf_bpfel.o
+		//    ./go-xdp-counter -iface eth0 -path /var/bpfman/bytecode/bpf_x86_bpfel.o
 		if len(cmdlineFile) != 0 {
 			// "-image" was entered so it is a URL
 			paramData.BytecodeSource = &gobpfman.BytecodeLocation{

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -1251,7 +1251,7 @@ pub struct DisableCosignGuard<'a> {
     path: &'a str,
 }
 
-impl<'a> Drop for DisableCosignGuard<'a> {
+impl Drop for DisableCosignGuard<'_> {
     fn drop(&mut self) {
         if Path::new(self.path).exists() {
             fs::remove_file(self.path).expect("Failed to delete file");


### PR DESCRIPTION
The documentation on examples has a section on building the examples which was still using the `docker build --build-arg ...` style. Switch it to use the `bpfman build image` command.

Also found a few spots in the documents that were still referencing the old object names, like `bpf_bpfel.o`. With multi-arch, all our bytecode object files have the arch in the name, like `bpf_x86_bpfel.o`.