### PR TITLE
Add an eBPF program with 9 global variables

### DIFF
--- a/tests/integration-test/bpf/kprobe_globals.bpf.c
+++ b/tests/integration-test/bpf/kprobe_globals.bpf.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+// Some kprobe test code
+
+// clang-format off
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+volatile const __u32 sampling = 0;
+volatile const __u8 trace_messages = 0;
+volatile const __u8 enable_rtt = 0;
+volatile const __u8 enable_pca = 0;
+volatile const __u8 enable_dns_tracking = 0;
+volatile const __u8 enable_flows_filtering = 0;
+volatile const __u16 dns_port = 0;
+volatile const __u8 enable_network_events_monitoring = 0;
+volatile const __u8 network_events_monitoring_groupid = 0;
+
+void print_globals() {
+  bpf_printk("sampling: 0x%08X, trace_messages: 0x%02X, enable_rtt: 0x%02X, "
+             "enable_pca: 0x%02X, enable_dns_tracking: 0x%02X, "
+             "enable_flows_filtering: 0x%02X, dns_port: 0x%02X, "
+             "enable_network_events_monitoring: 0x%02X, "
+             "network_events_monitoring_groupid: 0x%02X\n",
+             sampling, trace_messages, enable_rtt, enable_pca,
+             enable_dns_tracking, enable_flows_filtering, dns_port,
+             enable_network_events_monitoring,
+             network_events_monitoring_groupid);
+}
+
+SEC("kprobe/kprobe_globals")
+int kprobe_globals(struct pt_regs *ctx) {
+  print_globals();
+  return 0;
+}
+
+SEC("kretprobe/kprobe_globals")
+int kretprobe_globals(struct pt_regs *ctx) {
+  print_globals();
+  return 0;
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
As an example, this program can be installed with the following bpfman cli command:

bpfman load image \
-g sampling=01020304 trace_messages=05 enable_rtt=06 enable_pca=07 enable_dns_tracking=08 enable_flows_filtering=09 \ dns_port=0A0B enable_network_events_monitoring=0C network_events_monitoring_groupid=0D \ --image-url quay.io/bpfman-bytecode/kprobe_globals:latest \ -n kprobe_globals kprobe --fn-name try_to_wake_up