### PR TITLE
config: rework how default values are managed

### DIFF
--- a/bpfman/src/config.rs
+++ b/bpfman/src/config.rs
@@ -8,12 +8,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{errors::ParseError, TC_DISPATCHER_IMAGE, XDP_DISPATCHER_IMAGE};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub(crate) struct Config {
     interfaces: Option<HashMap<String, InterfaceConfig>>,
     #[serde(default)]
-    signing: Option<SigningConfig>,
-    database: Option<DatabaseConfig>,
+    signing: SigningConfig,
+    #[serde(default)]
+    database: DatabaseConfig,
     #[serde(default)]
     registry: RegistryConfig,
 }
@@ -23,19 +24,11 @@ impl Config {
         &self.interfaces
     }
 
-    pub(crate) fn set_signing(&mut self, signing: SigningConfig) {
-        self.signing = Some(signing);
-    }
-
-    pub(crate) fn signing(&self) -> &Option<SigningConfig> {
+    pub(crate) fn signing(&self) -> &SigningConfig {
         &self.signing
     }
 
-    pub(crate) fn set_database(&mut self, database: DatabaseConfig) {
-        self.database = Some(database);
-    }
-
-    pub(crate) fn database(&self) -> &Option<DatabaseConfig> {
+    pub(crate) fn database(&self) -> &DatabaseConfig {
         &self.database
     }
 
@@ -44,18 +37,8 @@ impl Config {
     }
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            interfaces: None,
-            signing: Some(SigningConfig::default()),
-            database: Some(DatabaseConfig::default()),
-            registry: RegistryConfig::default(),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
 pub struct SigningConfig {
     pub allow_unsigned: bool, // Allow unsigned programs
     pub verify_enabled: bool, // Enable verification of signed programs
@@ -73,6 +56,7 @@ impl Default for SigningConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
 pub struct DatabaseConfig {
     pub max_retries: u32,
     pub millisec_delay: u64,

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -715,7 +715,7 @@ pub async fn pull_bytecode(image: BytecodeImage) -> anyhow::Result<()> {
 }
 
 pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanError> {
-    let database_config = open_config_file().database().to_owned().unwrap_or_default();
+    let database_config = open_config_file().database().to_owned();
     for _ in 0..=database_config.max_retries {
         if let Ok(db) = sled_config.open() {
             debug!("Successfully opened database");
@@ -736,7 +736,7 @@ pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanE
 // explicitly control when bpfman blocks for network calls to both sigstore's
 // cosign tuf registries and container registries.
 pub(crate) async fn init_image_manager() -> Result<ImageManager, BpfmanError> {
-    let signing_config = open_config_file().signing().to_owned().unwrap_or_default();
+    let signing_config = open_config_file().signing().to_owned();
     match ImageManager::new(signing_config.verify_enabled, signing_config.allow_unsigned).await {
         Ok(im) => Ok(im),
         Err(e) => {

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -220,15 +220,7 @@ pub(crate) fn get_error_msg_from_stderr(stderr: &[u8]) -> String {
 
 pub(crate) fn open_config_file() -> Config {
     if let Ok(c) = std::fs::read_to_string(CFGPATH_BPFMAN_CONFIG) {
-        if let Ok(mut config) = c.parse::<Config>() {
-            if config.signing().is_none() {
-                debug!("No signing configuration found in config file.  using defaults");
-                config.set_signing(Default::default());
-            }
-            if config.database().is_none() {
-                debug!("No database configuration found in config file.  using defaults");
-                config.set_database(Default::default());
-            }
+        if let Ok(config) = c.parse::<Config>() {
             config
         } else {
             warn!("Unable to parse config file, using defaults");


### PR DESCRIPTION
Access functions to the config (configuration data read from bpfman.toml) return `Option<>`. So currently, `open_config_file()` checks for None and then call `default()` on each substructure. Update the data structures such that if they values are not in the bpfman.toml file, then default data is automatically used.