### PR TITLE
bpfman: fixed the panic issue of 'list' command when the prog name is…

### DIFF
--- a/bpfman/src/bin/cli/table.rs
+++ b/bpfman/src/bin/cli/table.rs
@@ -217,11 +217,7 @@ impl ProgTable {
             .fg(Color::Green)]);
 
         let p = r.get_data();
-        let name = if p.get_kernel_name()?.is_empty() {
-            "None".to_string()
-        } else {
-            p.get_kernel_name()?
-        };
+        let name = p.get_kernel_name()?;
 
         let rows = vec![
             vec!["Program ID:".to_string(), p.get_id()?.to_string()],

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -1144,10 +1144,7 @@ impl ProgramData {
 
     pub(crate) fn set_kernel_info(&mut self, prog: &AyaProgInfo) -> Result<(), BpfmanError> {
         self.set_id(prog.id())?;
-        self.set_kernel_name(
-            prog.name_as_str()
-                .expect("Program name is not valid unicode"),
-        )?;
+        self.set_kernel_name(prog.name_as_str().unwrap_or("None"))?;
         self.set_kernel_program_type(u32::from(ProgramType::from(
             prog.program_type().unwrap_or(AyaProgramType::Unspecified),
         )))?;


### PR DESCRIPTION
… empty

In the latest version of Aya, the semantics of 'AyaProgInfo::name_as_str()' have changed. In previous versions, it would return None only when the name was not valid Unicode, but in the latest version, it also returns None when the name is empty.

    pub fn name_as_str(&self) -> Option<&str> {
        let name = std::str::from_utf8(self.name()).ok()?;
        (FEATURES.bpf_name() || !name.is_empty()).then_some(name)
    }

Coincidentally, in my environment, there is an eBPF program whose name is empty.

Below is the output of 'bpftool prog' showing the program with an empty name:

	└─[:)] <git:(main 8438747) > bpftool prog
	51: cgroup_device  tag 03b4eaae2f14641a  gpl
        loaded_at 2024-12-02T00:39:06-0500  uid 0
        xlated 296B  jited 162B  memlock 4096B  map_ids 58

The panic backtrace:

	└─[:(] <git:(main 8438747) > RUST_BACKTRACE=1 cargo run -p bpfman list
	    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.46s
	     Running `target/debug/bpfman list`
	thread 'main' panicked at bpfman/src/types.rs:1149:18:
	Program name is not valid unicode
	stack backtrace:
	   0: rust_begin_unwind
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5
	   1: core::panicking::panic_fmt
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14
	   2: core::panicking::panic_display
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:262:5
	   3: core::option::expect_failed
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/option.rs:1995:5
	   4: core::option::Option<T>::expect
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/option.rs:898:21
	   5: bpfman::types::ProgramData::set_kernel_info
		     at ./bpfman/src/types.rs:1148:13
	   6: bpfman::list_programs::{{closure}}::{{closure}}
		     at ./bpfman/src/lib.rs:537:37
	   7: core::iter::adapters::map::map_try_fold::{{closure}}
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:96:28
	   8: core::iter::adapters::filter_map::filter_map_try_fold::{{closure}}
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/filter_map.rs:50:20
	   9: core::iter::adapters::map::map_try_fold::{{closure}}
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:96:21
	  10: core::iter::adapters::map::map_try_fold::{{closure}}
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:96:21
	  11: core::iter::adapters::map::map_try_fold::{{closure}}
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:96:21
	  12: core::iter::traits::iterator::Iterator::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/traits/iterator.rs:2411:21
	  13: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:122:9
	  14: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:122:9
	  15: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:122:9
	  16: <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/filter_map.rs:140:9
	  17: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/map.rs:122:9
	  18: core::iter::traits::iterator::Iterator::find
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/traits/iterator.rs:2880:9
	  19: <core::iter::adapters::filter::Filter<I,P> as core::iter::traits::iterator::Iterator>::next
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/adapters/filter.rs:60:9
	  20: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/alloc/src/vec/spec_from_iter_nested.rs:26:32
	  21: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/alloc/src/vec/spec_from_iter.rs:33:9
	  22: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/alloc/src/vec/mod.rs:2970:9
	  23: core::iter::traits::iterator::Iterator::collect
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/iter/traits/iterator.rs:2005:9
	  24: bpfman::list_programs::{{closure}}
		     at ./bpfman/src/lib.rs:522:8
	  25: bpfman::list::execute_list::{{closure}}
		     at ./bpfman/src/bin/cli/list.rs:25:36
	  26: bpfman::<impl bpfman::args::Commands>::execute::{{closure}}
		     at ./bpfman/src/bin/cli/main.rs:35:56
	  27: bpfman::main::{{closure}}
		     at ./bpfman/src/bin/cli/main.rs:27:27
	  28: <core::pin::Pin<P> as core::future::future::Future>::poll
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/future/future.rs:123:9
	  29: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/park.rs:281:63
	  30: tokio::runtime::coop::with_budget
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/coop.rs:107:5
	  31: tokio::runtime::coop::budget
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/coop.rs:73:5
	  32: tokio::runtime::park::CachedParkThread::block_on
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/park.rs:281:31
	  33: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/context/blocking.rs:66:9
	  34: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/scheduler/multi_thread/mod.rs:87:13
	  35: tokio::runtime::context::runtime::enter_runtime
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/context/runtime.rs:65:16
	  36: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/scheduler/multi_thread/mod.rs:86:9
	  37: tokio::runtime::runtime::Runtime::block_on_inner
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/runtime.rs:370:45
	  38: tokio::runtime::runtime::Runtime::block_on
		     at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/runtime/runtime.rs:340:13
	  39: bpfman::main
		     at ./bpfman/src/bin/cli/main.rs:27:5
	  40: core::ops::function::FnOnce::call_once
		     at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:250:5
	note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.