### PR TITLE
Fix Error deleting tc and xdp programs after netns deleted

### DIFF
--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -4,8 +4,6 @@
 mod tc;
 mod xdp;
 
-use std::path::PathBuf;
-
 use log::debug;
 use sled::Db;
 pub use tc::TcDispatcher;
@@ -59,7 +57,7 @@ impl Dispatcher {
                     xdp_mode,
                     if_index,
                     if_name.to_string(),
-                    p.netns()?,
+                    p.nsid()?,
                     revision,
                 )?;
 
@@ -85,7 +83,7 @@ impl Dispatcher {
                     direction.expect("missing direction"),
                     if_index,
                     if_name.to_string(),
-                    p.netns()?,
+                    p.nsid()?,
                     revision,
                 )?;
 
@@ -157,4 +155,4 @@ pub(crate) enum DispatcherId {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub(crate) struct DispatcherInfo(pub Option<PathBuf>, pub u32, pub Option<Direction>);
+pub(crate) struct DispatcherInfo(pub u64, pub u32, pub Option<Direction>);

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -339,7 +339,7 @@ pub(crate) fn enter_netns(netns: PathBuf) -> Result<NetnsGuard, BpfmanError> {
     })
 }
 
-fn nsid(ns_path: Option<PathBuf>) -> Result<u64, BpfmanError> {
+pub(crate) fn nsid(ns_path: Option<PathBuf>) -> Result<u64, BpfmanError> {
     let path = if let Some(p) = ns_path {
         p
     } else {
@@ -353,43 +353,34 @@ fn nsid(ns_path: Option<PathBuf>) -> Result<u64, BpfmanError> {
     Ok(metadata.ino())
 }
 
-pub(crate) fn xdp_dispatcher_id(
-    netns: Option<PathBuf>,
-    if_index: u32,
-) -> Result<String, BpfmanError> {
-    let nsid = nsid(netns)?;
+pub(crate) fn xdp_dispatcher_id(nsid: u64, if_index: u32) -> Result<String, BpfmanError> {
     Ok(format!("{}_{}_{}", XDP_DISPATCHER_PREFIX, nsid, if_index))
 }
 
 pub(crate) fn xdp_dispatcher_db_tree_name(
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     revision: u32,
 ) -> Result<String, BpfmanError> {
     Ok(format!(
         "{}_{}",
-        xdp_dispatcher_id(netns.clone(), if_index)?,
+        xdp_dispatcher_id(nsid, if_index)?,
         revision
     ))
 }
 
 pub(crate) fn xdp_dispatcher_rev_path(
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     revision: u32,
 ) -> Result<String, BpfmanError> {
-    let nsid = nsid(netns)?;
     Ok(format!(
         "{}/dispatcher_{}_{}_{}",
         RTDIR_FS_XDP, nsid, if_index, revision
     ))
 }
 
-pub(crate) fn xdp_dispatcher_link_path(
-    netns: Option<PathBuf>,
-    if_index: u32,
-) -> Result<String, BpfmanError> {
-    let nsid = nsid(netns)?;
+pub(crate) fn xdp_dispatcher_link_path(nsid: u64, if_index: u32) -> Result<String, BpfmanError> {
     Ok(format!(
         "{}/dispatcher_{}_{}_link",
         RTDIR_FS_XDP, nsid, if_index
@@ -397,24 +388,23 @@ pub(crate) fn xdp_dispatcher_link_path(
 }
 
 pub(crate) fn xdp_dispatcher_link_id_path(
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     revision: u32,
     id: u32,
 ) -> Result<String, BpfmanError> {
     Ok(format!(
         "{}/link_{}",
-        xdp_dispatcher_rev_path(netns, if_index, revision)?,
+        xdp_dispatcher_rev_path(nsid, if_index, revision)?,
         id
     ))
 }
 
 pub(crate) fn tc_dispatcher_id(
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     direction: Direction,
 ) -> Result<String, BpfmanError> {
-    let nsid = nsid(netns)?;
     Ok(format!(
         "{}_{}_{}_{}",
         TC_DISPATCHER_PREFIX, nsid, if_index, direction
@@ -422,21 +412,21 @@ pub(crate) fn tc_dispatcher_id(
 }
 
 pub(crate) fn tc_dispatcher_db_tree_name(
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     direction: Direction,
     revision: u32,
 ) -> Result<String, BpfmanError> {
     Ok(format!(
         "{}_{}",
-        tc_dispatcher_id(netns.clone(), if_index, direction)?,
+        tc_dispatcher_id(nsid, if_index, direction)?,
         revision
     ))
 }
 
 pub(crate) fn tc_dispatcher_rev_path(
     direction: Direction,
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     revision: u32,
 ) -> Result<String, BpfmanError> {
@@ -444,7 +434,6 @@ pub(crate) fn tc_dispatcher_rev_path(
         Direction::Ingress => RTDIR_FS_TC_INGRESS,
         Direction::Egress => RTDIR_FS_TC_EGRESS,
     };
-    let nsid = nsid(netns)?;
     Ok(format!(
         "{}/dispatcher_{}_{}_{}",
         tc_base, nsid, if_index, revision
@@ -453,14 +442,14 @@ pub(crate) fn tc_dispatcher_rev_path(
 
 pub(crate) fn tc_dispatcher_link_id_path(
     direction: Direction,
-    netns: Option<PathBuf>,
+    nsid: u64,
     if_index: u32,
     revision: u32,
     id: u32,
 ) -> Result<String, BpfmanError> {
     Ok(format!(
         "{}/link_{}",
-        tc_dispatcher_rev_path(direction, netns, if_index, revision)?,
+        tc_dispatcher_rev_path(direction, nsid, if_index, revision)?,
         id
     ))
 }

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -1402,6 +1402,7 @@ pub fn bpfman::types::TcProgram::get_direction(&self) -> core::result::Result<bp
 pub fn bpfman::types::TcProgram::get_if_index(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcProgram::get_iface(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcProgram::get_netns(&self) -> core::result::Result<core::option::Option<std::path::PathBuf>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcProgram::get_nsid(&self) -> core::result::Result<u64, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcProgram::get_priority(&self) -> core::result::Result<i32, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcProgram::get_proceed_on(&self) -> core::result::Result<bpfman::types::TcProceedOn, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcProgram::new(data: bpfman::types::ProgramData, priority: i32, iface: alloc::string::String, proceed_on: bpfman::types::TcProceedOn, direction: bpfman::types::Direction, netns: core::option::Option<std::path::PathBuf>) -> core::result::Result<Self, bpfman::errors::BpfmanError>
@@ -1461,6 +1462,7 @@ pub fn bpfman::types::TcxProgram::get_direction(&self) -> core::result::Result<b
 pub fn bpfman::types::TcxProgram::get_if_index(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcxProgram::get_iface(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcxProgram::get_netns(&self) -> core::result::Result<core::option::Option<std::path::PathBuf>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::TcxProgram::get_nsid(&self) -> core::result::Result<u64, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcxProgram::get_priority(&self) -> core::result::Result<i32, bpfman::errors::BpfmanError>
 pub fn bpfman::types::TcxProgram::new(data: bpfman::types::ProgramData, priority: i32, iface: alloc::string::String, direction: bpfman::types::Direction, netns: core::option::Option<std::path::PathBuf>) -> core::result::Result<Self, bpfman::errors::BpfmanError>
 impl core::clone::Clone for bpfman::types::TcxProgram
@@ -1704,6 +1706,7 @@ pub fn bpfman::types::XdpProgram::get_current_position(&self) -> core::result::R
 pub fn bpfman::types::XdpProgram::get_if_index(&self) -> core::result::Result<core::option::Option<u32>, bpfman::errors::BpfmanError>
 pub fn bpfman::types::XdpProgram::get_iface(&self) -> core::result::Result<alloc::string::String, bpfman::errors::BpfmanError>
 pub fn bpfman::types::XdpProgram::get_netns(&self) -> core::result::Result<core::option::Option<std::path::PathBuf>, bpfman::errors::BpfmanError>
+pub fn bpfman::types::XdpProgram::get_nsid(&self) -> core::result::Result<u64, bpfman::errors::BpfmanError>
 pub fn bpfman::types::XdpProgram::get_priority(&self) -> core::result::Result<i32, bpfman::errors::BpfmanError>
 pub fn bpfman::types::XdpProgram::get_proceed_on(&self) -> core::result::Result<bpfman::types::XdpProceedOn, bpfman::errors::BpfmanError>
 pub fn bpfman::types::XdpProgram::new(data: bpfman::types::ProgramData, priority: i32, iface: alloc::string::String, proceed_on: bpfman::types::XdpProceedOn, netns: core::option::Option<std::path::PathBuf>) -> core::result::Result<Self, bpfman::errors::BpfmanError>


### PR DESCRIPTION
This fix saves the network namespace ID when the program is loaded so it can be retrieved later when the program is being deleted even if the network namespace is deleted first.

Fixes: #1362