### PR TITLE
revert softprops/action-gh-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -481,7 +481,10 @@ jobs:
           merge-multiple: true
 
       - name: release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # @v2
+        # Revert softprops/action-gh-release from v2.2.0 to v2.1.0 due to
+        # "Error: Request body length does not match content-length header"
+        # https://github.com/softprops/action-gh-release/issues/556
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # @v2
         with:
           body_path: ./changelogs/CHANGELOG-${{ env.RELEASE_VERSION }}.md
           prerelease: ${{ env.PRE_RELEASE }}


### PR DESCRIPTION
Revert softprops/action-gh-release from v2.2.0 to v2.1.0 due to "Error: Request body length does not match content-length header"

See: https://github.com/softprops/action-gh-release/issues/556