### PR TITLE
image pull failure

### DIFF
--- a/bpf-log-exporter/src/main.rs
+++ b/bpf-log-exporter/src/main.rs
@@ -206,7 +206,7 @@ fn parse_field<'a>(
 
     if let Some(tmp) = tmp {
         let value = if last {
-            tmp.split(delimiter).last()
+            tmp.split(delimiter).next_back()
         } else {
             tmp.split(delimiter).next()
         };

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -1017,7 +1017,7 @@ fn get_programs_iter(root_db: &Db) -> impl Iterator<Item = (u32, Program)> + '_ 
         .filter_map(|p| {
             let id = bytes_to_string(&p)
                 .split('_')
-                .last()
+                .next_back()
                 .unwrap()
                 .parse::<u32>()
                 .unwrap();

--- a/bpfman/src/oci_utils/mod.rs
+++ b/bpfman/src/oci_utils/mod.rs
@@ -22,4 +22,6 @@ pub enum ImageError {
     ByteCodeImageNotfound(String),
     #[error("{0}: {1}")]
     DatabaseError(String, String),
+    #[error("{0}: {1}")]
+    BytecodeImageParseFailure(String, String),
 }

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -206,7 +206,7 @@ pub(crate) fn sled_insert(db_tree: &Tree, key: &str, value: &[u8]) -> Result<(),
 pub(crate) fn id_from_tree_name(name: &IVec) -> Result<u32, BpfmanError> {
     let id = bytes_to_string(name)
         .split('_')
-        .last()
+        .next_back()
         .ok_or_else(|| BpfmanError::InvalidTreeName(bytes_to_string(name)))?
         .parse::<u32>()
         .map_err(|_| BpfmanError::InvalidTreeName(bytes_to_string(name)))?;

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -1,7 +1,7 @@
 pub mod bpfman
 pub mod bpfman::errors
 pub enum bpfman::errors::BpfmanError
-pub bpfman::errors::BpfmanError::BpfBytecodeError(crate::oci_utils::ImageError)
+pub bpfman::errors::BpfmanError::BpfBytecodeError(bpfman::oci_utils::ImageError)
 pub bpfman::errors::BpfmanError::BpfFunctionNameNotValid(alloc::string::String)
 pub bpfman::errors::BpfmanError::BpfIOError(std::io::error::Error)
 pub bpfman::errors::BpfmanError::BpfLinkError(aya::programs::links::LinkError)


### PR DESCRIPTION
Image pull was failing with:

```
$ sudo bpfman load image --image-url quay.io/netobserv/ebpf-bytecode:e705638 \
  --name tcx_ingress_flow_parse tcx --iface eno3 --priority 100 --direction ingress

Error: failed to read db: Database entry quay.io_netobserv_ebpf-bytecode_mainc45136dba8fb3c73b87df1a0b125b5b354ae026cdd0ce2740dcf48c3ad54da10 does not exist in tree "__sled__default":
```

After further investigation, it was discovered that if bpfman is uninstalled and loaded fresh (empty database), the following error occurs:

```
$ sudo bpfman load image --image-url quay.io/netobserv/ebpf-bytecode:e705638 \
  --name tcx_ingress_flow_parse tcx --iface eno3 --priority 100 --direction ingress

Error: expected `,` or `}` at line 5 column 1
```

After adding additional debug logs, the primary issue was that the image was built with invalid map labels, there was a comma missing part of the way through the list. Once this occurred, there was an invalid/empty entry for that image. So subsequent calls to load checked the database to see if an entry already existed, which it did, so tried to load from there, and it failed because it really wasn't loaded.

This PR moved all the image pull DB writes to the end of the processing, to make sure pull succeeded properly before writing to the database. This should fix the "failed to read db" error. Also added a more informative error for the invalid map label:

```
$ sudo bpfman load image --image-url quay.io/netobserv/ebpf-bytecode:e705638 \
  --name tcx_ingress_flow_parse tcx --iface eno3 --priority 100 --direction ingress

Error: error pulling image, invalid image map label: expected `,` or `}` at line 5 column 1
```