### PR TITLE
chore: Unasync all the things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,12 +433,13 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-sys",
  "nix 0.28.0",
  "object",
  "oci-distribution",
  "rand",
- "rtnetlink",
  "serde",
  "serde_json",
  "sha2",
@@ -482,7 +483,6 @@ dependencies = [
  "oci-distribution",
  "prost",
  "rand",
- "rtnetlink",
  "serde",
  "serde_json",
  "sha2",
@@ -2475,10 +2475,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
- "futures",
  "libc",
  "log",
- "tokio",
 ]
 
 [[package]]
@@ -3566,24 +3564,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -53,7 +53,6 @@ oci-distribution = { workspace = true, default-features = false, features = [
 ] }
 prost = { workspace = true, features = ["prost-derive", "std"] }
 rand = { workspace = true }
-rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman-api/src/bin/rpc/rpc.rs
+++ b/bpfman-api/src/bin/rpc/rpc.rs
@@ -149,9 +149,7 @@ impl Bpfman for BpfmanLoader {
             ),
         };
 
-        let program = add_program(program)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        let program = add_program(program).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply_entry =
             LoadResponse {
@@ -173,9 +171,7 @@ impl Bpfman for BpfmanLoader {
         let reply = UnloadResponse {};
         let request = request.into_inner();
 
-        remove_program(request.id)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        remove_program(request.id).map_err(|e| Status::aborted(format!("{e}")))?;
 
         Ok(Response::new(reply))
     }
@@ -184,9 +180,7 @@ impl Bpfman for BpfmanLoader {
         let request = request.into_inner();
         let id = request.id;
 
-        let program = get_program(id)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        let program = get_program(id).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply_entry =
             GetResponse {
@@ -215,7 +209,6 @@ impl Bpfman for BpfmanLoader {
 
         // Await the response
         for r in list_programs(filter)
-            .await
             .map_err(|e| Status::aborted(format!("failed to list programs: {e}")))?
         {
             // Populate the response with the Program Info and the Kernel Info.
@@ -246,9 +239,7 @@ impl Bpfman for BpfmanLoader {
             None => return Err(Status::aborted("Empty pull_bytecode request received")),
         };
 
-        pull_bytecode(image)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        pull_bytecode(image).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply = PullBytecodeResponse {};
         Ok(Response::new(reply))

--- a/bpfman-api/src/bin/rpc/storage.rs
+++ b/bpfman-api/src/bin/rpc/storage.rs
@@ -146,7 +146,6 @@ impl Node for CsiNode {
 
                 // Find the Program with the specified *Program CRD name
                 let prog_data = list_programs(ListFilter::default())
-                    .await
                     .map_err(|e| Status::aborted(format!("failed list programs: {e}")))?
                     .into_iter()
                     .find(|p| {

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -41,7 +41,9 @@ futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
 log = { workspace = true }
+netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
+netlink-sys = { workspace = true }
 nix = { workspace = true, features = [
     "fs",
     "mount",
@@ -57,7 +59,6 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "trust-dns",
 ] }
 rand = { workspace = true }
-rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman/src/bin/cli/get.rs
+++ b/bpfman/src/bin/cli/get.rs
@@ -6,8 +6,8 @@ use log::warn;
 
 use crate::{args::GetArgs, table::ProgTable};
 
-pub(crate) async fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
-    match get_program(args.program_id).await {
+pub(crate) fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
+    match get_program(args.program_id) {
         Ok(program) => {
             if let Ok(p) = ProgTable::new_program(&program) {
                 p.print();

--- a/bpfman/src/bin/cli/image.rs
+++ b/bpfman/src/bin/cli/image.rs
@@ -24,11 +24,11 @@ use crate::args::{
 };
 
 impl ImageSubCommand {
-    pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
         match self {
-            ImageSubCommand::Pull(args) => execute_pull(args).await,
-            ImageSubCommand::Build(args) => execute_build(args).await,
-            ImageSubCommand::GenerateBuildArgs(args) => execute_build_args(args).await,
+            ImageSubCommand::Pull(args) => execute_pull(args),
+            ImageSubCommand::Build(args) => execute_build(args),
+            ImageSubCommand::GenerateBuildArgs(args) => execute_build_args(args),
         }
     }
 }
@@ -67,14 +67,14 @@ pub(crate) struct ImageBuilder {
     pub(crate) build_args: Vec<String>,
 }
 
-pub(crate) async fn execute_pull(args: &PullBytecodeArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_pull(args: &PullBytecodeArgs) -> anyhow::Result<()> {
     let image: BytecodeImage = args.try_into()?;
-    pull_bytecode(image).await?;
+    pull_bytecode(image)?;
 
     Ok(())
 }
 
-pub(crate) async fn execute_build(args: &BuildBytecodeArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_build(args: &BuildBytecodeArgs) -> anyhow::Result<()> {
     let container_tool = if let Some(runtime) = &args.runtime {
         match runtime.as_str() {
             "docker" => ContainerRuntime::Docker,
@@ -284,7 +284,7 @@ pub(crate) fn parse_bytecode_from_cilium_ebpf_project(
     })
 }
 
-pub(crate) async fn execute_build_args(args: &GenerateArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_build_args(args: &GenerateArgs) -> anyhow::Result<()> {
     let build_context = if let Some(project_path) = &args.bytecode.cilium_ebpf_project {
         parse_bytecode_from_cilium_ebpf_project(project_path)?
     } else {

--- a/bpfman/src/bin/cli/list.rs
+++ b/bpfman/src/bin/cli/list.rs
@@ -6,7 +6,7 @@ use bpfman::{list_programs, types::ListFilter};
 
 use crate::{args::ListArgs, table::ProgTable};
 
-pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
     let prog_type_filter = args.program_type.map(|p| p as u32);
 
     let filter = ListFilter::new(
@@ -22,7 +22,7 @@ pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
 
     let mut table = ProgTable::new_list();
 
-    for r in list_programs(filter).await? {
+    for r in list_programs(filter)? {
         if let Err(e) = table.add_response_prog(r) {
             bail!(e)
         }

--- a/bpfman/src/bin/cli/load.rs
+++ b/bpfman/src/bin/cli/load.rs
@@ -18,15 +18,15 @@ use crate::{
 };
 
 impl LoadSubcommand {
-    pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
         match self {
-            LoadSubcommand::File(l) => execute_load_file(l).await,
-            LoadSubcommand::Image(l) => execute_load_image(l).await,
+            LoadSubcommand::File(l) => execute_load_file(l),
+            LoadSubcommand::Image(l) => execute_load_image(l),
         }
     }
 }
 
-pub(crate) async fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
     let bytecode_source = Location::File(args.path.clone());
 
     let data = ProgramData::new(
@@ -42,14 +42,14 @@ pub(crate) async fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()>
         args.map_owner_id,
     )?;
 
-    let program = add_program(args.command.get_program(data)?).await?;
+    let program = add_program(args.command.get_program(data)?)?;
 
     ProgTable::new_program(&program)?.print();
     ProgTable::new_kernel_info(&program)?.print();
     Ok(())
 }
 
-pub(crate) async fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
     let bytecode_source = Location::Image((&args.pull_args).try_into()?);
 
     let data = ProgramData::new(
@@ -65,7 +65,7 @@ pub(crate) async fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<(
         args.map_owner_id,
     )?;
 
-    let program = add_program(args.command.get_program(data)?).await?;
+    let program = add_program(args.command.get_program(data)?)?;
 
     ProgTable::new_program(&program)?.print();
     ProgTable::new_kernel_info(&program)?.print();

--- a/bpfman/src/bin/cli/main.rs
+++ b/bpfman/src/bin/cli/main.rs
@@ -17,26 +17,23 @@ mod load;
 mod table;
 mod unload;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     env_logger::try_init()?;
     debug!("Log using env_logger");
 
     let cli = crate::args::Cli::parse();
 
-    cli.command.execute().await
+    cli.command.execute()
 }
 
 impl Commands {
-    pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
+    pub(crate) fn execute(&self) -> Result<(), anyhow::Error> {
         match self {
-            Commands::Load(l) => l.execute().await,
-            Commands::Unload(args) => execute_unload(args).await,
-            Commands::List(args) => execute_list(args).await,
-            Commands::Get(args) => execute_get(args)
-                .await
-                .map_err(|e| anyhow!("get error: {e}")),
-            Commands::Image(i) => i.execute().await,
+            Commands::Load(l) => l.execute(),
+            Commands::Unload(args) => execute_unload(args),
+            Commands::List(args) => execute_list(args),
+            Commands::Get(args) => execute_get(args).map_err(|e| anyhow!("get error: {e}")),
+            Commands::Image(i) => i.execute(),
         }?;
 
         Ok(())

--- a/bpfman/src/bin/cli/unload.rs
+++ b/bpfman/src/bin/cli/unload.rs
@@ -5,7 +5,7 @@ use bpfman::remove_program;
 
 use crate::args::UnloadArgs;
 
-pub(crate) async fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
-    remove_program(args.program_id).await?;
+pub(crate) fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
+    remove_program(args.program_id)?;
     Ok(())
 }

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -5,6 +5,8 @@ use std::{
     collections::HashMap,
     fs::{create_dir_all, remove_dir_all},
     path::{Path, PathBuf},
+    thread::sleep,
+    time::Duration,
 };
 
 use anyhow::anyhow;
@@ -25,7 +27,6 @@ use aya::{
 };
 use log::{debug, error, info, warn};
 use sled::{Config as SledConfig, Db};
-use tokio::time::{sleep, Duration};
 use types::AttachOrder;
 use utils::{id_from_tree_name, initialize_bpfman, tc_dispatcher_id, xdp_dispatcher_id};
 
@@ -50,6 +51,7 @@ mod config;
 mod dispatcher_config;
 pub mod errors;
 mod multiprog;
+mod netlink;
 mod oci_utils;
 mod static_program;
 pub mod types;
@@ -130,8 +132,7 @@ pub(crate) fn get_db_config() -> SledConfig {
 /// use bpfman::types::{KprobeProgram, Location, Program, ProgramData};
 /// use std::collections::HashMap;
 ///
-/// #[tokio::main]
-/// async fn main() -> Result<(), BpfmanError> {
+/// fn main() -> Result<(), BpfmanError> {
 ///     // Define the location of the eBPF object file.
 ///     let location = Location::File(String::from("kprobe.o"));
 ///
@@ -170,7 +171,7 @@ pub(crate) fn get_db_config() -> SledConfig {
 ///     let kprobe_program = KprobeProgram::new(program_data, String::from("do_sys_open"), probe_offset, is_retprobe, container_pid)?;
 ///
 ///     // Add the kprobe program using the bpfman manager.
-///     let added_program = add_program(Program::Kprobe(kprobe_program)).await?;
+///     let added_program = add_program(Program::Kprobe(kprobe_program))?;
 ///
 ///     // Print a success message with the name of the added program.
 ///     println!("Program '{}' added successfully.", added_program.get_data().get_name()?);
@@ -195,7 +196,7 @@ pub(crate) fn get_db_config() -> SledConfig {
 ///
 /// This function is asynchronous and should be awaited in an
 /// asynchronous context.
-pub async fn add_program(program: Program) -> Result<Program, BpfmanError> {
+pub fn add_program(program: Program) -> Result<Program, BpfmanError> {
     let kind = program
         .get_data()
         .get_kind()
@@ -207,7 +208,7 @@ pub async fn add_program(program: Program) -> Result<Program, BpfmanError> {
         .unwrap_or("not set".to_string());
     info!("Request to load {kind} program named \"{name}\"");
 
-    let result = add_program_internal(program).await;
+    let result = add_program_internal(program);
 
     match result {
         Ok(ref p) => {
@@ -221,9 +222,9 @@ pub async fn add_program(program: Program) -> Result<Program, BpfmanError> {
     result
 }
 
-async fn add_program_internal(mut program: Program) -> Result<Program, BpfmanError> {
-    let (config, root_db) = &setup().await?;
-    let mut image_manager = init_image_manager().await?;
+fn add_program_internal(mut program: Program) -> Result<Program, BpfmanError> {
+    let (config, root_db) = &setup()?;
+    let mut image_manager = init_image_manager()?;
     // This is only required in the add_program api
     program.get_data_mut().load(root_db)?;
 
@@ -236,15 +237,14 @@ async fn add_program_internal(mut program: Program) -> Result<Program, BpfmanErr
 
     program
         .get_data_mut()
-        .set_program_bytes(root_db, &mut image_manager)
-        .await?;
+        .set_program_bytes(root_db, &mut image_manager)?;
 
     let result = match program {
         Program::Xdp(_) | Program::Tc(_) => {
             let if_name = program.if_name()?;
             let netns = program.netns()?;
             program.set_if_index(get_ifindex(&if_name, netns)?)?;
-            add_multi_attach_program(root_db, &mut program, &mut image_manager, config).await
+            add_multi_attach_program(root_db, &mut program, &mut image_manager, config)
         }
         Program::Tcx(_) => {
             let if_name = program.if_name()?;
@@ -325,12 +325,9 @@ async fn add_program_internal(mut program: Program) -> Result<Program, BpfmanErr
 /// ```rust,no_run
 /// use bpfman::remove_program;
 ///
-/// #[tokio::main]
-/// async fn main() {
-///     match remove_program(42).await {
-///         Ok(()) => println!("Program successfully removed."),
-///         Err(e) => eprintln!("Failed to remove program: {:?}", e),
-///     }
+/// match remove_program(42) {
+///     Ok(()) => println!("Program successfully removed."),
+///     Err(e) => eprintln!("Failed to remove program: {:?}", e),
 /// }
 /// ```
 ///
@@ -338,8 +335,8 @@ async fn add_program_internal(mut program: Program) -> Result<Program, BpfmanErr
 ///
 /// This function is asynchronous and should be awaited in an
 /// asynchronous context.
-pub async fn remove_program(id: u32) -> Result<(), BpfmanError> {
-    let (config, root_db) = match setup().await {
+pub fn remove_program(id: u32) -> Result<(), BpfmanError> {
+    let (config, root_db) = match setup() {
         Ok((c, r)) => &(c, r),
         Err(e) => {
             error!("Error: Request to unload program with id {id} but unable to open db: {e}");
@@ -366,7 +363,7 @@ pub async fn remove_program(id: u32) -> Result<(), BpfmanError> {
     let name = prog.get_data().get_name().unwrap_or("not set".to_string());
     info!("Request to unload {kind} program named \"{name}\" with id {id}");
 
-    let result = remove_program_internal(id, config, root_db, prog).await;
+    let result = remove_program_internal(id, config, root_db, prog);
 
     match result {
         Ok(_) => info!("Success: unloaded {kind} program named \"{name}\" with id {id}"),
@@ -375,7 +372,7 @@ pub async fn remove_program(id: u32) -> Result<(), BpfmanError> {
     result
 }
 
-async fn remove_program_internal(
+fn remove_program_internal(
     id: u32,
     config: &Config,
     root_db: &Db,
@@ -406,8 +403,7 @@ async fn remove_program_internal(
                 if_name,
                 direction,
                 nsid,
-            )
-            .await?
+            )?
         }
         Program::Tcx(_) => {
             let nsid = prog.nsid()?;
@@ -473,8 +469,7 @@ async fn remove_program_internal(
 /// use bpfman::{errors::BpfmanError, list_programs, types::ListFilter};
 /// use std::collections::HashMap;
 ///
-/// #[tokio::main]
-/// async fn main() -> Result<(), BpfmanError> {
+/// fn main() -> Result<(), BpfmanError> {
 ///     let program_type = None;
 ///     let metadata_selector = HashMap::new();
 ///     let bpfman_programs_only = true;
@@ -486,7 +481,7 @@ async fn remove_program_internal(
 ///     // program types.
 ///     let filter = ListFilter::new(program_type, metadata_selector, bpfman_programs_only);
 ///
-///     match list_programs(filter).await {
+///     match list_programs(filter) {
 ///         Ok(programs) => {
 ///             for program in programs {
 ///                 match program.get_data().get_id() {
@@ -508,8 +503,8 @@ async fn remove_program_internal(
 ///
 /// This function is asynchronous and should be awaited in an
 /// asynchronous context.
-pub async fn list_programs(filter: ListFilter) -> Result<Vec<Program>, BpfmanError> {
-    let (_, root_db) = &setup().await?;
+pub fn list_programs(filter: ListFilter) -> Result<Vec<Program>, BpfmanError> {
+    let (_, root_db) = &setup()?;
 
     debug!("BpfManager::list_programs()");
 
@@ -586,12 +581,9 @@ pub async fn list_programs(filter: ListFilter) -> Result<Vec<Program>, BpfmanErr
 /// ```rust,no_run
 /// use bpfman::get_program;
 ///
-/// #[tokio::main]
-/// async fn main() {
-///     match get_program(42).await {
-///         Ok(program) => println!("Program info: {:?}", program),
-///         Err(e) => eprintln!("Error fetching program: {:?}", e),
-///     }
+/// match get_program(42) {
+///     Ok(program) => println!("Program info: {:?}", program),
+///     Err(e) => eprintln!("Error fetching program: {:?}", e),
 /// }
 /// ```
 ///
@@ -599,8 +591,8 @@ pub async fn list_programs(filter: ListFilter) -> Result<Vec<Program>, BpfmanErr
 ///
 /// This function is asynchronous and should be awaited in an
 /// asynchronous context.
-pub async fn get_program(id: u32) -> Result<Program, BpfmanError> {
-    let (_, root_db) = &setup().await?;
+pub fn get_program(id: u32) -> Result<Program, BpfmanError> {
+    let (_, root_db) = &setup()?;
 
     debug!("Getting program with id: {id}");
     // If the program was loaded by bpfman, then use it.
@@ -672,21 +664,18 @@ pub async fn get_program(id: u32) -> Result<Program, BpfmanError> {
 /// use bpfman::pull_bytecode;
 /// use bpfman::types::{BytecodeImage, ImagePullPolicy};
 ///
-/// #[tokio::main]
-/// async fn main() {
-///     let image = BytecodeImage {
-///         image_url: "example.com/myrepository/myimage:latest".to_string(),
-///         image_pull_policy: ImagePullPolicy::IfNotPresent,
+/// let image = BytecodeImage {
+///     image_url: "example.com/myrepository/myimage:latest".to_string(),
+///     image_pull_policy: ImagePullPolicy::IfNotPresent,
 ///
-///         // Optional username/password for authentication.
-///         username: Some("username".to_string()),
-///         password: Some("password".to_string()),
-///     };
+///     // Optional username/password for authentication.
+///     username: Some("username".to_string()),
+///     password: Some("password".to_string()),
+/// };
 ///
-///     match pull_bytecode(image).await {
-///         Ok(_) => println!("Image pulled successfully."),
-///         Err(e) => eprintln!("Failed to pull image: {}", e),
-///     }
+/// match pull_bytecode(image) {
+///     Ok(_) => println!("Image pulled successfully."),
+///     Err(e) => eprintln!("Failed to pull image: {}", e),
 /// }
 /// ```
 ///
@@ -694,25 +683,21 @@ pub async fn get_program(id: u32) -> Result<Program, BpfmanError> {
 ///
 /// This function is asynchronous and should be awaited in an
 /// asynchronous context.
-pub async fn pull_bytecode(image: BytecodeImage) -> anyhow::Result<()> {
-    let (_, root_db) = &setup().await?;
-    let image_manager = &mut init_image_manager()
-        .await
-        .map_err(|e| anyhow!(format!("{e}")))?;
+pub fn pull_bytecode(image: BytecodeImage) -> anyhow::Result<()> {
+    let (_, root_db) = &setup()?;
+    let image_manager = &mut init_image_manager().map_err(|e| anyhow!(format!("{e}")))?;
 
-    image_manager
-        .get_image(
-            root_db,
-            &image.image_url,
-            image.image_pull_policy.clone(),
-            image.username.clone(),
-            image.password.clone(),
-        )
-        .await?;
+    image_manager.get_image(
+        root_db,
+        &image.image_url,
+        image.image_pull_policy.clone(),
+        image.username.clone(),
+        image.password.clone(),
+    )?;
     Ok(())
 }
 
-pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanError> {
+pub(crate) fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanError> {
     let database_config = open_config_file().database().to_owned();
     for _ in 0..=database_config.max_retries {
         if let Ok(db) = sled_config.open() {
@@ -723,7 +708,7 @@ pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanE
                 "Database lock is already held, retrying after {} milliseconds",
                 database_config.millisec_delay
             );
-            sleep(Duration::from_millis(database_config.millisec_delay)).await;
+            sleep(Duration::from_millis(database_config.millisec_delay));
         }
     }
     Err(BpfmanError::DatabaseLockError)
@@ -733,9 +718,9 @@ pub(crate) async fn init_database(sled_config: SledConfig) -> Result<Db, BpfmanE
 // an OCI based container registry. It should ONLY be used where needed, to
 // explicitly control when bpfman blocks for network calls to both sigstore's
 // cosign tuf registries and container registries.
-pub(crate) async fn init_image_manager() -> Result<ImageManager, BpfmanError> {
+pub(crate) fn init_image_manager() -> Result<ImageManager, BpfmanError> {
     let signing_config = open_config_file().signing().to_owned();
-    match ImageManager::new(signing_config.verify_enabled, signing_config.allow_unsigned).await {
+    match ImageManager::new(signing_config.verify_enabled, signing_config.allow_unsigned) {
         Ok(im) => Ok(im),
         Err(e) => {
             error!("Unable to initialize ImageManager: {e}");
@@ -1029,13 +1014,13 @@ fn get_programs_iter(root_db: &Db) -> impl Iterator<Item = (u32, Program)> + '_ 
         })
 }
 
-async fn setup() -> Result<(Config, Db), BpfmanError> {
+fn setup() -> Result<(Config, Db), BpfmanError> {
     initialize_bpfman()?;
 
-    Ok((open_config_file(), init_database(get_db_config()).await?))
+    Ok((open_config_file(), init_database(get_db_config())?))
 }
 
-async fn add_multi_attach_program(
+fn add_multi_attach_program(
     root_db: &Db,
     program: &mut Program,
     image_manager: &mut ImageManager,
@@ -1100,7 +1085,6 @@ async fn add_multi_attach_program(
         old_dispatcher,
         image_manager,
     )
-    .await
     .or_else(|e| {
         // If kernel ID was never set there's no pins to cleanup here so just continue
         if program.get_data().get_id().is_ok() {
@@ -1480,7 +1464,7 @@ pub(crate) fn add_single_attach_program(root_db: &Db, p: &mut Program) -> Result
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn remove_multi_attach_program(
+fn remove_multi_attach_program(
     root_db: &Db,
     config: &Config,
     did: DispatcherId,
@@ -1491,7 +1475,7 @@ async fn remove_multi_attach_program(
     nsid: u64,
 ) -> Result<(), BpfmanError> {
     debug!("BpfManager::remove_multi_attach_program()");
-    let mut image_manager = init_image_manager().await?;
+    let mut image_manager = init_image_manager()?;
 
     let next_available_id = num_attached_programs(&did, root_db)? - 1;
     debug!("next_available_id = {next_available_id}");
@@ -1530,8 +1514,7 @@ async fn remove_multi_attach_program(
         next_revision,
         old_dispatcher,
         &mut image_manager,
-    )
-    .await?;
+    )?;
 
     Ok(())
 }

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -27,7 +27,7 @@ pub(crate) enum Dispatcher {
 }
 
 impl Dispatcher {
-    pub async fn new(
+    pub fn new(
         root_db: &Db,
         if_config: Option<&InterfaceConfig>,
         registry_config: &RegistryConfig,
@@ -61,17 +61,14 @@ impl Dispatcher {
                     revision,
                 )?;
 
-                if let Err(res) = x
-                    .load(
-                        root_db,
-                        programs,
-                        old_dispatcher,
-                        image_manager,
-                        registry_config,
-                        p.netns()?,
-                    )
-                    .await
-                {
+                if let Err(res) = x.load(
+                    root_db,
+                    programs,
+                    old_dispatcher,
+                    image_manager,
+                    registry_config,
+                    p.netns()?,
+                ) {
                     let _ = x.delete(root_db, true);
                     return Err(res);
                 }
@@ -87,17 +84,14 @@ impl Dispatcher {
                     revision,
                 )?;
 
-                if let Err(res) = t
-                    .load(
-                        root_db,
-                        programs,
-                        old_dispatcher,
-                        image_manager,
-                        registry_config,
-                        p.netns()?,
-                    )
-                    .await
-                {
+                if let Err(res) = t.load(
+                    root_db,
+                    programs,
+                    old_dispatcher,
+                    image_manager,
+                    registry_config,
+                    p.netns()?,
+                ) {
                     let _ = t.delete(root_db, true);
                     return Err(res);
                 }

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -11,9 +11,7 @@ use aya::{
     },
     Ebpf, EbpfLoader,
 };
-use futures::stream::TryStreamExt;
 use log::debug;
-use netlink_packet_route::tc::TcAttribute;
 use sled::Db;
 
 use crate::{
@@ -24,6 +22,7 @@ use crate::{
     dispatcher_config::TcDispatcherConfig,
     errors::BpfmanError,
     multiprog::Dispatcher,
+    netlink::NetlinkManager,
     oci_utils::image_manager::ImageManager,
     types::{
         BytecodeImage,
@@ -95,7 +94,7 @@ impl TcDispatcher {
         }
     }
 
-    pub(crate) async fn load(
+    pub(crate) fn load(
         &mut self,
         root_db: &Db,
         programs: &mut [Program],
@@ -135,15 +134,13 @@ impl TcDispatcher {
             None,
         );
 
-        let (path, bpf_program_names) = image_manager
-            .get_image(
-                root_db,
-                &image.image_url,
-                image.image_pull_policy.clone(),
-                image.username.clone(),
-                image.password.clone(),
-            )
-            .await?;
+        let (path, bpf_program_names) = image_manager.get_image(
+            root_db,
+            &image.image_url,
+            image.image_pull_policy.clone(),
+            image.username.clone(),
+            image.password.clone(),
+        )?;
 
         if !bpf_program_names.contains(&TC_DISPATCHER_PROGRAM_NAME.to_string()) {
             return Err(BpfmanError::ProgramNotFoundInBytecode {
@@ -180,34 +177,21 @@ impl TcDispatcher {
 
         if let Some(netns) = netns {
             let _netns_guard = enter_netns(netns)?;
-            self.attach(root_db, old_dispatcher).await?;
+            self.attach(root_db, old_dispatcher)?;
         } else {
-            self.attach(root_db, old_dispatcher).await?;
+            self.attach(root_db, old_dispatcher)?;
         };
 
         Ok(())
     }
 
     /// has_qdisc returns true if the qdisc_name is found on the if_index.
-    async fn has_qdisc(qdisc_name: String, if_index: i32) -> Result<bool, anyhow::Error> {
-        let (connection, handle, _) = rtnetlink::new_connection().unwrap();
-        tokio::spawn(connection);
-
-        let mut qdiscs = handle.qdisc().get().execute();
-        while let Some(qdisc_message) = qdiscs.try_next().await? {
-            if qdisc_message.header.index == if_index
-                && qdisc_message
-                    .attributes
-                    .contains(&TcAttribute::Kind(qdisc_name.clone()))
-            {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
+    fn has_qdisc(qdisc_name: String, if_index: i32) -> Result<bool, anyhow::Error> {
+        let nl = NetlinkManager::new();
+        nl.has_qdisc(qdisc_name, if_index)
     }
 
-    async fn attach(
+    fn attach(
         &mut self,
         root_db: &Db,
         old_dispatcher: Option<Dispatcher>,
@@ -229,14 +213,14 @@ impl TcDispatcher {
         // qdisc, we return an error. If the qdisc is a clsact qdisc, we do nothing. Otherwise, we add a clsact qdisc.
 
         // no need to add a new clsact qdisc if one already exists.
-        if TcDispatcher::has_qdisc("clsact".to_string(), if_index as i32).await? {
+        if TcDispatcher::has_qdisc("clsact".to_string(), if_index as i32)? {
             debug!(
                 "clsact qdisc found for if_index {}, no need to add a new clsact qdisc",
                 if_index
             );
 
         // if ingress qdisc exists, return error.
-        } else if TcDispatcher::has_qdisc("ingress".to_string(), if_index as i32).await? {
+        } else if TcDispatcher::has_qdisc("ingress".to_string(), if_index as i32)? {
             debug!("ingress qdisc found for if_index {}", if_index);
             return Err(BpfmanError::InvalidAttach(format!(
                 "Ingress qdisc found for if_index {}",

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -84,7 +84,7 @@ impl XdpDispatcher {
         }
     }
 
-    pub(crate) async fn load(
+    pub(crate) fn load(
         &mut self,
         root_db: &Db,
         programs: &mut [Program],
@@ -130,15 +130,13 @@ impl XdpDispatcher {
             None,
         );
 
-        let (path, bpf_program_names) = image_manager
-            .get_image(
-                root_db,
-                &image.image_url.clone(),
-                image.image_pull_policy.clone(),
-                image.username.clone(),
-                image.password.clone(),
-            )
-            .await?;
+        let (path, bpf_program_names) = image_manager.get_image(
+            root_db,
+            &image.image_url.clone(),
+            image.image_pull_policy.clone(),
+            image.username.clone(),
+            image.password.clone(),
+        )?;
 
         if !bpf_program_names.contains(&XDP_DISPATCHER_PROGRAM_NAME.to_string()) {
             return Err(BpfmanError::ProgramNotFoundInBytecode {

--- a/bpfman/src/netlink.rs
+++ b/bpfman/src/netlink.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use std::{
+    cell::RefCell,
+    fs::File,
+    os::fd::{FromRawFd, OwnedFd, RawFd},
+};
+
+use anyhow::{anyhow, bail};
+use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_route::{
+    tc::{TcAttribute, TcMessage},
+    RouteNetlinkMessage,
+};
+use netlink_sys::{constants::NETLINK_ROUTE, Socket, SocketAddr};
+use nix::{
+    fcntl::{self, OFlag},
+    sched::{setns, CloneFlags},
+    sys::stat::Mode,
+};
+
+pub struct NetlinkManager {
+    sock: RefCell<Socket>,
+}
+
+impl NetlinkManager {
+    pub(crate) fn new() -> Self {
+        NetlinkManager {
+            sock: RefCell::new(init_sock()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_in_namespace(ns: &str) -> Result<Self, anyhow::Error> {
+        Ok(NetlinkManager {
+            sock: RefCell::new(init_namespace_sock(ns)?),
+        })
+    }
+
+    pub(crate) fn has_qdisc(
+        &self,
+        qdisc_name: String,
+        if_index: i32,
+    ) -> Result<bool, anyhow::Error> {
+        let mut req =
+            NetlinkMessage::from(RouteNetlinkMessage::GetQueueDiscipline(TcMessage::default()));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        req.finalize();
+        let mut buf = vec![0; req.header.length as usize];
+        req.serialize(&mut buf);
+
+        let socket = self.sock.borrow_mut();
+        socket
+            .send(&buf, 0)
+            .expect("failed to send netlink message");
+
+        let mut receive_buffer = vec![0; 4096];
+        let mut found = false;
+        loop {
+            let n = socket.recv(&mut &mut receive_buffer[..], 0)?;
+            let bytes = &receive_buffer[..n];
+            let rx_packet: NetlinkMessage<RouteNetlinkMessage> =
+                NetlinkMessage::deserialize(bytes).unwrap();
+            match rx_packet.payload {
+                NetlinkPayload::Done(_) => break,
+                NetlinkPayload::Error(e) => bail!(e),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::GetQueueDiscipline(
+                    qdisc_message,
+                )) => {
+                    if qdisc_message.header.index == if_index
+                        && qdisc_message
+                            .attributes
+                            .contains(&TcAttribute::Kind(qdisc_name.clone()))
+                    {
+                        found = true;
+                        break;
+                    }
+                    continue;
+                }
+                _ => continue,
+            }
+        }
+        Ok(found)
+    }
+}
+
+fn init_sock() -> Socket {
+    let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
+    socket.bind_auto().unwrap();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+    socket
+}
+
+fn init_namespace_sock(namespace: &str) -> Result<Socket, anyhow::Error> {
+    let current_netns = current_netns()?;
+    change_netns_fd(namespace)?;
+    let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
+    socket.bind_auto().unwrap();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+    change_netns_id(current_netns)?;
+    Ok(socket)
+}
+
+pub fn current_netns() -> Result<OwnedFd, anyhow::Error> {
+    // FD is opened with CLOEXEC so it will be closed once we exit
+    // We need to keep this alive so we can get back home
+
+    let fd = fcntl::open(
+        "/proc/self/ns/net",
+        OFlag::O_CLOEXEC | OFlag::O_RDONLY,
+        Mode::empty(),
+    )
+    .map_err(|e| anyhow!(e))? as RawFd;
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    Ok(fd)
+}
+
+fn change_netns_fd(path: &str) -> Result<(), anyhow::Error> {
+    let f = File::open(path)?;
+    setns(f, CloneFlags::CLONE_NEWNET).map_err(|e| anyhow!(e))
+}
+
+fn change_netns_id(fd: OwnedFd) -> Result<(), anyhow::Error> {
+    setns(fd, CloneFlags::CLONE_NEWNET).map_err(|e| anyhow!(e))
+}

--- a/bpfman/src/static_program.rs
+++ b/bpfman/src/static_program.rs
@@ -97,16 +97,16 @@
 // }
 
 // impl StaticProgramManager {
-//     async fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
-//         if let Ok(mut entries) = fs::read_dir(self.path).await {
-//             while let Some(file) = entries.next_entry().await? {
+//     fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
+//         if let Ok(mut entries) = fs::read_dir(self.path) {
+//             while let Some(file) = entries.next_entry()? {
 //                 let path = &file.path();
 //                 // ignore directories
 //                 if path.is_dir() {
 //                     continue;
 //                 }
 
-//                 if let Ok(contents) = read_to_string(path).await {
+//                 if let Ok(contents) = read_to_string(path) {
 //                     let program = toml::from_str(&contents)?;
 
 //                     self.programs.push(program);
@@ -120,7 +120,7 @@
 //     }
 // }
 
-// pub(crate) async fn get_static_programs<P: AsRef<Path>>(
+// pub(crate) fn get_static_programs<P: AsRef<Path>>(
 //     path: P,
 // ) -> Result<Vec<Program>, anyhow::Error> {
 //     let static_program_manager = StaticProgramManager {
@@ -131,7 +131,7 @@
 //     static_program_manager
 //         .clone()
 //         .programs_from_directory()
-//         .await?;
+//         ?;
 
 //     let mut programs: Vec<Program> = Vec::new();
 
@@ -199,7 +199,7 @@
 //     use super::*;
 
 //     #[tokio::test]
-//     async fn test_parse_program_from_invalid_path() {
+//     fn test_parse_program_from_invalid_path() {
 //         let static_program_manager = StaticProgramManager {
 //             path: "/tmp/file.toml".into(),
 //             programs: Vec::new(),
@@ -208,7 +208,7 @@
 //         static_program_manager
 //             .clone()
 //             .programs_from_directory()
-//             .await
+//
 //             .unwrap();
 //         assert!(static_program_manager.programs.is_empty())
 //     }

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -296,7 +296,7 @@ pub enum Location {
 }
 
 impl Location {
-    async fn get_program_bytes(
+    fn get_program_bytes(
         &self,
         root_db: &Db,
         image_manager: &mut ImageManager,
@@ -304,15 +304,13 @@ impl Location {
         match self {
             Location::File(l) => Ok((crate::utils::read(l)?, Vec::new())),
             Location::Image(l) => {
-                let (path, bpf_function_names) = image_manager
-                    .get_image(
-                        root_db,
-                        &l.image_url,
-                        l.image_pull_policy.clone(),
-                        l.username.clone(),
-                        l.password.clone(),
-                    )
-                    .await?;
+                let (path, bpf_function_names) = image_manager.get_image(
+                    root_db,
+                    &l.image_url,
+                    l.image_pull_policy.clone(),
+                    l.username.clone(),
+                    l.password.clone(),
+                )?;
                 let bytecode = image_manager.get_bytecode_from_image_store(root_db, path)?;
 
                 Ok((bytecode, bpf_function_names))
@@ -816,13 +814,13 @@ impl ProgramData {
         sled_get(&self.db_tree, PROGRAM_BYTES)
     }
 
-    pub(crate) async fn set_program_bytes(
+    pub(crate) fn set_program_bytes(
         &mut self,
         root_db: &Db,
         image_manager: &mut ImageManager,
     ) -> Result<(), BpfmanError> {
         let loc = self.get_location()?;
-        match loc.get_program_bytes(root_db, image_manager).await {
+        match loc.get_program_bytes(root_db, image_manager) {
             Err(e) => Err(e),
             Ok((v, s)) => {
                 match loc {

--- a/xtask/public-api/bpfman.txt
+++ b/xtask/public-api/bpfman.txt
@@ -1,7 +1,7 @@
 pub mod bpfman
 pub mod bpfman::errors
 pub enum bpfman::errors::BpfmanError
-pub bpfman::errors::BpfmanError::BpfBytecodeError(crate::oci_utils::ImageError)
+pub bpfman::errors::BpfmanError::BpfBytecodeError(bpfman::oci_utils::ImageError)
 pub bpfman::errors::BpfmanError::BpfFunctionNameNotValid(alloc::string::String)
 pub bpfman::errors::BpfmanError::BpfIOError(std::io::error::Error)
 pub bpfman::errors::BpfmanError::BpfLinkError(aya::programs::links::LinkError)
@@ -1764,8 +1764,8 @@ pub const bpfman::utils::SOCK_MODE: u32
 pub fn bpfman::utils::create_bpffs(directory: &str) -> anyhow::Result<()>
 pub fn bpfman::utils::set_dir_permissions(directory: &str, mode: u32)
 pub fn bpfman::utils::set_file_permissions(path: &std::path::Path, mode: u32)
-pub async fn bpfman::add_program(program: bpfman::types::Program) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
-pub async fn bpfman::get_program(id: u32) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
-pub async fn bpfman::list_programs(filter: bpfman::types::ListFilter) -> core::result::Result<alloc::vec::Vec<bpfman::types::Program>, bpfman::errors::BpfmanError>
-pub async fn bpfman::pull_bytecode(image: bpfman::types::BytecodeImage) -> anyhow::Result<()>
-pub async fn bpfman::remove_program(id: u32) -> core::result::Result<(), bpfman::errors::BpfmanError>
+pub fn bpfman::add_program(program: bpfman::types::Program) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
+pub fn bpfman::get_program(id: u32) -> core::result::Result<bpfman::types::Program, bpfman::errors::BpfmanError>
+pub fn bpfman::list_programs(filter: bpfman::types::ListFilter) -> core::result::Result<alloc::vec::Vec<bpfman::types::Program>, bpfman::errors::BpfmanError>
+pub fn bpfman::pull_bytecode(image: bpfman::types::BytecodeImage) -> anyhow::Result<()>
+pub fn bpfman::remove_program(id: u32) -> core::result::Result<(), bpfman::errors::BpfmanError>


### PR DESCRIPTION
When we moved bpfman to be a oneshot commandline program instead of being a daemon we noted that we should run sync and not async given that a lot of the work we do is synchronous.

The blocking factor here was that sigstore and oci_distribution required us to use tokio.

This was solved by creating a Tokio current thread runtime when required and running any async tasks using `block_on`.

In effect, bpfman can remain sync, while using dependnecies that might require an async runtime like tokio.

This should make debugging bpfman a little easier than it was before and may hopefully help us figure out any data races we may have - regardless of the backend db that we're using.