### PR TITLE
docs: github doc build fails in package lxml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,6 +424,13 @@ jobs:
   build-docs:
     runs-on: ubuntu-24.04
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy \
+            libxml2-dev \
+            libxslt-dev \
+
       - name: Checkout bpfman
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,6 +24,10 @@ jobs:
           go-version: '1.21' # yamllint disable-line rule:quoted-strings
       - name: Install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -qy \
+            libxml2-dev \
+            libxslt-dev \
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ghp-import==2.1.0
 idna==3.4
 importlib-metadata==4.11.4
 Jinja2==3.1.2
-lxml==4.9.3
+lxml==5.0.2
 Markdown==3.3.7
 markdown2==2.4.10
 MarkupSafe==2.1.1


### PR DESCRIPTION
In github actions for building the docs, while installing the dependancies from requirements.txt, lxml started failing. The first failure was:

```
pkg_resources.html
      Building lxml version 4.9.3.
      Building without Cython.
      Error: Please make sure the libxml2 and libxslt development packages are installed.
```

Once libxml2 and libxslt were installed using `apt-get install`, lxml failed with lots of compile errors. Bumping the versionfrom 4.9.3 to 5.0.2 fixed the compile errors.