### PR TITLE
docs: building docs after a PR merges fails

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy \
+            libxml2-dev \
+            libxslt-dev \
+
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # @v4
         with:
           ref: gh-pages
@@ -22,12 +29,8 @@ jobs:
         with:
           # prettier-ignore
           go-version: '1.21' # yamllint disable-line rule:quoted-strings
-      - name: Install dependencies
+      - name: Install requirements
         run: |
-          sudo apt-get update
-          sudo apt-get install -qy \
-            libxml2-dev \
-            libxslt-dev \
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 


### PR DESCRIPTION
When a PR merges, a job from docs-build.yml is run. This is currently failing with:

```
  pip install -r requirements.txt
  shell: /usr/bin/bash -e {0}
  :
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  2to3 python-is-python3

E: Package 'python' has no installation candidate
E: Unable to locate package install
Error: Process completed with exit code 100.
```