### PR TITLE
ci: update scorecard workflow to clarify upload-artifact version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,7 +60,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v3.pre.node20
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # @v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Fixes #1358 

The scorecard workflow referenced
`upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08` with a
misleading comment (`# v3.pre.node20`). This SHA corresponds to
`v4.6.0`, as confirmed by checking the tags in the upstream
repository:

% repoduper https://github.com/actions/upload-artifact.git
% cd upload-artifact
% pwd
/home/aim/src/github.com/actions/upload-artifact
% git tag --contains 65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
v4
v4.6.0

Update the comment to `# @v4` to match other workflows and reflect the
correct version.

Signed-off-by: Andrew McDermott <amcdermo@redhat.com>
