### PR TITLE
disable image verification until sigstore fixed

### DIFF
--- a/bpfman/src/config.rs
+++ b/bpfman/src/config.rs
@@ -50,7 +50,8 @@ impl Default for SigningConfig {
             // Whether to allow unsigned programs by default
             allow_unsigned: true,
             // Whether the signing of programs should be verified by default
-            verify_enabled: true,
+            // DISABLED until https://github.com/bpfman/bpfman/issues/1399 is resolved.
+            verify_enabled: false,
         }
     }
 }


### PR DESCRIPTION
The last signing event from sigstore/root-signing included a change that broke sigstore-rs. bpfman cannot load any images at the moment. Change the interanl default for `verify_enabled` to false until sigstore fixes their issue.

Related: #1399