### PR TITLE
Fix errors deleting tc and xdp programs in network namespaces

### DIFF
--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -50,6 +50,7 @@ impl Dispatcher {
         } else {
             &XdpMode::Drv
         };
+
         let d = match p.kind() {
             ProgramType::Xdp => {
                 let mut x = XdpDispatcher::new(
@@ -84,6 +85,7 @@ impl Dispatcher {
                     if_index,
                     if_name.to_string(),
                     p.nsid()?,
+                    p.netns()?,
                     revision,
                 )?;
 


### PR DESCRIPTION
For TC Programs:
When a TC program is attached within a network namespace, switch to that namespace to detach the TC dispatcher after removing the last program.

For TC and XDP Programs:
If TC or XDP programs are attached within a network namespace, avoid attempting to rebuild and reattach the dispatcher if the namespace has already been deleted when the programs are removed.

Fixes: #1402