### PR TITLE
rpm: RPM builds failing - clang

### DIFF
--- a/bpfman.spec
+++ b/bpfman.spec
@@ -33,6 +33,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  gcc
 BuildRequires:  cmake
+BuildRequires:  clang-devel
 
 # TODO: Generate Provides for all of the vendored dependencies
 


### PR DESCRIPTION
Upstream RPM builds are failing:

```
error: failed to run custom build command for `aws-lc-sys v0.25.1`
:
  --- stderr
  thread 'main' panicked at /builddir/build/BUILD/bpfman-897329fbe2222b97998ac5a13f24b3e1b37d6247/vendor/bindgen/lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
```