### PR TITLE
revert go-xdp-counter change

### DIFF
--- a/examples/config/base/go-xdp-counter/deployment.yaml
+++ b/examples/config/base/go-xdp-counter/deployment.yaml
@@ -1,15 +1,20 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-xdp-counter
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bpfman-app-go-xdp-counter
-  namespace: bpfman
+  namespace: go-xdp-counter
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: go-xdp-counter-ds
-  namespace: bpfman
+  namespace: go-xdp-counter
   labels:
     k8s-app: go-xdp-counter
 spec:


### PR DESCRIPTION
A temporary change to the go-xdp-counter deployment was made to launch the example in the bpfman namespace to test security-profiles-operator logic and the temporary change got accidentally pushed and merged with #1388. Revert those changes.