### PR TITLE
adjust building with aws-lc-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,27 +220,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-fips-sys"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29003a681b2b9465c1139bfb726da452a841a8b025f35953f3bce71139f10b21"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "paste",
- "regex",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
- "aws-lc-fips-sys",
  "aws-lc-sys",
  "paste",
  "untrusted 0.7.1",
@@ -718,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -3640,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
@@ -3800,15 +3784,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { version = "1", default-features = false }
 assert_cmd = { version = "2", default-features = false }
 assert_matches = { version = "1", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-aws-lc-rs = { version = "1.12.2", default-features = false }
+aws-lc-rs = { version = "1", default-features = false }
 aya = { version = "0.13.1", default-features = false }
 aya-obj = { version = "0.2.1", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/rpc/main.rs"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }
-aws-lc-rs = { workspace = true, features = ["bindgen"] }
+aws-lc-rs = { workspace = true, features = ["prebuilt-nasm"] }
 aya = { workspace = true }
 base16ct = { workspace = true, features = ["alloc"] }
 base64 = { workspace = true }

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -32,8 +32,6 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  openssl-devel
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  gcc
-BuildRequires:  cmake
-BuildRequires:  clang-devel
 
 # TODO: Generate Provides for all of the vendored dependencies
 


### PR DESCRIPTION
PR #1406 bumped the version of sigstore from 0.10.0 to 0.11.0. That bump also brought in a dependency on aws-lc-rs. Several subsequent PRs fixed RPM build failures do to aws-lc-rs (#1407 and #1410). Now downstream OpenShift builds of bpfman are failing on certain arches. Attempting a workaround to the downstream failures by changing the asw-lc-rs feature flags.

Ultimately, aws-lc-rs should not be a dependency, see: https://github.com/sigstore/sigstore-rs/issues/436