### PR TITLE
WIP: Migrate from SLED to SQLite – Initial Schema and CRUD Layer

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,14 @@
 [alias]
 xtask = "run --package xtask --"
+
+# To use the system's libsqlite3 (via pkg-config) instead of building
+# SQLite from source, enable the following env override:
+#
+# Note: bpfman/Cargo.toml currently sets:
+#   libsqlite3-sys = { workspace = true, features = ["bundled"] }
+#
+# which compiles SQLite from source. To switch to the system library,
+# remove the "bundled" feature and enable this environment variable.
+#
+# [env]
+# LIBSQLITE3_SYS_USE_PKG_CONFIG = "1"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -14,6 +14,7 @@ header:
       - "**/*.lock"
       - "**/*.yml"
       - "**/*.md"
+      - bpfman/src/db/schema.rs
     comment: on-failure
   - license:
       content: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,10 +451,14 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "comfy-table",
+ "derive_builder",
+ "diesel",
+ "diesel_migrations",
  "env_logger",
  "flate2",
  "hex",
  "lazy_static",
+ "libsqlite3-sys",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
@@ -1147,6 +1151,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "2.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470eb10efc8646313634c99bb1593f402a6434cbd86e266770c6e39219adb86a"
+dependencies = [
+ "chrono",
+ "diesel_derives",
+ "libsqlite3-sys",
+ "time",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "dsl_auto_type",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+dependencies = [
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1219,20 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -2341,6 +2404,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libsystemd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2514,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "migrations_internals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,10 @@ clap = { version = "4", default-features = false }
 clap_complete = { version = "4.5.46", default-features = false }
 clap_mangen = { version = "0.2.26", default-features = false }
 comfy-table = { version = "7.1.4", default-features = false }
+derive_builder = { version = "0.20.2", default-features = false }
 dialoguer = { version = "0.11", default-features = false }
+diesel = { version = "2.2.7", default-features = false }
+diesel_migrations = { version = "2.2.0", default-features = false }
 diff = { version = "0.1.13", default-features = false }
 env_logger = { version = "0.11.8", default-features = false }
 flate2 = { version = "1.1", default-features = false }
@@ -58,6 +61,7 @@ hex = { version = "0.4.3", default-features = false }
 integration-test-macros = { path = "./tests/integration-test-macros" }
 inventory = { version = "0.3", default-features = false }
 lazy_static = { version = "1", default-features = false }
+libsqlite3-sys = { version = "0.31.0", default-features = false }
 libsystemd = { version = "0.7.0", default-features = false }
 log = { version = "0.4", default-features = false }
 netlink-packet-audit = { version = "^0.5", default-features = false }
@@ -75,6 +79,7 @@ predicates = { version = "3.1.3", default-features = false }
 procfs = { version = "0.16.0", default-features = false }
 prost = { version = "0.12.6", default-features = false }
 prost-types = { version = "0.12.6", default-features = false }
+public-api = { version = "0.43.0", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.9", default-features = false }
 regex = { version = "1.11.1", default-features = false }

--- a/bpfman-sqlite
+++ b/bpfman-sqlite
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of bpfman
+
+# bpfman-sqlite — safe sqlite3 wrapper with FK (foreign key) support
+# enabled.
+#
+# SQLite supports foreign key constraints (FKs), which let you express
+# and enforce relationships between tables — for example,
+# automatically deleting rows in a join table when a referenced parent
+# row is deleted (`ON DELETE CASCADE`).
+#
+# However, **foreign key enforcement is disabled by default in
+# SQLite**, including in the `sqlite3` CLI and many script-based
+# invocations. This means constraints like `ON DELETE CASCADE` will be
+# silently ignored unless explicitly enabled.
+#
+# This wrapper ensures FK support is always turned on by inserting the
+# following directive before executing any commands:
+#
+#     PRAGMA foreign_keys = ON;
+#
+# In bpfman application code (e.g., via Diesel), this pragma is
+# enabled automatically during connection setup (see
+# `establish_database_connection()`). But shell users and scripts must
+# handle this themselves.
+#
+# Example (interactive):
+#
+#     $ bpfman-sqlite /var/lib/bpfman/db.sqlite
+#     sqlite> DELETE FROM bpf_programs WHERE id = 123;
+#
+# Example (scripted):
+#
+#     $ bpfman-sqlite /var/lib/bpfman/db.sqlite "DELETE FROM bpf_programs WHERE id = 123;"
+#
+# If you don’t enable this pragma, foreign key constraints will not
+# work — e.g., dependent rows will remain, and referential integrity
+# will be silently broken.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+command -v sqlite3 >/dev/null || {
+    echo "Error: sqlite3 not found in PATH." >&2
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    echo "Usage: ${0##*/} /path/to/db.sqlite [SQLITE-ARGS...]" >&2
+    exit 1
+fi
+
+db="$1"
+shift
+
+init_file=$(mktemp)
+trap 'rm -f "$init_file"' EXIT
+
+echo 'PRAGMA foreign_keys = ON;' > "$init_file"
+
+exec sqlite3 -init "$init_file" "$db" "$@"

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -39,10 +39,19 @@ clap = { workspace = true, features = [
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
 comfy-table = { workspace = true, features = ["tty"] }
+derive_builder = { workspace = true, features = ["std"] }
+diesel = { workspace = true, features = [
+    "32-column-tables",
+    "chrono",
+    "returning_clauses_for_sqlite_3_35",
+    "sqlite",
+] }
+diesel_migrations = { workspace = true, features = ["sqlite"] }
 env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
 hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
+libsqlite3-sys = { workspace = true, features = ["bundled"] }
 log = { workspace = true }
 netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }

--- a/bpfman/build.rs
+++ b/bpfman/build.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=diesel.toml");
+}

--- a/bpfman/diesel.toml
+++ b/bpfman/diesel.toml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of bpfman
+
+[print_schema]
+file = "src/db/schema.rs"
+with_docs = false
+
+# https://github.com/diesel-rs/diesel/issues/852.
+# https://github.com/diesel-rs/diesel/pull/3940.
+sqlite_integer_primary_key_is_bigint = true
+
+[migrations_directory]
+dir = "migrations"

--- a/bpfman/generate-diesel-schema
+++ b/bpfman/generate-diesel-schema
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of bpfman
+
+set -euo pipefail
+
+script_dir="$(dirname "$0")"
+db=$(mktemp)
+trap 'rm -rf "$db"' EXIT
+
+export DATABASE_URL="$db"
+
+diesel migration run \
+       --migration-dir "$script_dir/migrations" \
+       --config-file "$script_dir/diesel.toml"
+
+diesel print-schema \
+       --config-file "$script_dir/diesel.toml" \
+       > "$script_dir/src/db/schema.rs"

--- a/bpfman/migrations/2025-02-12-140102_create_initial_schema/down.sql
+++ b/bpfman/migrations/2025-02-12-140102_create_initial_schema/down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright Authors of bpfman
+
+-- This file should undo anything in `up.sql`.
+DROP TABLE IF EXISTS bpf_links;
+DROP TABLE IF EXISTS bpf_maps;
+DROP TABLE IF EXISTS bpf_program_maps;
+DROP TABLE IF EXISTS bpf_programs;

--- a/bpfman/migrations/2025-02-12-140102_create_initial_schema/up.sql
+++ b/bpfman/migrations/2025-02-12-140102_create_initial_schema/up.sql
@@ -1,0 +1,421 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright Authors of bpfman
+
+-- =============================================================================
+-- bpfman Database Schema: Design Notes and Guidelines
+-- =============================================================================
+--
+-- This schema is designed to store and manage metadata for eBPF programs,
+-- links, and maps. It also enforces referential integrity via foreign key
+-- constraints (ensure that `PRAGMA foreign_keys = ON;` is set for each
+-- session).
+--
+-- --- Kernel IDs and Unsigned Integers ---
+--
+-- Kernel interfaces (via Aya) commonly return unsigned 32-bit values
+-- (u32). In this schema, these values are stored in BIGINT columns.
+-- This is safe because:
+--
+--   1. A u32 value (0 to 4,294,967,295) can be represented within a
+--      64-bit signed integer (i64) without loss of precision.
+--   2. All kernel IDs (and other identifiers) are handled as i64 in the
+--      database.
+--
+-- In the Rust code, a custom wrapper type, `KernelU32`, is used to
+-- represent kernel-provided u32 values. The `KernelU32` type provides:
+--
+--   - Runtime type safety by checking at runtime when converting from i64
+--     to u32, ensuring that the value does not exceed u32::MAX.
+--
+--   - Diesel integration by implementing the necessary traits (e.g.,
+--     `ToSql<BigInt, Sqlite>` and `FromSql<BigInt, Sqlite>`) so that it
+--     can be used directly with Diesel.
+--
+-- When designing tables that need to store kernel u32 values (such as program
+-- IDs, map owner IDs, or other kernel-related fields), declare the column as
+-- BIGINT in the schema and use `KernelU32` in the corresponding Rust structs.
+-- For primary keys that originate from the kernel (which are u32), using
+-- `KernelU32` is recommended.
+--
+-- --- Full-Width Unsigned Integers ---
+--
+-- SQLite's native INTEGER type is a 64-bit signed integer, which is
+-- insufficient for Rust's `u64` (or wider) when exact, lossless round-
+-- tripping is required. For such values, BLOB columns are used in SQLite.
+--
+-- In the Rust code, wrapper types (e.g., `U64Blob` and `U128Blob`) are
+-- provided that:
+--
+--   - Convert the primitive into a fixed-length, big-endian byte array on
+--     write.
+--
+--   - Convert back to the primitive on read, failing with a descriptive
+--     error if the stored blob's length does not match the expected size.
+--
+--   - Preserve numeric ordering when compared lexicographically in SQLite.
+--
+-- Use these wrappers when a full 64-bit (or wider) unsigned integer must be
+-- stored.
+--
+-- --- General Guidelines ---
+--
+-- * Row IDs and other kernel-provided IDs from Aya are u32 values that are
+--   stored as BIGINT (i64) in SQLite, with conversion handled by `KernelU32`.
+--
+-- * If a full u64 value needs to be represented, declare the column as BLOB
+--   and use the appropriate wrapper (e.g., `U64Blob`) in the Rust model.
+--
+-- * Diesel models should have types that mirror the schema:
+--     - BIGINT columns for kernel u32 values (using KernelU32).
+--     - BLOB columns for larger unsigned values (using U64Blob, U128Blob, etc.).
+--
+-- * Ensure that all conversions are safe:
+--     - Use `.try_u32()` for fallible conversions from KernelU32 when passing
+--       values back to kernel APIs.
+--     - Use the methods provided by the wrapper types (e.g., `get()`)
+--       to retrieve their inner values.
+--
+-- --- Example: Representing a Kernel u32 Value ---
+--
+-- Consider a kernel that returns a u32 value (for example, 1234). In the
+-- database, this value is stored in a BIGINT column (i64). In the Rust code,
+-- such values are represented using the `KernelU32` wrapper, which enforces
+-- runtime safety and provides Diesel integration.
+--
+-- Database schema snippet:
+--
+--   CREATE TABLE example_table (
+--       id         BIGINT PRIMARY KEY NOT NULL,
+--       kernel_id  BIGINT NOT NULL  -- Kernel-provided u32 stored as BIGINT
+--   );
+--
+-- Rust model:
+--
+--   #[derive(Queryable, Insertable)]
+--   #[diesel(table_name = example_table)]
+--   pub struct Example {
+--       pub id: i64,
+--       pub kernel_id: KernelU32,
+--   }
+--
+-- When inserting a new row, a u32 value is converted to KernelU32:
+--
+--   let example = Example {
+--       id: 1,
+--       kernel_id: 1234u32.into(),  // Converts u32 to KernelU32 via From<u32>
+--   };
+--
+-- When reading from the database, Diesel converts the BIGINT value into a
+-- KernelU32 using the FromSql implementation, ensuring that the value is
+-- within the valid u32 range.
+
+-- Enable and enforce foreign key support in SQLite.
+PRAGMA foreign_keys = ON;
+--
+-- NOTE: SQLite does not enforce foreign key constraints unless
+--       `PRAGMA foreign_keys` is explicitly enabled. This includes
+--       rules like ON DELETE CASCADE and ON UPDATE CASCADE.
+--
+-- In application code (e.g., via Diesel), this PRAGMA is set at
+-- connection time for bpfman clients (see
+-- establish_database_connection()).
+--
+-- But if you're using the SQLite CLI or scripts, foreign key
+-- constraints are **disabled by default** and must be enabled
+-- manually **per session**:
+--
+-- Example in the SQLite shell:
+--
+--     $ sqlite3 /var/lib/bpfman/db.sqlite
+--     sqlite> PRAGMA foreign_keys = ON;
+--
+-- You must run this before executing any statements that rely on
+-- foreign key constraints, or else they will be silently ignored.
+--
+-- Script-friendly check (Bash snippet):
+--
+--    if [ "$(sqlite3 /var/lib/bpfman/db.sqlite 'PRAGMA foreign_keys')" != "1" ]; then
+--        echo "Foreign key constraints are NOT enabled for this session."
+--        echo "Add 'PRAGMA foreign_keys = ON;' before executing any SQL."
+--        exit 1
+--    fi
+--
+-- Failing to enable this pragma can result in orphaned rows and
+-- broken referential integrity — foreign key constraints will not
+-- work even though they are declared here in the schema.
+
+-- Table for BPF Programs.
+--
+-- A BPF program is the central object loaded into the kernel. The
+-- kernel assigns each program a unique 32-bit (u32) ID. In SQLite,
+-- declaring the id as an BIGINT PRIMARY KEY makes it an alias for
+-- the rowid. This table stores metadata about the program along with
+-- the actual program binary in a BLOB.
+CREATE TABLE bpf_programs (
+    id BIGINT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+
+    -- Program type discriminator (lowercase).
+    kind TEXT NOT NULL
+        CHECK(kind IN ('xdp', 'tc', 'tcx', 'tracepoint', 'kprobe', 'uprobe', 'fentry', 'fexit')),
+
+    -- State: whether the program is pre-loaded or loaded
+    state TEXT NOT NULL
+        CHECK(state IN ('pre_load', 'loaded')),
+
+    -- Location info: the program comes either from a file or an image.
+    location_type TEXT NOT NULL
+        CHECK(location_type IN ('file', 'image')),
+    file_path TEXT,          -- Required if location_type = 'file'
+    image_url TEXT,          -- Required if location_type = 'image'
+    image_pull_policy TEXT,  -- Only for image-based programs
+    username TEXT,           -- Optional for image-based programs
+    password TEXT,           -- Optional for image-based programs
+
+    -- Additional location/pinning info.
+    map_pin_path TEXT NOT NULL,
+
+    -- Map owner.
+    map_owner_id BIGINT,
+
+    -- The program binary. (For our purposes, this is NOT NULL.)
+    program_bytes BLOB NOT NULL,
+
+    -- Arbitrary key/value data stored as JSON.
+    metadata TEXT,
+    global_data TEXT,
+
+    -- Type-specific fields:
+    retprobe BOOLEAN,  -- Only for kprobe/uprobe; must be non-null when applicable.
+    fn_name TEXT,      -- Only for fentry/fexit; must be non-null when applicable.
+
+    -- Kernel information (populated after the program is loaded into the kernel).
+    kernel_name TEXT,
+    kernel_program_type BIGINT,
+    kernel_loaded_at TEXT,    -- ISO8601 timestamp string
+    kernel_tag BLOB NOT NULL,
+    kernel_gpl_compatible BOOLEAN,
+    kernel_btf_id BIGINT,
+    kernel_bytes_xlated BIGINT,
+    kernel_jited BOOLEAN,
+    kernel_bytes_jited BIGINT,
+    kernel_verified_insns BIGINT,
+    kernel_bytes_memlock BIGINT,
+
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+
+    -- Check: if location_type is 'file' then file_path must be provided;
+    --        if 'image' then image_url must be provided.
+    CHECK (
+      (location_type = 'file' AND file_path IS NOT NULL)
+      OR (location_type = 'image' AND image_url IS NOT NULL)
+    ),
+
+    -- Check: if kind is 'fentry' or 'fexit', then fn_name must be provided.
+    CHECK (
+      (kind IN ('fentry', 'fexit') AND fn_name IS NOT NULL)
+      OR (kind NOT IN ('fentry', 'fexit'))
+    ),
+
+    -- Check: if kind is 'kprobe' or 'uprobe', then retprobe must be provided.
+    CHECK (
+      (kind IN ('kprobe', 'uprobe') AND retprobe IS NOT NULL)
+      OR (kind NOT IN ('kprobe', 'uprobe'))
+    )
+);
+
+-- Table for BPF Links.
+--
+-- A BPF link represents a specific attachment of a program to a
+-- target (e.g. a network interface, cgroup, etc.). Although a program
+-- may create several links (e.g. attaching to multiple interfaces),
+-- each link is an independent object associated with exactly one
+-- program. Therefore, we model this as a one-to-many relationship:
+-- each link row includes a foreign key referencing its owning
+-- program.
+CREATE TABLE bpf_links (
+    id BIGINT PRIMARY KEY NOT NULL,
+    program_id BIGINT NOT NULL REFERENCES bpf_programs(id) ON DELETE CASCADE,
+    link_type TEXT,
+    target TEXT,
+    state TEXT NOT NULL,  -- Expected values: 'pre_attach' or 'attached'
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+);
+
+-- Table for BPF Maps.
+--
+-- A BPF map stores key-value data that a BPF program may use. A
+-- single map can be shared among multiple programs. For this reason,
+-- we separate the identity of a map from its association with a
+-- program. The bpf_maps table stores one record per unique map (with
+-- the kernel's map ID, which is a 32-bit unsigned integer stored as
+-- an BIGINT PRIMARY KEY).
+CREATE TABLE bpf_maps (
+    id BIGINT PRIMARY KEY NOT NULL,  -- Kernel's BPF map ID (u32)
+    name TEXT NOT NULL,
+    map_type TEXT,
+    key_size BIGINT NOT NULL,
+    value_size BIGINT NOT NULL,
+    max_entries BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+);
+
+-- Join Table for the Many-to-Many Relationship between Programs and
+-- Maps.
+--
+-- A single BPF map may be shared by multiple programs, and a program
+-- may use multiple maps. This intermediary table models that
+-- relationship. Each row links a program (via program_id) to a map
+-- (via map_id), with the composite primary key enforcing uniqueness.
+--
+-- Deletion behaviour:
+-- - If a program is deleted from bpf_programs, all associated rows
+--   in this table are automatically removed.
+-- - If a map is deleted from bpf_maps, all associated rows in this
+--   table are also removed.
+--
+-- This cascading behaviour is enforced via ON DELETE CASCADE on both
+-- foreign keys, ensuring referential integrity without manual
+-- cleanup. Note: PRAGMA foreign_keys = ON must be enabled for this to
+-- work.
+CREATE TABLE bpf_program_maps (
+    program_id BIGINT NOT NULL REFERENCES bpf_programs(id) ON DELETE CASCADE,
+    map_id     BIGINT NOT NULL REFERENCES bpf_maps(id)     ON DELETE CASCADE,
+    PRIMARY KEY (program_id, map_id)
+);
+
+-- Trigger to automatically delete unused BPF maps.
+--
+-- Purpose:
+--
+-- When a BPF program is deleted, we want to clean up any maps it was
+-- using — but only if no other programs are still using those maps.
+-- This trigger ensures unused maps are cleaned up automatically.
+--
+-- Tables involved:
+-- - `bpf_programs`:     Metadata for BPF programs.
+-- - `bpf_maps`:         Metadata for BPF maps.
+-- - `bpf_program_maps`: Join table linking programs to maps.
+--
+-- This is a many-to-many relationship:
+--   - A program may use multiple maps.
+--   - A map may be used by multiple programs.
+--
+-- The join table (i.e., bpf_program_maps) has ON DELETE CASCADE set,
+-- so when a program is deleted, any associated rows in
+-- `bpf_program_maps` are also deleted. However, maps themselves are
+-- not deleted unless **no programs** use them. This trigger enforces
+-- that.
+--
+-- How the trigger works:
+--
+-- 1. The trigger runs **after** a row is deleted from
+--    `bpf_program_maps`. That means some program is no longer using a
+--    specific map.
+--
+-- 2. It checks whether any other rows in `bpf_program_maps` still
+--    reference the same map:
+--
+--       SELECT 1 FROM bpf_program_maps WHERE map_id = OLD.map_id
+--
+--    This query:
+--    - returns **rows** if any other program still uses the map;
+--    - returns **nothing** if the map is now unused.
+--
+--    We wrap this in `NOT EXISTS (...)` to ask:
+--      "Is this map now unused?"
+--
+-- 3. If the answer is yes (no rows found), the trigger deletes the
+--    map from `bpf_maps`.
+--
+-- Why SELECT 1?
+-- - `SELECT 1` is a lightweight way to test for existence of rows.
+-- - It doesn’t matter what we select; we just care whether any rows exist.
+--
+-- Real-world examples:
+--
+--   Case 1: The map is still in use
+--   -------------------------------
+--     bpf_program_maps:
+--       program_id | map_id
+--       -----------|-------
+--       101        | 300
+--       102        | 300
+--
+--     Deleting program 101 -> removes row (101, 300)
+--     SELECT 1 FROM bpf_program_maps WHERE map_id = 300 -> returns row for 102
+--     -> NOT EXISTS = false -> map 300 is **not** deleted
+--
+--   Case 2: The map is now unused
+--   -----------------------------
+--     bpf_program_maps:
+--       program_id | map_id
+--       -----------|-------
+--       103        | 301
+--
+--     Deleting program 103 -> removes row (103, 301)
+--     SELECT 1 FROM bpf_program_maps WHERE map_id = 301 -> returns nothing
+--     -> NOT EXISTS = true -> map 301 **is deleted**
+--
+-- Why implement this in SQL?
+--
+-- 1. It avoids putting this logic in application code.
+--
+-- 2. It guarantees correctness even if multiple programs are deleted
+--    or manipulated outside the application (e.g., SQL maintenance
+--    using the SQLite shell).
+--
+-- 3. It’s easier to reason about and maintain at the database level.
+--
+-- Summary:
+--
+-- This trigger ensures that `bpf_maps` contains only maps that are
+-- still in use by at least one program. It enforces garbage
+-- collection of orphaned maps without requiring external application
+-- logic. This trigger ensures `bpf_maps` never contains stale, unused
+-- maps.
+CREATE TRIGGER delete_unused_map_after_program_unlink
+AFTER DELETE ON bpf_program_maps
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1 FROM bpf_program_maps WHERE map_id = OLD.map_id
+)
+BEGIN
+  DELETE FROM bpf_maps WHERE id = OLD.map_id;
+END;
+
+-- Trigger for bpf_programs.
+CREATE TRIGGER update_bpf_programs_updated_at
+AFTER UPDATE ON bpf_programs
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE bpf_programs
+  SET updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
+  WHERE id = NEW.id;
+END;
+
+-- Trigger for bpf_links.
+CREATE TRIGGER update_bpf_links_updated_at
+AFTER UPDATE ON bpf_links
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE bpf_links
+  SET updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
+  WHERE id = NEW.id;
+END;
+
+-- Trigger for bpf_maps.
+CREATE TRIGGER update_bpf_maps_updated_at
+AFTER UPDATE ON bpf_maps
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE bpf_maps
+  SET updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
+  WHERE id = NEW.id;
+END;

--- a/bpfman/migrations/2025-04-03-140102_add_indices/down.sql
+++ b/bpfman/migrations/2025-04-03-140102_add_indices/down.sql
@@ -1,0 +1,12 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright Authors of bpfman
+
+-- Drop indexes added for performance improvements.
+
+DROP INDEX IF EXISTS idx_program_maps_map_id;
+DROP INDEX IF EXISTS idx_links_program_id;
+DROP INDEX IF EXISTS idx_programs_kind;
+DROP INDEX IF EXISTS idx_programs_state;
+DROP INDEX IF EXISTS idx_programs_kernel_type;
+DROP INDEX IF EXISTS idx_maps_name;
+DROP INDEX IF EXISTS idx_programs_name;

--- a/bpfman/migrations/2025-04-03-140102_add_indices/up.sql
+++ b/bpfman/migrations/2025-04-03-140102_add_indices/up.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright Authors of bpfman
+
+-- Index for quick lookups of all maps used by programs.
+CREATE INDEX idx_program_maps_map_id ON bpf_program_maps(map_id);
+
+-- Index for querying all links associated with a program.
+CREATE INDEX idx_links_program_id ON bpf_links(program_id);
+
+-- Index to filter or group programs by kind.
+CREATE INDEX idx_programs_kind ON bpf_programs(kind);
+
+-- Index to filter programs by state (e.g. loaded).
+CREATE INDEX idx_programs_state ON bpf_programs(state);
+
+-- Index for kernel program type lookups.
+CREATE INDEX idx_programs_kernel_type ON bpf_programs(kernel_program_type);
+
+-- Index for fast lookups by map name.
+CREATE INDEX idx_maps_name ON bpf_maps(name);
+
+-- Index for fast lookups by program name.
+CREATE INDEX idx_programs_name ON bpf_programs(name);

--- a/bpfman/src/db/mod.rs
+++ b/bpfman/src/db/mod.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Top-level database module.
+//!
+//! This module re-exports types and helpers used throughout the
+//! crate, flattening the module structure so consumers can simply
+//! use crate::db::KernelU32;
+//!
+//! The `types` module and its internal submodules are kept private to
+//! encourage consistent usage and avoid exposing internal structure.
+//!
+//! If a type appears in `crate::db`, it's part of the crate's
+//! intended public interface.
+
+use diesel::{Connection, prelude::*, sqlite::SqliteConnection};
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+
+use crate::BpfmanError;
+
+pub mod models;
+pub mod prelude;
+pub mod schema;
+mod types;
+pub use models::*;
+pub use schema::{bpf_links, bpf_maps, bpf_program_maps, bpf_programs};
+// Re-export database column types and wrappers for public use. These
+// types are defined in the private `types` module and exposed here to
+// flatten the db module API.
+//
+// See also: `crate::db::prelude` for glob imports.
+pub use types::{KernelU32, U8Blob, U16Blob, U32Blob, U64Blob, U128Blob, UxBlobError};
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+/// Internal note: This function is `pub` only to support integration
+/// tests and CLI binaries. It is not part of the stable public API
+/// and should be considered an implementation detail.
+///
+/// Ideally, this would remain `pub(crate)`, but Rust’s visibility
+/// rules require it to be `pub` for use outside the crate (e.g., in
+/// `src/bin/` or integration tests).
+///
+/// Why this is considered undesirable:
+///
+/// - Exposes low-level persistence machinery that is intended for
+///   internal use only.
+/// - Requires external consumers (e.g. tests, binaries) to be aware of
+///   Diesel internals, PRAGMA settings, and connection semantics.
+/// - Inconsistent with the higher-level abstractions provided elsewhere
+///   (such as `load_ebpf_programs`, which encapsulates both kernel and
+///   DB logic).
+/// - Becomes an API liability if the backing storage engine (e.g.
+///   Diesel) is ever swapped out or wrapped differently.
+///
+/// ---
+///
+/// Establish a new SQLite database connection and run pending
+/// migrations.
+///
+/// This function connects to the SQLite database at the provided URL,
+/// applies standard PRAGMA settings, and runs any unapplied schema
+/// migrations embedded in the binary.
+///
+/// The following PRAGMAs are set to configure the database's
+/// behaviour:
+///
+/// - `journal_mode = WAL`: Enables Write-Ahead Logging for improved
+///   concurrency and performance in multi-writer scenarios.
+/// - `busy_timeout = 5000`: Sets a 5-second timeout when the database
+///   is locked, to avoid immediate failure under contention.
+/// - `foreign_keys = ON`: Enforces foreign key constraints at the
+///   database level.
+///
+/// After applying PRAGMAs, all pending migrations are executed using
+/// `diesel_migrations::MigrationHarness::run_pending_migrations`.
+///
+/// # Arguments
+///
+/// * `database_url` – Path or URI to the SQLite database file.
+///
+/// # Errors
+///
+/// Returns a [`BpfmanError`] if:
+///
+/// - The connection cannot be established.
+/// - Any of the PRAGMA statements fail to execute.
+/// - One or more schema migrations fail to apply.
+pub fn establish_database_connection(database_url: &str) -> Result<SqliteConnection, BpfmanError> {
+    let mut conn = SqliteConnection::establish(database_url).map_err(|e| {
+        BpfmanError::SqliteConnectionError {
+            database_url: database_url.to_string(),
+            source: e,
+        }
+    })?;
+
+    diesel::sql_query("PRAGMA journal_mode = WAL")
+        .execute(&mut conn)
+        .map_err(|e| BpfmanError::SqliteQueryError {
+            database_url: database_url.to_string(),
+            context: "setting WAL journal mode".into(),
+            source: e,
+        })?;
+
+    diesel::sql_query("PRAGMA busy_timeout = 5000")
+        .execute(&mut conn)
+        .map_err(|e| BpfmanError::SqliteQueryError {
+            database_url: database_url.to_string(),
+            context: "setting busy timeout".into(),
+            source: e,
+        })?;
+
+    diesel::sql_query("PRAGMA foreign_keys = ON")
+        .execute(&mut conn)
+        .map_err(|e| BpfmanError::SqliteQueryError {
+            database_url: database_url.to_string(),
+            context: "enabling foreign key support".into(),
+            source: e,
+        })?;
+
+    conn.run_pending_migrations(MIGRATIONS)
+        .map_err(|e| BpfmanError::SqliteMigrationError {
+            database_url: database_url.to_string(),
+            source: e,
+        })?;
+
+    Ok(conn)
+}

--- a/bpfman/src/db/models/bpf_link.rs
+++ b/bpfman/src/db/models/bpf_link.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+use crate::db::KernelU32;
+
+/// A persisted record for a BPF link that associates a program with a target.
+#[derive(Debug, AsChangeset, Insertable, Identifiable, Queryable)]
+#[diesel(belongs_to(BpfProgram, foreign_key = program_id))]
+#[diesel(table_name = crate::db::bpf_links)]
+#[diesel(primary_key(id))]
+pub struct BpfLink {
+    pub id: KernelU32,
+    pub program_id: KernelU32,
+    pub link_type: Option<String>,
+    pub target: Option<String>,
+    pub state: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl BpfLink {
+    /// Inserts a new BPF link record.
+    pub fn insert_record(conn: &mut SqliteConnection, link: &BpfLink) -> QueryResult<()> {
+        diesel::insert_into(crate::db::bpf_links::table)
+            .values(link)
+            .execute(conn)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Default for BpfLink {
+    fn default() -> Self {
+        Self {
+            id: Default::default(),
+            program_id: Default::default(),
+            link_type: None,
+            target: None,
+            state: "".to_owned(),
+            created_at: Default::default(),
+            updated_at: Default::default(),
+        }
+    }
+}

--- a/bpfman/src/db/models/bpf_map.rs
+++ b/bpfman/src/db/models/bpf_map.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+use crate::db::KernelU32;
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    AsChangeset,
+    Insertable,
+    Identifiable,
+    Queryable,
+)]
+#[diesel(table_name = crate::db::bpf_maps)]
+#[diesel(primary_key(id))]
+pub struct BpfMap {
+    pub id: KernelU32,
+    pub name: String,
+    pub map_type: Option<String>,
+    pub key_size: KernelU32,
+    pub value_size: KernelU32,
+    pub max_entries: KernelU32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl BpfMap {
+    /// Inserts a map record into the database, ignoring conflicts if
+    /// the record already exists.
+    ///
+    /// This method is particularly useful when dealing with shared
+    /// maps between multiple programs. If a map with the same ID
+    /// already exists in the database, the insertion is silently
+    /// skipped without raising an error.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn` - A mutable reference to an active SQLite connection
+    /// * `map` - The BpfMap record to insert
+    ///
+    /// # Returns
+    ///
+    /// * `QueryResult<usize>` - On success, returns the number of rows affected (1 if inserted, 0 if skipped).
+    /// * On failure, returns a Diesel error (e.g., for connection
+    ///   issues or constraint violations).
+    pub fn insert_record_on_conflict_do_nothing(
+        conn: &mut SqliteConnection,
+        map: &BpfMap,
+    ) -> QueryResult<usize> {
+        diesel::insert_into(crate::db::bpf_maps::table)
+            .values(map)
+            .on_conflict_do_nothing()
+            .execute(conn)
+    }
+}
+
+#[cfg(test)]
+impl Default for BpfMap {
+    fn default() -> Self {
+        Self {
+            id: 0u32.into(),
+            name: "".to_owned(),
+            map_type: None,
+            key_size: 0u32.into(),
+            value_size: 0u32.into(),
+            max_entries: 0u32.into(),
+            created_at: Default::default(),
+            updated_at: Default::default(),
+        }
+    }
+}

--- a/bpfman/src/db/models/bpf_program.rs
+++ b/bpfman/src/db/models/bpf_program.rs
@@ -1,0 +1,788 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+use crate::db::{KernelU32, U64Blob};
+
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    AsChangeset,
+    Insertable,
+    Identifiable,
+    Queryable,
+)]
+#[diesel(table_name = crate::db::bpf_programs)]
+#[diesel(primary_key(id))]
+pub struct BpfProgram {
+    pub id: KernelU32,
+    pub name: String,
+    pub kind: String,
+    pub state: String,
+    pub location_type: String,
+    pub file_path: Option<String>,
+    pub image_url: Option<String>,
+    pub image_pull_policy: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub map_pin_path: String,
+    pub map_owner_id: Option<KernelU32>,
+    #[diesel(sql_type = diesel::sql_types::Binary)]
+    #[serde(skip)]
+    pub program_bytes: Vec<u8>,
+    pub metadata: Option<String>,
+    pub global_data: Option<String>,
+    pub retprobe: Option<bool>,
+    pub fn_name: Option<String>,
+    pub kernel_name: Option<String>,
+    pub kernel_program_type: Option<KernelU32>,
+    pub kernel_loaded_at: Option<String>,
+    pub kernel_tag: U64Blob,
+    pub kernel_gpl_compatible: Option<bool>,
+    pub kernel_btf_id: Option<KernelU32>,
+    pub kernel_bytes_xlated: Option<KernelU32>,
+    pub kernel_jited: Option<bool>,
+    pub kernel_bytes_jited: Option<KernelU32>,
+    pub kernel_verified_insns: Option<KernelU32>,
+    pub kernel_bytes_memlock: Option<KernelU32>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl BpfProgram {
+    pub fn insert_record(
+        conn: &mut SqliteConnection,
+        program: &BpfProgram,
+    ) -> QueryResult<BpfProgram> {
+        diesel::insert_into(crate::db::bpf_programs::table)
+            .values(program)
+            .returning(crate::db::bpf_programs::all_columns)
+            .get_result(conn)
+    }
+
+    pub fn find_all(conn: &mut SqliteConnection) -> QueryResult<Vec<BpfProgram>> {
+        use crate::db::bpf_programs::dsl::*;
+        bpf_programs.load(conn)
+    }
+
+    pub fn find_record(
+        conn: &mut SqliteConnection,
+        search_id: KernelU32,
+    ) -> QueryResult<BpfProgram> {
+        use crate::db::bpf_programs::dsl::*;
+        bpf_programs.filter(id.eq(search_id)).first(conn)
+    }
+
+    pub fn update_record(&mut self, conn: &mut SqliteConnection) -> QueryResult<()> {
+        use crate::db::bpf_programs::dsl::*;
+        let updated: BpfProgram = diesel::update(bpf_programs.filter(id.eq(self.id)))
+            .set(&*self)
+            .get_result(conn)?;
+        *self = updated;
+        Ok(())
+    }
+
+    pub fn delete_record(conn: &mut SqliteConnection, delete_id: KernelU32) -> QueryResult<bool> {
+        use crate::db::bpf_programs::dsl::*;
+        let num_deleted = diesel::delete(bpf_programs.filter(id.eq(delete_id))).execute(conn)?;
+        Ok(num_deleted > 0)
+    }
+}
+
+#[cfg(test)]
+impl Default for BpfProgram {
+    fn default() -> Self {
+        Self {
+            id: 0u32.into(),
+            name: "".to_owned(),
+            kind: "".to_owned(),
+            state: "".to_owned(),
+            location_type: "".to_owned(),
+            file_path: None,
+            image_url: None,
+            image_pull_policy: None,
+            username: None,
+            password: None,
+            map_pin_path: "".to_owned(),
+            map_owner_id: None,
+            program_bytes: vec![],
+            metadata: None,
+            global_data: None,
+            retprobe: None,
+            fn_name: None,
+            kernel_name: None,
+            kernel_program_type: None,
+            kernel_loaded_at: None,
+            kernel_tag: U64Blob::from(0u64),
+            kernel_gpl_compatible: None,
+            kernel_btf_id: None,
+            kernel_bytes_xlated: None,
+            kernel_jited: None,
+            kernel_bytes_jited: None,
+            kernel_verified_insns: None,
+            kernel_bytes_memlock: None,
+            created_at: Default::default(),
+            updated_at: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BpfProgramMap, establish_database_connection};
+
+    fn setup_test_db() -> SqliteConnection {
+        let database_url = ":memory:";
+        establish_database_connection(database_url)
+            .expect("Failed to establish in-memory SQLite connection")
+    }
+
+    /// Verifies that the SQLite PRAGMA foreign_keys setting is
+    /// enabled (value = 1) when establishing database connections
+    /// through our standard method.
+    ///
+    /// This test is critical because:
+    /// 1. SQLite does NOT enforce foreign key constraints by default.
+    /// 2. Our schema depends heavily on ON DELETE CASCADE behaviors for referential integrity.
+    /// 3. Without this setting enabled, cascading deletes silently fail, causing orphaned data.
+    ///
+    /// If this test fails, cascade operations like automatic map
+    /// cleanup won't work properly. We also want to regress early
+    /// should the pragma be inadvertently removed.
+    #[test]
+    fn test_foreign_keys_pragma_enabled() {
+        let mut conn = setup_test_db();
+
+        #[derive(QueryableByName, Debug)]
+        struct ForeignKeySetting {
+            #[diesel(sql_type = diesel::sql_types::Integer)]
+            foreign_keys: i32,
+        }
+
+        let result = diesel::sql_query("PRAGMA foreign_keys")
+            .load::<ForeignKeySetting>(&mut conn)
+            .expect("Failed to query foreign_keys PRAGMA");
+
+        let foreign_keys_enabled = result
+            .first()
+            .expect("Expected one row from PRAGMA foreign_keys")
+            .foreign_keys;
+
+        assert_eq!(
+            foreign_keys_enabled, 1,
+            "PRAGMA foreign_keys is not enabled! This will break cascade deletes and referential integrity."
+        );
+    }
+
+    #[test]
+    /// Tests the insertion and retrieval of BPF programs in the
+    /// database.
+    ///
+    /// This test verifies several aspects in sequence:
+    ///
+    /// 1. Program Creation:
+    ///    - Creates a minimal but valid BPF program with required fields
+    ///    - Verifies default timestamps are set to epoch
+    ///
+    /// 2. Program Insertion:
+    ///    - Tests successful insertion into the database
+    ///    - Verifies timestamps are updated (no longer epoch)
+    ///    - After syncing timestamps, confirms complete equality between
+    ///      input and inserted program
+    ///
+    /// 3. Default Values and JSON Validity:
+    ///    - Confirms metadata defaults to "{}"
+    ///    - Confirms global_data defaults to "{}"
+    ///    - Verifies all are valid JSON structures
+    ///
+    /// 4. Record Retrieval:
+    ///    - Tests the find_record operation by ID
+    ///    - Verifies complete equality between inserted and retrieved records
+    ///
+    /// The test uses Eq for complete record comparison after
+    /// synchronising timestamps, providing thorough verification of
+    /// all fields through the database round-trip.
+    fn test_insert_and_find_bpf_program() {
+        let mut db_conn = setup_test_db();
+
+        // Setup test program with minimal required fields.
+        // Ensure BpfProgram derives Clone (if not, add #[derive(Clone)] to its definition).
+        let prog = BpfProgram {
+            id: 100u32.into(),
+            name: "xdp_test_program".to_owned(),
+            kind: "xdp".to_owned(),
+            state: "pre_load".to_owned(),
+            location_type: "file".to_owned(),
+            file_path: Some("/path/to/test_program.o".to_owned()),
+            map_pin_path: "/sys/fs/bpf/test_program".to_owned(),
+            program_bytes: vec![0xAA, 0xBB, 0xCC],
+            ..Default::default()
+        };
+
+        // Verify default timestamps are epoch.
+        let epoch: NaiveDateTime = Default::default();
+        assert_eq!(prog.created_at, epoch, "Default created_at should be epoch");
+        assert_eq!(prog.updated_at, None, "Default updated_at should be None");
+
+        // Clone prog so we have a copy to compare later.
+        let mut prog_for_assert = prog.clone();
+
+        // Insert program.
+        // Note: insert_record now takes ownership of `prog`.
+        let inserted_program =
+            BpfProgram::insert_record(&mut db_conn, &prog).expect("Insert failed");
+
+        // Sync timestamps to enable Eq comparisons.
+        prog_for_assert.created_at = inserted_program.created_at;
+        prog_for_assert.updated_at = inserted_program.updated_at;
+
+        // Assert that the modified copy equals the inserted record.
+        assert_eq!(prog_for_assert, inserted_program);
+
+        // Verify record retrieval using full Eq comparison.
+        {
+            let found_program = BpfProgram::find_record(&mut db_conn, prog_for_assert.id)
+                .expect("Failed to find program");
+            assert_eq!(found_program, inserted_program);
+        }
+    }
+
+    #[test]
+    /// This test verifies the serialisation, deserialisation, and
+    /// database persistence of BpfProgram structs. It ensures that:
+    ///
+    /// - The Serde derive macros work correctly for all field types
+    ///   (KernelU32, String, Option<String>, Vec<u8>, etc.).
+    /// - No data is lost in the JSON conversion.
+    /// - Diesel's type mappings are correct for all fields.
+    /// - The database schema matches the struct.
+    /// - No data is lost or corrupted during database operations.
+    /// - Timestamps are handled correctly.
+    /// - Optional fields are preserved.
+    /// - Binary data is stored and retrieved accurately.
+    /// - JSON string fields (metadata, global_data, kernel_map_ids)
+    ///   maintain their format.
+    ///
+    /// It performs two round-trip tests:
+    ///
+    /// 1. **JSON round-trip:**
+    ///    - Creates a BpfProgram with all fields populated.
+    ///    - Serialises it to JSON.
+    ///    - Deserialises back to a BpfProgram.
+    ///    - Verifies all fields match the original.
+    ///
+    /// 2. **Database round-trip:**
+    ///    - Takes the same BpfProgram.
+    ///    - Inserts it into SQLite.
+    ///    - Retrieves it.
+    ///    - Serialises to JSON.
+    ///    - Deserialises back to a BpfProgram.
+    ///    - Verifies all fields match.
+    fn test_bpf_program_serde_roundtrip() {
+        let prog = BpfProgram {
+            id: 100u32.into(),
+            name: "xdp_test_program".to_owned(),
+            kind: "xdp".to_owned(),
+            state: "pre_load".to_owned(),
+            location_type: "file".to_owned(),
+            file_path: Some("/path/to/test_program.o".to_owned()),
+            image_url: Some("registry.example.com/image:tag".to_owned()),
+            image_pull_policy: Some("Always".to_owned()),
+            username: Some("testuser".to_owned()),
+            password: Some("testpass".to_owned()),
+            map_pin_path: "/sys/fs/bpf/test_program".to_owned(),
+            map_owner_id: Some(1234u32.into()),
+            program_bytes: vec![0xAA, 0xBB, 0xCC],
+            metadata: Some("{}".to_owned()),
+            global_data: Some("{}".to_owned()),
+            retprobe: Some(true),
+            fn_name: Some("test_function".to_owned()),
+            kernel_name: Some("test_kernel_prog".to_owned()),
+            kernel_program_type: Some(123u32.into()),
+            kernel_loaded_at: Some("2024-02-18T12:00:00Z".to_owned()),
+            kernel_tag: U64Blob::from(u64::MAX),
+            kernel_gpl_compatible: Some(true),
+            kernel_btf_id: Some(456u32.into()),
+            kernel_bytes_xlated: Some(1024u32.into()),
+            kernel_jited: Some(true),
+            kernel_bytes_jited: Some(2048u32.into()),
+            kernel_verified_insns: Some(100u32.into()),
+            kernel_bytes_memlock: Some(4096u32.into()),
+            ..Default::default()
+        };
+
+        // Test JSON serialisation round-trip.
+        {
+            let json = serde_json::to_string(&prog).expect("Failed to serialize to JSON");
+
+            let mut deserialized: BpfProgram =
+                serde_json::from_str(&json).expect("Failed to deserialize from JSON");
+
+            // Manually restore the skipped field for comparison.
+            deserialized.program_bytes = prog.program_bytes.clone();
+
+            assert_eq!(prog, deserialized);
+        }
+
+        // Test database round-trip.
+        {
+            let mut db_conn = setup_test_db();
+
+            let inserted =
+                BpfProgram::insert_record(&mut db_conn, &prog).expect("Failed to insert");
+
+            let json_after_db =
+                serde_json::to_string(&inserted).expect("Failed to serialize after DB");
+
+            let mut deserialized_after_db: BpfProgram =
+                serde_json::from_str(&json_after_db).expect("Failed to deserialize after DB");
+
+            // Manually restore the skipped field for comparison.
+            deserialized_after_db.program_bytes = prog.program_bytes.clone();
+
+            assert_eq!(inserted, deserialized_after_db);
+        }
+    }
+
+    #[test]
+    /// Verifies cascade + trigger behaviour across multiple programs
+    /// sharing the same BPF map. Ensures the map is only deleted once
+    /// all referencing programs are removed.
+    ///
+    /// Test plan:
+    ///
+    /// 1. Insert two BPF programs: prog1 and prog2.
+    /// 2. Insert one shared map.
+    /// 3. Link both programs to the map.
+    /// 4. Confirm both program_map links exist.
+    /// 5. Delete prog1 — program_map row is deleted, map remains.
+    /// 6. Confirm only prog2's mapping remains.
+    /// 7. Delete prog2 — remaining mapping and map are deleted.
+    /// 8. Confirm bpf_maps is now empty.
+    fn test_program_map_cascade_deletes_map_only_when_unused() {
+        use crate::{
+            BpfMap,
+            db::{
+                bpf_maps::dsl::bpf_maps,
+                bpf_program_maps::dsl::{
+                    bpf_program_maps, map_id as map_id_col, program_id as program_id_col,
+                },
+            },
+        };
+
+        let mut conn = setup_test_db();
+
+        // Shared map inserted once.
+        let shared_map = BpfMap {
+            id: 900u32.into(),
+            name: "shared_map".to_owned(),
+            map_type: Some("Array".to_owned()),
+            key_size: 4u32.into(),
+            value_size: 64u32.into(),
+            max_entries: 128u32.into(),
+            created_at: Default::default(),
+            updated_at: Default::default(),
+        };
+        BpfMap::insert_record_on_conflict_do_nothing(&mut conn, &shared_map).unwrap();
+
+        // Insert first program.
+        let prog1 = BpfProgram {
+            id: 101u32.into(),
+            name: "prog1".into(),
+            kind: "tracepoint".into(),
+            state: "pre_load".into(),
+            location_type: "file".into(),
+            file_path: Some("/tmp/prog1.o".into()),
+            map_pin_path: "/sys/fs/bpf/prog1".into(),
+            program_bytes: vec![0x1],
+            metadata: Some("{}".into()),
+            global_data: Some("{}".into()),
+            ..Default::default()
+        };
+        BpfProgram::insert_record(&mut conn, &prog1).unwrap();
+
+        let prog2 = BpfProgram {
+            id: 102u32.into(),
+            name: "prog2".into(),
+            kind: "tracepoint".into(),
+            state: "pre_load".into(),
+            location_type: "file".into(),
+            file_path: Some("/tmp/prog2.o".into()),
+            map_pin_path: "/sys/fs/bpf/prog2".into(),
+            program_bytes: vec![0x2],
+            metadata: Some("{}".into()),
+            global_data: Some("{}".into()),
+            ..Default::default()
+        };
+        BpfProgram::insert_record(&mut conn, &prog2).unwrap();
+
+        // Link both programs to the shared map.
+        BpfProgramMap::insert_record(&mut conn, prog1.id, shared_map.id).unwrap();
+        BpfProgramMap::insert_record(&mut conn, prog2.id, shared_map.id).unwrap();
+
+        // Confirm both join rows exist.
+        let mappings: Vec<(KernelU32, KernelU32)> = bpf_program_maps
+            .select((program_id_col, map_id_col))
+            .order_by(program_id_col)
+            .load(&mut conn)
+            .unwrap();
+        assert_eq!(
+            mappings,
+            vec![(prog1.id, shared_map.id), (prog2.id, shared_map.id)],
+            "Expected both program_map rows to exist"
+        );
+
+        // Delete first program.
+        BpfProgram::delete_record(&mut conn, prog1.id).unwrap();
+
+        let mappings: Vec<(KernelU32, KernelU32)> = bpf_program_maps
+            .select((program_id_col, map_id_col))
+            .load(&mut conn)
+            .unwrap();
+        assert_eq!(
+            mappings,
+            vec![(prog2.id, shared_map.id)],
+            "Expected only prog2 mapping to remain"
+        );
+
+        // Confirm map still exists.
+        let maps: Vec<BpfMap> = bpf_maps.load(&mut conn).unwrap();
+        assert_eq!(maps.len(), 1, "Expected shared map to still exist");
+
+        BpfProgram::delete_record(&mut conn, prog2.id).unwrap();
+
+        let mappings: Vec<(KernelU32, KernelU32)> = bpf_program_maps
+            .select((program_id_col, map_id_col))
+            .load(&mut conn)
+            .unwrap();
+        assert!(
+            mappings.is_empty(),
+            "Expected all program_map rows to be gone"
+        );
+
+        // Confirm shared map is now deleted.
+        let maps: Vec<BpfMap> = bpf_maps.load(&mut conn).unwrap();
+        assert!(
+            maps.is_empty(),
+            "Expected shared map to be deleted after all program references removed"
+        );
+    }
+
+    #[cfg(test)]
+    mod bpfprogram_constraint_tests {
+        use diesel::result::{DatabaseErrorKind, Error};
+
+        use super::*;
+
+        fn create_valid_base_program() -> BpfProgram {
+            BpfProgram {
+                id: 100u32.into(),
+                name: "test_program".to_owned(),
+                kind: "xdp".to_owned(),
+                state: "pre_load".to_owned(),
+                location_type: "file".to_owned(),
+                file_path: Some("/path/to/test_program.o".to_owned()),
+                map_pin_path: "/sys/fs/bpf/test_program".to_owned(),
+                program_bytes: vec![0xAA, 0xBB, 0xCC],
+                ..Default::default()
+            }
+        }
+
+        fn assert_constraint_violation(result: Result<BpfProgram, Error>) {
+            match result {
+                Err(Error::DatabaseError(DatabaseErrorKind::CheckViolation, _)) => {
+                    // This is the expected outcome for a constraint
+                    // violation.
+                }
+                Err(e) => panic!(
+                    "Expected check constraint violation, got different error: {:?}",
+                    e
+                ),
+                Ok(_) => {
+                    panic!("Expected insertion to fail with constraint violation, but it succeeded")
+                }
+            }
+        }
+
+        #[test]
+        /// Tests that the 'kind' field constraint is enforced. The
+        /// schema only allows specific values: 'xdp', 'tc', 'tcx',
+        /// 'tracepoint', 'kprobe', 'uprobe', 'fentry', 'fexit'.
+        fn test_kind_constraint() {
+            let mut conn = setup_test_db();
+
+            // Valid kind should succeed.
+            let valid_program = create_valid_base_program();
+            BpfProgram::insert_record(&mut conn, &valid_program)
+                .expect("Valid program should insert successfully");
+
+            // Invalid kind should fail.
+            let mut invalid_program = create_valid_base_program();
+            invalid_program.id = 101u32.into();
+            invalid_program.kind = "invalid_kind".to_owned();
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_program);
+            assert_constraint_violation(result);
+        }
+
+        #[test]
+        /// Tests that the 'state' field constraint is enforced. The
+        /// schema only allows 'pre_load' or 'loaded'.
+        fn test_state_constraint() {
+            let mut conn = setup_test_db();
+
+            // Valid state should succeed.
+            let valid_program = create_valid_base_program();
+            BpfProgram::insert_record(&mut conn, &valid_program)
+                .expect("Valid program should insert successfully");
+
+            // Test with 'loaded' state, which should also be valid.
+            let mut loaded_program = create_valid_base_program();
+            loaded_program.id = 101u32.into();
+            loaded_program.state = "loaded".to_owned();
+            BpfProgram::insert_record(&mut conn, &loaded_program)
+                .expect("Program with 'loaded' state should insert successfully");
+
+            // Invalid state should fail.
+            let mut invalid_program = create_valid_base_program();
+            invalid_program.id = 102u32.into();
+            invalid_program.state = "running".to_owned();
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_program);
+            assert_constraint_violation(result);
+        }
+
+        #[test]
+        /// Tests that the 'location_type' and corresponding field
+        /// constraints are enforced. If location_type is 'file',
+        /// file_path must be provided. If location_type is 'image',
+        /// image_url must be provided.
+        fn test_location_type_constraints() {
+            let mut conn = setup_test_db();
+
+            // Valid file location should succeed.
+            let valid_file_program = create_valid_base_program();
+            BpfProgram::insert_record(&mut conn, &valid_file_program)
+                .expect("Valid file-based program should insert successfully");
+
+            // Valid image location should succeed.
+            let mut valid_image_program = create_valid_base_program();
+            valid_image_program.id = 101u32.into();
+            valid_image_program.location_type = "image".to_owned();
+            valid_image_program.file_path = None;
+            valid_image_program.image_url = Some("registry.example.com/image:tag".to_owned());
+            BpfProgram::insert_record(&mut conn, &valid_image_program)
+                .expect("Valid image-based program should insert successfully");
+
+            // Invalid: File location type without file_path.
+            let mut invalid_file_program = create_valid_base_program();
+            invalid_file_program.id = 102u32.into();
+            invalid_file_program.file_path = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_file_program);
+            assert_constraint_violation(result);
+
+            // Invalid: Image location type without image_url.
+            let mut invalid_image_program = create_valid_base_program();
+            invalid_image_program.id = 103u32.into();
+            invalid_image_program.location_type = "image".to_owned();
+            invalid_image_program.file_path = None;
+            invalid_image_program.image_url = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_image_program);
+            assert_constraint_violation(result);
+
+            // Invalid location_type should fail.
+            let mut invalid_location_program = create_valid_base_program();
+            invalid_location_program.id = 104u32.into();
+            invalid_location_program.location_type = "network".to_owned();
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_location_program);
+            assert_constraint_violation(result);
+        }
+
+        #[test]
+        /// Tests that the function name constraint is enforced for
+        /// 'fentry' and 'fexit' program types.
+        fn test_function_name_constraint() {
+            let mut conn = setup_test_db();
+
+            // Valid fentry program with fn_name should succeed.
+            let mut valid_fentry_program = create_valid_base_program();
+            valid_fentry_program.kind = "fentry".to_owned();
+            valid_fentry_program.fn_name = Some("test_function".to_owned());
+
+            BpfProgram::insert_record(&mut conn, &valid_fentry_program)
+                .expect("Valid fentry program should insert successfully");
+
+            // Valid fexit program with fn_name should succeed.
+            let mut valid_fexit_program = create_valid_base_program();
+            valid_fexit_program.id = 101u32.into();
+            valid_fexit_program.kind = "fexit".to_owned();
+            valid_fexit_program.fn_name = Some("test_function".to_owned());
+
+            BpfProgram::insert_record(&mut conn, &valid_fexit_program)
+                .expect("Valid fexit program should insert successfully");
+
+            // Invalid: fentry program without fn_name should fail.
+            let mut invalid_fentry_program = create_valid_base_program();
+            invalid_fentry_program.id = 102u32.into();
+            invalid_fentry_program.kind = "fentry".to_owned();
+            invalid_fentry_program.fn_name = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_fentry_program);
+            assert_constraint_violation(result);
+
+            // Invalid: fexit program without fn_name should fail.
+            let mut invalid_fexit_program = create_valid_base_program();
+            invalid_fexit_program.id = 103u32.into();
+            invalid_fexit_program.kind = "fexit".to_owned();
+            invalid_fexit_program.fn_name = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_fexit_program);
+            assert_constraint_violation(result);
+
+            // Other program types don't require fn_name.
+            let mut tracepoint_program = create_valid_base_program();
+            tracepoint_program.id = 104u32.into();
+            tracepoint_program.kind = "tracepoint".to_owned();
+            tracepoint_program.fn_name = None;
+
+            BpfProgram::insert_record(&mut conn, &tracepoint_program)
+                .expect("Tracepoint program without fn_name should insert successfully");
+        }
+
+        #[test]
+        /// Tests that the retprobe constraint is enforced for
+        /// 'kprobe' and 'uprobe' program types.
+        fn test_retprobe_constraint() {
+            let mut conn = setup_test_db();
+
+            // Valid kprobe program with retprobe should succeed.
+            let mut valid_kprobe_program = create_valid_base_program();
+            valid_kprobe_program.kind = "kprobe".to_owned();
+            valid_kprobe_program.retprobe = Some(false);
+
+            BpfProgram::insert_record(&mut conn, &valid_kprobe_program)
+                .expect("Valid kprobe program should insert successfully");
+
+            // Valid uprobe program with retprobe should succeed.
+            let mut valid_uprobe_program = create_valid_base_program();
+            valid_uprobe_program.id = 101u32.into();
+            valid_uprobe_program.kind = "uprobe".to_owned();
+            valid_uprobe_program.retprobe = Some(true);
+
+            BpfProgram::insert_record(&mut conn, &valid_uprobe_program)
+                .expect("Valid uprobe program should insert successfully");
+
+            // Invalid: kprobe program without retprobe should fail.
+            let mut invalid_kprobe_program = create_valid_base_program();
+            invalid_kprobe_program.id = 102u32.into();
+            invalid_kprobe_program.kind = "kprobe".to_owned();
+            invalid_kprobe_program.retprobe = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_kprobe_program);
+            assert_constraint_violation(result);
+
+            // Invalid: uprobe program without retprobe should fail.
+            let mut invalid_uprobe_program = create_valid_base_program();
+            invalid_uprobe_program.id = 103u32.into();
+            invalid_uprobe_program.kind = "uprobe".to_owned();
+            invalid_uprobe_program.retprobe = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_uprobe_program);
+            assert_constraint_violation(result);
+
+            // Other program types don't require retprobe.
+            let mut xdp_program = create_valid_base_program();
+            xdp_program.id = 104u32.into();
+            xdp_program.kind = "xdp".to_owned();
+            xdp_program.retprobe = None;
+
+            BpfProgram::insert_record(&mut conn, &xdp_program)
+                .expect("XDP program without retprobe should insert successfully");
+        }
+
+        #[test]
+        /// Test that program can be updated while still enforcing
+        /// constraints.
+        fn test_update_with_constraints() {
+            let mut conn = setup_test_db();
+
+            // Create a valid program.
+            let program = create_valid_base_program();
+            let inserted_program = BpfProgram::insert_record(&mut conn, &program)
+                .expect("Valid program should insert successfully");
+
+            // Valid update should succeed.
+            let mut program_to_update = inserted_program.clone();
+            program_to_update.name = "updated_name".to_owned();
+            program_to_update
+                .update_record(&mut conn)
+                .expect("Valid update should succeed");
+
+            // Invalid update should fail (invalid kind).
+            let mut invalid_update = inserted_program.clone();
+            invalid_update.kind = "invalid_kind".to_owned();
+            let result = invalid_update.update_record(&mut conn);
+            match result {
+                Err(Error::DatabaseError(DatabaseErrorKind::CheckViolation, _)) => {
+                    // This is the expected outcome
+                }
+                Err(e) => panic!(
+                    "Expected check constraint violation, got different error: {:?}",
+                    e
+                ),
+                Ok(_) => {
+                    panic!("Expected update to fail with constraint violation, but it succeeded")
+                }
+            }
+
+            // Invalid update should fail (missing required field
+            // based on kind).
+            let mut invalid_update = inserted_program.clone();
+            invalid_update.kind = "fentry".to_owned();
+            invalid_update.fn_name = None;
+            let result = invalid_update.update_record(&mut conn);
+            assert_constraint_violation(Result::Err(result.unwrap_err()));
+        }
+
+        #[test]
+        /// Test combination of multiple constraints.
+        fn test_combined_constraints() {
+            let mut conn = setup_test_db();
+
+            // Complex valid case: fentry program with image location.
+            let mut program = create_valid_base_program();
+            program.id = 101u32.into();
+            program.kind = "fentry".to_owned();
+            program.fn_name = Some("test_function".to_owned());
+            program.location_type = "image".to_owned();
+            program.file_path = None;
+            program.image_url = Some("registry.example.com/image:tag".to_owned());
+            program.image_pull_policy = Some("Always".to_owned());
+
+            BpfProgram::insert_record(&mut conn, &program)
+                .expect("Valid complex program should insert successfully");
+
+            // Invalid complex case: missing multiple required fields.
+            let mut invalid_complex_program = create_valid_base_program();
+            invalid_complex_program.id = 102u32.into();
+            invalid_complex_program.kind = "kprobe".to_owned(); // Requires retprobe
+            invalid_complex_program.retprobe = None;
+            invalid_complex_program.location_type = "image".to_owned(); // Requires image_url
+            invalid_complex_program.file_path = None;
+            invalid_complex_program.image_url = None;
+
+            let result = BpfProgram::insert_record(&mut conn, &invalid_complex_program);
+            assert_constraint_violation(result);
+        }
+    }
+}

--- a/bpfman/src/db/models/bpf_program_map.rs
+++ b/bpfman/src/db/models/bpf_program_map.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! BpfProgramMap represents the many-to-many relationship between
+//! BPF programs and BPF maps.
+
+use diesel::prelude::*;
+
+use crate::db::KernelU32;
+
+#[derive(Debug, Queryable, Selectable, Associations)]
+#[diesel(belongs_to(crate::db::BpfProgram, foreign_key = program_id))]
+#[diesel(belongs_to(crate::db::BpfMap, foreign_key = map_id))]
+#[diesel(table_name = crate::db::bpf_program_maps)]
+pub struct BpfProgramMap {
+    pub program_id: KernelU32,
+    pub map_id: KernelU32,
+}
+
+impl BpfProgramMap {
+    /// Inserts a new mapping between a BPF program and a BPF map.
+    ///
+    /// This establishes an entry in the join table linking the two
+    /// resources. The caller must ensure both program and map IDs
+    /// exist.
+    pub fn insert_record(
+        conn: &mut SqliteConnection,
+        program_id: KernelU32,
+        map_id: KernelU32,
+    ) -> Result<(), diesel::result::Error> {
+        use crate::db::bpf_program_maps;
+
+        diesel::insert_into(bpf_program_maps::table)
+            .values((
+                bpf_program_maps::program_id.eq(program_id),
+                bpf_program_maps::map_id.eq(map_id),
+            ))
+            .execute(conn)?;
+
+        Ok(())
+    }
+}

--- a/bpfman/src/db/models/mod.rs
+++ b/bpfman/src/db/models/mod.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Diesel model definitions for bpfman.
+//!
+//! This module defines domain-level types that correspond to rows in
+//! the database. These types implement Diesel traits like
+//! `Queryable`, `Insertable`, and `Identifiable`.
+//!
+//! Each entity (program, map, link, etc.) has its own submodule for
+//! clarity and separation of concerns.
+//!
+//! # Design Notes: No `Default` for Model Types
+//!
+//! The model types in this module (`BpfProgram`, `BpfMap`, etc.) do
+//! **not** implement `Default` in production code. This is
+//! intentional:
+//!
+//! - These types represent persisted data with required fields.
+//!
+//! - Constructing a zeroed or placeholder version risks violating
+//!   database constraints or semantic invariants.
+//!
+//! - Diesel’s insert/update operations rely on fully initialised
+//!   data.
+//!
+//! We *do* implement `Default` under `#[cfg(test)]` to support unit
+//! tests and reduce boilerplate, but this is limited to internal use.
+//!
+//! Consumers should construct model instances explicitly.
+//!
+//! # Diesel Trait Derivations
+//!
+//! These traits are commonly derived on Diesel model structs to enable
+//! interaction with the database:
+//!
+//! - [`diesel::Queryable`]: Loads rows from the database into Rust structs.
+//! - [`diesel::Insertable`]: Enables inserting structs as new rows.
+//! - [`diesel::Identifiable`]: Associates a struct with a primary key.
+//! - [`diesel::AsChangeset`]: Updates rows by mapping struct fields to columns.
+//! - [`diesel::associations::HasTable`]: Required by various table operations.
+//! - [`diesel::Associations`]: Enables modelling relationships (`belongs_to`, etc.).
+//! - [`diesel::Selectable`]: Enables typed column projections.
+//! - [`diesel::QueryableByName`]: Used with raw SQL queries via `sql_query(...)`.
+//!
+//! These traits are usually brought into scope with `use
+//! diesel::prelude::*`.
+
+mod bpf_link;
+mod bpf_map;
+mod bpf_program;
+mod bpf_program_map;
+
+pub use bpf_link::*;
+pub use bpf_map::*;
+pub use bpf_program::*;
+pub use bpf_program_map::*;

--- a/bpfman/src/db/prelude.rs
+++ b/bpfman/src/db/prelude.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Commonly used database types and helpers.
+//!
+//! This module exposes domain-level types and column wrappers, but
+//! **not** Diesel schema definitions like `bpf_programs::dsl::*`.
+//! Schema elements are intentionally excluded to avoid polluting the
+//! namespace with common column names like `id`, `name`, etc.
+//! Instead, import schema elements explicitly where needed.
+
+// Some of these imports are currently unused. We're migrating to
+// SQLite, and only the `load` path is backed by the new DB layer so
+// far. As more functionality is ported, the remaining types will be
+// come into play.
+#![allow(unused_imports)]
+pub use super::{
+    BpfLink, BpfMap, BpfProgram, BpfProgramMap, KernelU32, U8Blob, U16Blob, U32Blob, U64Blob,
+    U128Blob, UxBlobError,
+};

--- a/bpfman/src/db/schema.rs
+++ b/bpfman/src/db/schema.rs
@@ -1,0 +1,74 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    bpf_links (id) {
+        id -> BigInt,
+        program_id -> BigInt,
+        link_type -> Nullable<Text>,
+        target -> Nullable<Text>,
+        state -> Text,
+        created_at -> Timestamp,
+        updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    bpf_maps (id) {
+        id -> BigInt,
+        name -> Text,
+        map_type -> Nullable<Text>,
+        key_size -> BigInt,
+        value_size -> BigInt,
+        max_entries -> BigInt,
+        created_at -> Timestamp,
+        updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    bpf_program_maps (program_id, map_id) {
+        program_id -> BigInt,
+        map_id -> BigInt,
+    }
+}
+
+diesel::table! {
+    bpf_programs (id) {
+        id -> BigInt,
+        name -> Text,
+        kind -> Text,
+        state -> Text,
+        location_type -> Text,
+        file_path -> Nullable<Text>,
+        image_url -> Nullable<Text>,
+        image_pull_policy -> Nullable<Text>,
+        username -> Nullable<Text>,
+        password -> Nullable<Text>,
+        map_pin_path -> Text,
+        map_owner_id -> Nullable<BigInt>,
+        program_bytes -> Binary,
+        metadata -> Nullable<Text>,
+        global_data -> Nullable<Text>,
+        retprobe -> Nullable<Bool>,
+        fn_name -> Nullable<Text>,
+        kernel_name -> Nullable<Text>,
+        kernel_program_type -> Nullable<BigInt>,
+        kernel_loaded_at -> Nullable<Text>,
+        kernel_tag -> Binary,
+        kernel_gpl_compatible -> Nullable<Bool>,
+        kernel_btf_id -> Nullable<BigInt>,
+        kernel_bytes_xlated -> Nullable<BigInt>,
+        kernel_jited -> Nullable<Bool>,
+        kernel_bytes_jited -> Nullable<BigInt>,
+        kernel_verified_insns -> Nullable<BigInt>,
+        kernel_bytes_memlock -> Nullable<BigInt>,
+        created_at -> Timestamp,
+        updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::joinable!(bpf_links -> bpf_programs (program_id));
+diesel::joinable!(bpf_program_maps -> bpf_maps (map_id));
+diesel::joinable!(bpf_program_maps -> bpf_programs (program_id));
+
+diesel::allow_tables_to_appear_in_same_query!(bpf_links, bpf_maps, bpf_program_maps, bpf_programs,);

--- a/bpfman/src/db/types/ku32.rs
+++ b/bpfman/src/db/types/ku32.rs
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! A wrapper type for handling kernel-provided `u32` values in SQLite
+//! databases.
+//!
+//! # Overview
+//!
+//! `KernelU32` addresses a specific use case: storing kernel-provided
+//! `u32` values in SQLite using Diesel, where:
+//!
+//! 1. SQLite has no native unsigned integer types
+//! 2. Kernel interfaces commonly return `u32` values
+//! 3. Sometime those values must be round-tripped back to `u32` for
+//!    kernel calls
+//!
+//! # Purpose
+//!
+//! While all `u32` values can be safely stored as `i64` in SQLite
+//! (using BIGINT columns), downcasting from `i64` to `u32` is
+//! potentially unsafe if the value exceeds the `u32` range. This
+//! wrapper provides the necessary runtime type safety checks when
+//! these conversions happen.
+//!
+//! For fields that need to be round-tripped from Rust `u32` -> SQLite
+//! `BIGINT` -> Rust `u32` (typically for passing to kernel APIs), you
+//! should:
+//!
+//! 1. Declare the database column as `BIGINT` in your schema
+//! 2. Use `KernelU32` as the field type in your Rust struct
+//! 3. Use `try_u32()` when retrieving values for kernel calls
+//!
+//! # Value Handling
+//!
+//! * A `u32` ranges from 0 to 4,294,967,295
+//! * An `i64` can represent this entire range without loss of precision
+//!
+//! When retrieving a value:
+//! * `get()` returns the value as `u32`, panicking if out of range
+//! * `try_u32()` returns a `Result<u32, KernelU32Error>`, allowing error handling
+//!
+//! # Diesel Integration
+//!
+//! `KernelU32` implements:
+//! * `ToSql<BigInt, Sqlite>`
+//! * `FromSql<BigInt, Sqlite>`
+//! * `AsExpression<BigInt>`
+//! * `FromSqlRow<BigInt>`
+
+/// Errors that can occur when working with KernelU32 values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KernelU32Error {
+    /// The i64 value is outside the valid range for u32 (0 to
+    /// [`u32::MAX`]).
+    OutOfRange {
+        /// The invalid value that was encountered.
+        value: i64,
+    },
+}
+
+impl std::fmt::Display for KernelU32Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KernelU32Error::OutOfRange { value } => {
+                write!(
+                    f,
+                    "Value {} is outside the valid range for u32 (0 to {})",
+                    value,
+                    u32::MAX,
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for KernelU32Error {}
+
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    diesel::expression::AsExpression,
+    diesel::deserialize::FromSqlRow,
+)]
+#[diesel(sql_type = diesel::sql_types::BigInt)]
+#[repr(transparent)]
+pub struct KernelU32(i64);
+
+impl KernelU32 {
+    /// Returns the value as `u32`, panicking if out of range.
+    ///
+    /// For fallible conversion, use [`Self::try_u32()`] instead.
+    pub fn get(self) -> u32 {
+        self.try_u32().expect("KernelU32: value out of u32 range")
+    }
+
+    /// Try to extract `u32`, returning an error if the stored `i64`
+    /// is outside the valid range for `u32`.
+    pub fn try_u32(self) -> Result<u32, KernelU32Error> {
+        u32::try_from(self.0).map_err(|_| KernelU32Error::OutOfRange { value: self.0 })
+    }
+
+    /// Returns the inner i64 value.
+    pub fn as_i64(self) -> i64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for KernelU32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Using `get()` is acceptable because KernelU32 should always
+        // hold a valid u32.
+        write!(f, "{}", self.get())
+    }
+}
+
+impl From<u32> for KernelU32 {
+    fn from(val: u32) -> Self {
+        Self(val as i64)
+    }
+}
+
+impl From<KernelU32> for i64 {
+    fn from(val: KernelU32) -> Self {
+        val.0
+    }
+}
+
+impl TryFrom<i64> for KernelU32 {
+    type Error = KernelU32Error;
+    fn try_from(val: i64) -> Result<Self, Self::Error> {
+        u32::try_from(val)
+            .map(|_| Self(val))
+            .map_err(|_| KernelU32Error::OutOfRange { value: val })
+    }
+}
+
+impl diesel::serialize::ToSql<diesel::sql_types::BigInt, diesel::sqlite::Sqlite> for KernelU32 {
+    fn to_sql<'b>(
+        &'b self,
+        out: &mut diesel::serialize::Output<'b, '_, diesel::sqlite::Sqlite>,
+    ) -> diesel::serialize::Result {
+        diesel::serialize::ToSql::<diesel::sql_types::BigInt, diesel::sqlite::Sqlite>::to_sql(
+            &self.0, out,
+        )
+    }
+}
+
+impl diesel::deserialize::FromSql<diesel::sql_types::BigInt, diesel::sqlite::Sqlite> for KernelU32 {
+    fn from_sql(
+        bytes: <diesel::sqlite::Sqlite as diesel::backend::Backend>::RawValue<'_>,
+    ) -> diesel::deserialize::Result<Self> {
+        let value = i64::from_sql(bytes)?;
+        Self::try_from(value).map_err(|e| {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid KernelU32 value: {}", e),
+            )) as Box<dyn std::error::Error + Send + Sync>
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use diesel::{prelude::*, sqlite::SqliteConnection};
+
+    use super::*;
+
+    // Basic Conversion Tests.
+
+    #[test]
+    fn test_k32_from_u32() {
+        let val = 123u32;
+        let wrapped = KernelU32::from(val);
+        assert_eq!(wrapped.get(), val);
+        assert_eq!(wrapped.as_i64(), val as i64);
+    }
+
+    #[test]
+    fn test_k32_into_i64() {
+        let val = 987u32;
+        let wrapped = KernelU32::from(val);
+        let raw: i64 = wrapped.into();
+        assert_eq!(raw, val as i64);
+    }
+
+    // Boundary Tests.
+
+    #[test]
+    fn test_k32_boundary_values() {
+        // Test minimum value (0).
+        let min_val = 0u32;
+        let wrapped_min = KernelU32::from(min_val);
+        assert_eq!(wrapped_min.get(), min_val);
+
+        // Test maximum value (u32::MAX).
+        let max_val = u32::MAX;
+        let wrapped_max = KernelU32::from(max_val);
+        assert_eq!(wrapped_max.get(), max_val);
+    }
+
+    // TryFrom Tests.
+
+    #[test]
+    fn test_k32_try_from_i64_valid() {
+        let val: i64 = u32::MAX as i64;
+        let wrapped = KernelU32::try_from(val).unwrap();
+        assert_eq!(wrapped.get(), u32::MAX);
+    }
+
+    #[test]
+    fn test_k32_try_from_i64_invalid_negative() {
+        let val: i64 = -1;
+        let result = KernelU32::try_from(val);
+        assert!(result.is_err());
+
+        match result {
+            Err(KernelU32Error::OutOfRange { .. }) => {}
+            _ => panic!("Expected OutOfRange error"),
+        }
+    }
+
+    #[test]
+    fn test_k32_try_from_i64_invalid_too_large() {
+        let val: i64 = u32::MAX as i64 + 1;
+        let result = KernelU32::try_from(val);
+        assert!(result.is_err());
+
+        match result {
+            Err(KernelU32Error::OutOfRange { .. }) => {}
+            _ => panic!("Expected OutOfRange error"),
+        }
+    }
+
+    // try_u32 Method Tests.
+
+    #[test]
+    fn test_k32_try_u32() {
+        // Valid case.
+        let valid = KernelU32::from(42u32);
+        assert_eq!(valid.try_u32().unwrap(), 42u32);
+
+        // Invalid case (negative).
+        let negative = KernelU32(-1);
+        assert!(negative.try_u32().is_err());
+
+        // Invalid case (too large).
+        let too_large = KernelU32(i64::MAX);
+        assert!(too_large.try_u32().is_err());
+
+        // Check the error type.
+        match too_large.try_u32() {
+            Err(KernelU32Error::OutOfRange { .. }) => {}
+            _ => panic!("Expected OutOfRange error"),
+        }
+    }
+
+    // Panic Tests.
+
+    #[test]
+    #[should_panic(expected = "KernelU32: value out of u32 range")]
+    fn test_k32_get_panics_if_out_of_range() {
+        let bad = KernelU32(i64::MAX);
+        let _ = bad.get(); // should panic
+    }
+
+    // Serde Tests.
+
+    #[test]
+    fn test_k32_serde() {
+        let original = KernelU32::from(123u32);
+
+        // Serialize to JSON.
+        let serialized = serde_json::to_string(&original).unwrap();
+        assert_eq!(serialized, "123"); // Value should be serialized as its inner i64
+
+        // Deserialize from JSON.
+        let deserialized: KernelU32 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.get(), 123u32);
+
+        // Verify round-trip.
+        assert_eq!(original, deserialized);
+    }
+
+    // Diesel Integration Tests.
+
+    mod diesel_integration {
+        use super::*;
+
+        table! {
+            k32_test (id) {
+                id -> Integer,
+                value -> BigInt,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = k32_test)]
+        struct KernelU32Test {
+            id: i32,
+            value: KernelU32,
+        }
+
+        fn setup_db() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            diesel::sql_query(
+                "CREATE TABLE k32_test (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)",
+            )
+            .execute(&mut conn)
+            .unwrap();
+            conn
+        }
+
+        #[test]
+        fn test_diesel_k32_crud_operations() {
+            let mut conn = setup_db();
+
+            // Insert test.
+            let entry = KernelU32Test {
+                id: 1,
+                value: KernelU32::from(42u32),
+            };
+            diesel::insert_into(k32_test::table)
+                .values(&entry)
+                .execute(&mut conn)
+                .unwrap();
+
+            // Query test.
+            let result: KernelU32Test = k32_test::table.find(1).first(&mut conn).unwrap();
+            assert_eq!(result.value.get(), 42u32);
+
+            // Filter test.
+            let filtered: Vec<KernelU32Test> = k32_test::table
+                .filter(k32_test::value.eq(KernelU32::from(42u32)))
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(filtered.len(), 1);
+
+            // Update test.
+            diesel::update(k32_test::table.find(1))
+                .set(k32_test::value.eq(KernelU32::from(100u32)))
+                .execute(&mut conn)
+                .unwrap();
+
+            let updated: KernelU32Test = k32_test::table.find(1).first(&mut conn).unwrap();
+            assert_eq!(updated.value.get(), 100u32);
+
+            // Delete test.
+            diesel::delete(k32_test::table.find(1))
+                .execute(&mut conn)
+                .unwrap();
+
+            let results: Vec<KernelU32Test> = k32_test::table.load(&mut conn).unwrap();
+            assert!(results.is_empty());
+        }
+
+        #[test]
+        fn test_diesel_k32_boundary_values() {
+            let mut conn = setup_db();
+
+            // Insert minimum and maximum values.
+            diesel::insert_into(k32_test::table)
+                .values(&[
+                    KernelU32Test {
+                        id: 1,
+                        value: KernelU32::from(0u32),
+                    },
+                    KernelU32Test {
+                        id: 2,
+                        value: KernelU32::from(u32::MAX),
+                    },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Verify values were stored and retrieved correctly.
+            let min_val: KernelU32Test = k32_test::table.find(1).first(&mut conn).unwrap();
+            let max_val: KernelU32Test = k32_test::table.find(2).first(&mut conn).unwrap();
+
+            assert_eq!(min_val.value.get(), 0u32);
+            assert_eq!(max_val.value.get(), u32::MAX);
+        }
+
+        #[test]
+        fn test_diesel_k32_ordering() {
+            let mut conn = setup_db();
+
+            // Insert values in non-sequential order.
+            diesel::insert_into(k32_test::table)
+                .values(&[
+                    KernelU32Test {
+                        id: 1,
+                        value: KernelU32::from(300u32),
+                    },
+                    KernelU32Test {
+                        id: 2,
+                        value: KernelU32::from(100u32),
+                    },
+                    KernelU32Test {
+                        id: 3,
+                        value: KernelU32::from(200u32),
+                    },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Test ordering (ascending).
+            let asc_results: Vec<KernelU32Test> = k32_test::table
+                .order(k32_test::value.asc())
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(asc_results[0].value.get(), 100u32);
+            assert_eq!(asc_results[1].value.get(), 200u32);
+            assert_eq!(asc_results[2].value.get(), 300u32);
+
+            // Test ordering (descending).
+            let desc_results: Vec<KernelU32Test> = k32_test::table
+                .order(k32_test::value.desc())
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(desc_results[0].value.get(), 300u32);
+            assert_eq!(desc_results[1].value.get(), 200u32);
+            assert_eq!(desc_results[2].value.get(), 100u32);
+        }
+
+        #[test]
+        fn test_diesel_k32_comparisons() {
+            let mut conn = setup_db();
+
+            // Insert test values.
+            diesel::insert_into(k32_test::table)
+                .values(&[
+                    KernelU32Test {
+                        id: 1,
+                        value: KernelU32::from(100u32),
+                    },
+                    KernelU32Test {
+                        id: 2,
+                        value: KernelU32::from(200u32),
+                    },
+                    KernelU32Test {
+                        id: 3,
+                        value: KernelU32::from(300u32),
+                    },
+                    KernelU32Test {
+                        id: 4,
+                        value: KernelU32::from(400u32),
+                    },
+                    KernelU32Test {
+                        id: 5,
+                        value: KernelU32::from(500u32),
+                    },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Test greater than.
+            let gt_results: Vec<KernelU32Test> = k32_test::table
+                .filter(k32_test::value.gt(KernelU32::from(300u32)))
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(gt_results.len(), 2);
+
+            // Test less than or equal to.
+            let lte_results: Vec<KernelU32Test> = k32_test::table
+                .filter(k32_test::value.le(KernelU32::from(300u32)))
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(lte_results.len(), 3);
+
+            // Test range (between).
+            let between_results: Vec<KernelU32Test> = k32_test::table
+                .filter(k32_test::value.gt(KernelU32::from(100u32)))
+                .filter(k32_test::value.lt(KernelU32::from(400u32)))
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(between_results.len(), 2);
+        }
+    }
+
+    // Optional Null Handling Tests.
+
+    mod diesel_null_handling {
+        use super::*;
+
+        table! {
+            nullable_k32 (id) {
+                id -> Integer,
+                value -> Nullable<BigInt>,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = nullable_k32)]
+        struct NullableKernelU32Test {
+            id: i32,
+            value: Option<KernelU32>,
+        }
+
+        fn setup_nullable_db() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            diesel::sql_query("CREATE TABLE nullable_k32 (id INTEGER PRIMARY KEY, value INTEGER)")
+                .execute(&mut conn)
+                .unwrap();
+            conn
+        }
+
+        #[test]
+        fn test_diesel_k32_null_handling() {
+            let mut conn = setup_nullable_db();
+
+            // Insert with and without values.
+            diesel::insert_into(nullable_k32::table)
+                .values(&[
+                    NullableKernelU32Test {
+                        id: 1,
+                        value: Some(KernelU32::from(42u32)),
+                    },
+                    NullableKernelU32Test { id: 2, value: None },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Retrieve entries.
+            let with_value: NullableKernelU32Test =
+                nullable_k32::table.find(1).first(&mut conn).unwrap();
+            let without_value: NullableKernelU32Test =
+                nullable_k32::table.find(2).first(&mut conn).unwrap();
+
+            assert_eq!(with_value.value.unwrap().get(), 42u32);
+            assert_eq!(without_value.value, None);
+
+            // Filter for NULL and NOT NULL.
+            let null_results: Vec<NullableKernelU32Test> = nullable_k32::table
+                .filter(nullable_k32::value.is_null())
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(null_results.len(), 1);
+            assert_eq!(null_results[0].id, 2);
+
+            let non_null_results: Vec<NullableKernelU32Test> = nullable_k32::table
+                .filter(nullable_k32::value.is_not_null())
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(non_null_results.len(), 1);
+            assert_eq!(non_null_results[0].id, 1);
+
+            // Update NULL to value.
+            diesel::update(nullable_k32::table.find(2))
+                .set(nullable_k32::value.eq(Some(KernelU32::from(100u32))))
+                .execute(&mut conn)
+                .unwrap();
+
+            let updated: NullableKernelU32Test =
+                nullable_k32::table.find(2).first(&mut conn).unwrap();
+            assert_eq!(updated.value.unwrap().get(), 100u32);
+
+            // Update value to NULL.
+            diesel::update(nullable_k32::table.find(1))
+                .set(nullable_k32::value.eq::<Option<KernelU32>>(None))
+                .execute(&mut conn)
+                .unwrap();
+
+            let nullified: NullableKernelU32Test =
+                nullable_k32::table.find(1).first(&mut conn).unwrap();
+            assert_eq!(nullified.value, None);
+        }
+    }
+
+    // Edge Case Handling.
+
+    #[test]
+    fn test_k32_exact_boundary_cases() {
+        // Test value exactly at u32::MAX.
+        let max_val = KernelU32::try_from(u32::MAX as i64).unwrap();
+        assert_eq!(max_val.get(), u32::MAX);
+
+        // Test value exactly one more than u32::MAX.
+        let overflow_val = KernelU32::try_from((u32::MAX as i64) + 1);
+        assert!(overflow_val.is_err());
+
+        // Test value exactly at 0.
+        let min_val = KernelU32::try_from(0i64).unwrap();
+        assert_eq!(min_val.get(), 0);
+
+        // Test value exactly one less than 0.
+        let underflow_val = KernelU32::try_from(-1i64);
+        assert!(underflow_val.is_err());
+    }
+}

--- a/bpfman/src/db/types/mod.rs
+++ b/bpfman/src/db/types/mod.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Column-level database types and wrappers.
+//!
+//! This internal module defines helper types used in Diesel models
+//! for representing non-standard Rust values in SQLite:
+//!
+//! - [`KernelU32`]: stores `u32` values in SQLite `BIGINT` columns
+//! - [`U64Blob`], [`U128Blob`], etc.: store fixed-size integers in
+//!   BLOB columns with strict encoding
+//!
+//! These wrappers provide:
+//!
+//! - Type safety for numeric IDs and identifiers
+//! - Fixed-size binary encoding (for BLOB columns)
+//! - Integration with Diesel (`ToSql`, `FromSql`, `AsExpression`, etc.)
+//! - Deserialisation-time size checks and conversions
+//!
+//! These are *not* domain types like [`BpfProgram`] or [`BpfMap`].
+//! For those, see the per-entity modules (`bpf_program.rs`, etc.).
+//!
+//! All types here are re-exported at the `crate::db` level, so users
+//! can write `use crate::db::KernelU32` without referring to
+//! implementation details.
+
+mod ku32;
+mod uintblob;
+
+pub use self::{
+    ku32::KernelU32,
+    uintblob::{U8Blob, U16Blob, U32Blob, U64Blob, U128Blob, UxBlobError},
+};

--- a/bpfman/src/db/types/uintblob.rs
+++ b/bpfman/src/db/types/uintblob.rs
@@ -1,0 +1,1187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Provides wrapper types ([`U8Blob`], [`U16Blob`], [`U32Blob`],
+//! [`U64Blob`], [`U128Blob`]) for storing Rust unsigned integers in
+//! SQLite BLOB columns. SQLite’s native INTEGER is signed (and capped
+//! at 64 bits), so to persist a Rust `u64` (or wider) you declare
+//! your schema column as BLOB but use `U64Blob` (or the appropriate
+//! width) in your Rust struct.
+//!
+//! On **write**, the wrapper converts the primitive into a
+//! fixed-length, big-endian byte array. On **read**, it converts back
+//! into the primitive, failing with `UIntBlobError::InvalidSize {
+//! expected, actual, type_name }` if the stored BLOB’s length does
+//! not exactly match the type’s byte width. This eliminates silent
+//! truncation or padding errors.
+//!
+//! ## Diesel Integration
+//!
+//! These types integrate seamlessly with Diesel's SQLite backend.
+//!
+//! They implement [`ToSql<Binary, Sqlite>`] and [`FromSql<Binary,
+//! Sqlite>`], and derive [`diesel::sql_types::Binary`] via
+//! [`diesel::expression::AsExpression`] and
+//! [`diesel::deserialize::FromSqlRow`].
+//!
+//! This allows them to be used directly in structs that derive
+//! `Insertable` and `Queryable`, without requiring manual trait
+//! implementations or extra annotations.
+//!
+//! # Example
+//!
+//! ```rust
+//! # use diesel::prelude::*;
+//! # use bpfman::{U32Blob, U16Blob, UxBlobError};
+//! # table! {
+//! #     counters (id) {
+//! #         id -> Integer,
+//! #         value -> Binary,
+//! #     }
+//! # }
+//! # #[derive(Queryable, Insertable)]
+//! # #[diesel(table_name = counters)]
+//! # struct Counter32 {
+//! #     id: i32,
+//! #     value: U32Blob,
+//! # }
+//! # #[derive(Debug, Queryable)]
+//! # #[diesel(table_name = counters)]
+//! # struct Counter16 {
+//! #     id: i32,
+//! #     value: U16Blob,
+//! # }
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut conn = SqliteConnection::establish(":memory:")?;
+//! # diesel::sql_query("CREATE TABLE counters (id INTEGER PRIMARY KEY, value BLOB NOT NULL)").execute(&mut conn)?;
+//!
+//! // Create U32Blob values and insert them.
+//! let counters = vec![
+//!     Counter32 { id: 1, value: U32Blob::from(100u32) },
+//!     Counter32 { id: 2, value: U32Blob::from(200u32) },
+//!     Counter32 { id: 3, value: U32Blob::from(50u32) },
+//! ];
+//!
+//! diesel::insert_into(counters::table)
+//!     .values(&counters)
+//!     .execute(&mut conn)?;
+//!
+//! // Query with ordering preserved (50, 100, 200).
+//! let ordered_results = counters::table
+//!     .order_by(counters::value.asc())
+//!     .load::<Counter32>(&mut conn)?;
+//!
+//! assert_eq!(ordered_results[0].value.get(), 50u32);
+//! assert_eq!(ordered_results[2].value.get(), 200u32);
+//!
+//! // Access the inner value using `.get()`.
+//! for counter in &ordered_results {
+//!     println!("id={} value={}", counter.id, counter.value.get());
+//! }
+//!
+//! // Filter for values greater than 75.
+//! let filtered_results = counters::table
+//!     .filter(counters::value.gt(U32Blob::from(75u32)))
+//!     .load::<Counter32>(&mut conn)?;
+//!
+//! assert_eq!(filtered_results.len(), 2); // 100 and 200
+//!
+//! // ERROR CASE: Attempting to read a U32Blob as U16Blob.
+//! let result = counters::table.find(1).first::<Counter16>(&mut conn);
+//!
+//! // This will fail with an UxBlobError.
+//! assert!(result.is_err());
+//! let error = result.unwrap_err().to_string();
+//! assert!(error.contains("Invalid input size"));
+//! # Ok(())
+//! # }
+//! ```
+
+use diesel::{
+    backend::Backend,
+    deserialize::{FromSql, FromSqlRow},
+    expression::AsExpression,
+    serialize::{IsNull, Output, ToSql},
+    sql_types::Binary,
+    sqlite::Sqlite,
+};
+use serde::{Deserialize, Serialize};
+
+/// Error type for decoding byte slices into unsigned integer
+/// wrappers.
+///
+/// These errors occur when validating binary input, typically read
+/// from SQLite BLOB columns, during deserialisation into typed
+/// wrappers like [`U32Blob`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum UxBlobError {
+    /// Error when the byte slice has an invalid size for the
+    /// requested type.
+    ///
+    /// This error occurs when converting a byte slice into a wrapped
+    /// integer type (e.g., [`U32Blob`]) and the slice length does not
+    /// match the expected size.
+    ///
+    /// # Fields
+    ///
+    /// * `expected` - The number of bytes expected for the requested type
+    /// * `actual` - The actual number of bytes in the provided slice
+    /// * `type_name` - The name of the requested type (e.g., "u16", "u32")
+    InvalidSize {
+        expected: usize,
+        actual: usize,
+        type_name: String,
+    },
+}
+
+impl std::fmt::Display for UxBlobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSize {
+                expected,
+                actual,
+                type_name,
+            } => {
+                write!(
+                    f,
+                    "Invalid input size: expected {} bytes for `{}`, got {}",
+                    expected, type_name, actual
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for UxBlobError {}
+
+impl From<UxBlobError> for diesel::result::Error {
+    fn from(err: UxBlobError) -> Self {
+        diesel::result::Error::DeserializationError(Box::new(err))
+    }
+}
+
+macro_rules! define_uint_blob {
+    ($name:ident, $type:ty) => {
+        /// A wrapper that stores an unsigned integer as a fixed-size
+        /// big-endian byte array.
+        ///
+        /// This encoding ensures that numeric ordering is preserved
+        /// when values are stored as BLOBs and compared
+        /// lexicographically, such as in SQLite.
+        ///
+        /// Internally, this wrapper has the same memory layout as the
+        /// underlying integer due to `#[repr(transparent)]`.
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow,
+        )]
+        #[diesel(sql_type = Binary)]
+        #[repr(transparent)]
+        pub struct $name($type);
+
+        impl $name {
+            /// Returns a copy of the inner value.
+            ///
+            /// This method provides read access to the wrapped
+            /// integer without consuming the blob.
+            pub fn get(&self) -> $type {
+                self.0
+            }
+
+            /// Consumes the blob, returning the inner value.
+            ///
+            /// Unlike [`Self::get()`], this method consumes the blob
+            /// and returns ownership of the inner value.
+            pub fn into_inner(self) -> $type {
+                self.0
+            }
+
+            /// Converts the inner value to a byte vector in
+            /// big-endian order.
+            ///
+            /// This method is used by [`Self::to_sql`] when
+            /// serialising this type for Diesel's SQLite backend. It
+            /// converts the inner value into a `Vec<u8>` formatted as
+            /// a fixed-size, big-endian byte array suitable for use
+            /// in SQLite BLOB columns.
+            ///
+            /// Note: This method allocates a new `Vec<u8>` each time.
+            /// This allocation is required by Diesel's SQLite API,
+            /// which expects owned data (`Vec<u8>`) in its
+            /// [`Output::set_value`] method.
+            fn to_bytes(self) -> Vec<u8> {
+                self.0.to_be_bytes().to_vec()
+            }
+
+            /// Decodes a big-endian byte slice into the wrapped
+            /// integer type.
+            ///
+            /// This method validates that the byte slice has exactly
+            /// the expected length for the type and converts it to
+            /// the target integer type in big-endian order. It uses
+            /// [`TryInto`] to convert the slice to a
+            /// fixed-size array, which automatically validates the
+            /// length.
+            fn from_bytes(bytes: &[u8]) -> Result<Self, UxBlobError> {
+                const EXPECTED_SIZE: usize = std::mem::size_of::<$type>();
+
+                let array: Result<[u8; EXPECTED_SIZE], _> = bytes.try_into();
+
+                match array {
+                    Ok(byte_array) => Ok($name(<$type>::from_be_bytes(byte_array))),
+                    Err(_) => Err(UxBlobError::InvalidSize {
+                        expected: EXPECTED_SIZE,
+                        actual: bytes.len(),
+                        type_name: std::any::type_name::<$type>().to_string(),
+                    }),
+                }
+            }
+        }
+
+        /// Allows constructing this wrapper from the underlying type
+        /// via [`From`].
+        impl From<$type> for $name {
+            fn from(value: $type) -> Self {
+                $name(value)
+            }
+        }
+
+        /// Implementation of [`diesel::serialize::ToSql<Binary,
+        /// Sqlite>`] for Diesel integration.
+        impl ToSql<Binary, Sqlite> for $name {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> diesel::serialize::Result {
+                out.set_value(self.to_bytes());
+                Ok(IsNull::No)
+            }
+        }
+
+        /// Implementation of [`diesel::deserialize::FromSql<Binary,
+        /// Sqlite>`] for Diesel integration.
+        impl FromSql<Binary, Sqlite> for $name {
+            fn from_sql(
+                bytes: <Sqlite as Backend>::RawValue<'_>,
+            ) -> diesel::deserialize::Result<Self> {
+                let blob = <Vec<u8> as FromSql<Binary, Sqlite>>::from_sql(bytes)?;
+                Self::from_bytes(&blob).map_err(|e| e.into())
+            }
+        }
+
+        // Display for consistent user-facing output.
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "{:0width$x}",
+                    self.0,
+                    width = std::mem::size_of::<$type>() * 2
+                )
+            }
+        }
+    };
+}
+
+define_uint_blob!(U8Blob, u8);
+define_uint_blob!(U16Blob, u16);
+define_uint_blob!(U32Blob, u32);
+define_uint_blob!(U64Blob, u64);
+define_uint_blob!(U128Blob, u128);
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use diesel::{dsl::count_star, prelude::*, sqlite::SqliteConnection};
+
+    use super::*;
+
+    macro_rules! test_diesel_boundary_values {
+        ($name:ident, $type:ty, $blob_type:ty) => {
+            #[test]
+            fn $name() {
+                table! {
+                    boundary_test (id) {
+                        id -> Integer,
+                        value -> Binary,
+                    }
+                }
+
+                #[derive(Queryable)]
+                #[allow(dead_code)]
+                struct BoundaryTest {
+                    id: i32,
+                    value: $blob_type,
+                }
+
+                let mut conn = SqliteConnection::establish(":memory:").unwrap();
+                diesel::sql_query(
+                    "CREATE TABLE boundary_test (id INTEGER PRIMARY KEY, value BLOB NOT NULL)",
+                )
+                .execute(&mut conn)
+                .unwrap();
+
+                diesel::insert_into(boundary_test::table)
+                    .values((
+                        boundary_test::id.eq(1),
+                        boundary_test::value.eq(<$blob_type>::from(0 as $type)),
+                    ))
+                    .execute(&mut conn)
+                    .unwrap();
+
+                diesel::insert_into(boundary_test::table)
+                    .values((
+                        boundary_test::id.eq(2),
+                        boundary_test::value.eq(<$blob_type>::from(<$type>::MAX)),
+                    ))
+                    .execute(&mut conn)
+                    .unwrap();
+
+                let min_value = boundary_test::table
+                    .find(1)
+                    .first::<BoundaryTest>(&mut conn)
+                    .unwrap();
+
+                let max_value = boundary_test::table
+                    .find(2)
+                    .first::<BoundaryTest>(&mut conn)
+                    .unwrap();
+
+                assert_eq!(min_value.value.get(), 0 as $type);
+                assert_eq!(max_value.value.get(), <$type>::MAX);
+            }
+        };
+    }
+
+    macro_rules! test_blob_generic {
+        ($name:ident, $blob:ty, $val:expr) => {
+            #[test]
+            fn $name() {
+                let blob: $blob = <$blob>::from($val);
+                assert_eq!(<$blob>::from_bytes(&blob.to_bytes()).unwrap().get(), $val);
+            }
+        };
+    }
+
+    test_blob_generic!(roundtrip_u8, U8Blob, 42u8);
+    test_blob_generic!(roundtrip_u128, U128Blob, u128::MAX);
+
+    test_diesel_boundary_values!(test_u8_boundary_values, u8, U8Blob);
+    test_diesel_boundary_values!(test_u16_boundary_values, u16, U16Blob);
+    test_diesel_boundary_values!(test_u32_boundary_values, u32, U32Blob);
+    test_diesel_boundary_values!(test_u64_boundary_values, u64, U64Blob);
+    test_diesel_boundary_values!(test_u128_boundary_values, u128, U128Blob);
+
+    #[cfg(test)]
+    mod diesel_crud_operations {
+        use super::*;
+
+        table! {
+            blob_crud (id) {
+                id -> Integer,
+                name -> Text,
+                value_u8 -> Binary,
+                value_u64 -> Binary,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = blob_crud)]
+        struct CrudEntry {
+            id: i32,
+            name: String,
+            value_u8: U8Blob,
+            value_u64: U64Blob,
+        }
+
+        fn setup_crud() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE blob_crud (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                value_u8 BLOB NOT NULL,
+                value_u64 BLOB NOT NULL
+            )",
+            )
+            .execute(&mut conn)
+            .unwrap();
+            conn
+        }
+
+        #[test]
+        fn test_crud_insertion() {
+            let entry = CrudEntry {
+                id: 1,
+                name: "Test".into(),
+                value_u8: U8Blob::from(42),
+                value_u64: U64Blob::from(1_000),
+            };
+
+            let rows = diesel::insert_into(blob_crud::table)
+                .values(&entry)
+                .execute(&mut setup_crud())
+                .unwrap();
+            assert_eq!(rows, 1);
+        }
+
+        #[test]
+        fn test_crud_read() {
+            let mut conn = setup_crud();
+
+            let entry = CrudEntry {
+                id: 1,
+                name: "ReadMe".into(),
+                value_u8: U8Blob::from(7),
+                value_u64: U64Blob::from(777),
+            };
+
+            diesel::insert_into(blob_crud::table)
+                .values(&entry)
+                .execute(&mut conn)
+                .unwrap();
+
+            let fetched: CrudEntry = blob_crud::table.find(1).first(&mut conn).unwrap();
+            assert_eq!(fetched, entry);
+        }
+
+        #[test]
+        fn test_crud_filter() {
+            let mut conn = setup_crud();
+
+            let entries = vec![
+                CrudEntry {
+                    id: 1,
+                    name: "A".into(),
+                    value_u8: U8Blob::from(10),
+                    value_u64: U64Blob::from(100),
+                },
+                CrudEntry {
+                    id: 2,
+                    name: "B".into(),
+                    value_u8: U8Blob::from(20),
+                    value_u64: U64Blob::from(200),
+                },
+            ];
+
+            diesel::insert_into(blob_crud::table)
+                .values(&entries)
+                .execute(&mut conn)
+                .unwrap();
+
+            let filtered: Vec<CrudEntry> = blob_crud::table
+                .filter(blob_crud::value_u8.eq(U8Blob::from(20)))
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(filtered[0].id, 2);
+        }
+
+        #[test]
+        fn test_crud_update() {
+            let mut conn = setup_crud();
+
+            let entry = CrudEntry {
+                id: 1,
+                name: "Updatable".into(),
+                value_u8: U8Blob::from(5),
+                value_u64: U64Blob::from(500),
+            };
+
+            diesel::insert_into(blob_crud::table)
+                .values(&entry)
+                .execute(&mut conn)
+                .unwrap();
+
+            let updated = diesel::update(blob_crud::table.find(1))
+                .set(blob_crud::value_u8.eq(U8Blob::from(55)))
+                .execute(&mut conn)
+                .unwrap();
+
+            assert_eq!(updated, 1);
+            let fetched: CrudEntry = blob_crud::table.find(1).first(&mut conn).unwrap();
+            assert_eq!(fetched.value_u8.get(), 55);
+        }
+
+        #[test]
+        fn test_crud_delete() {
+            let mut conn = setup_crud();
+
+            let entry = CrudEntry {
+                id: 1,
+                name: "Deletable".into(),
+                value_u8: U8Blob::from(9),
+                value_u64: U64Blob::from(900),
+            };
+
+            diesel::insert_into(blob_crud::table)
+                .values(&entry)
+                .execute(&mut conn)
+                .unwrap();
+
+            let deleted =
+                diesel::delete(blob_crud::table.filter(blob_crud::value_u8.eq(U8Blob::from(9))))
+                    .execute(&mut conn)
+                    .unwrap();
+
+            assert_eq!(deleted, 1);
+            let remaining: Vec<CrudEntry> = blob_crud::table.load(&mut conn).unwrap();
+            assert!(remaining.is_empty());
+        }
+    }
+
+    #[cfg(test)]
+    mod diesel_edge_cases {
+        use super::*;
+
+        // Type mismatch when reading wrong-sized BLOB.
+        table! {
+            type_test (id) {
+                id -> Integer,
+                value -> Binary,
+            }
+        }
+
+        #[derive(Debug, Insertable, Queryable)]
+        #[diesel(table_name = type_test)]
+        struct TypeTestU16 {
+            id: i32,
+            value: U16Blob,
+        }
+
+        #[derive(Debug, Insertable, Queryable)]
+        #[diesel(table_name = type_test)]
+        struct TypeTestU32 {
+            id: i32,
+            value: U32Blob,
+        }
+
+        #[test]
+        fn diesel_type_mismatch_read() {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE type_test (id INTEGER PRIMARY KEY, value BLOB NOT NULL)",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            diesel::insert_into(type_test::table)
+                .values(&TypeTestU16 {
+                    id: 1,
+                    value: U16Blob::from(12345),
+                })
+                .execute(&mut conn)
+                .unwrap();
+
+            let result = type_test::table.find(1).first::<TypeTestU32>(&mut conn);
+
+            assert!(result.is_err());
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Invalid input size")
+            );
+        }
+
+        // Empty and undersized BLOBs.
+        table! {
+            blob_test (id) {
+                id -> Integer,
+                size_type -> Text,
+                value -> Binary,
+            }
+        }
+
+        #[derive(Debug, Queryable)]
+        #[allow(dead_code)]
+        struct BlobTestU8 {
+            id: i32,
+            size_type: String,
+            value: U8Blob,
+        }
+        #[derive(Debug, Queryable)]
+        #[allow(dead_code)]
+        struct BlobTestU16 {
+            id: i32,
+            size_type: String,
+            value: U16Blob,
+        }
+
+        #[test]
+        fn diesel_empty_and_undersized_blob() {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE blob_test (id INTEGER PRIMARY KEY, size_type TEXT, value BLOB)",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            diesel::sql_query(
+                "INSERT INTO blob_test (id, size_type, value) VALUES (1, 'empty', X'')",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            diesel::sql_query(
+                "INSERT INTO blob_test (id, size_type, value) VALUES (2, 'undersized', X'2A')",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            let err_empty = blob_test::table
+                .filter(blob_test::size_type.eq("empty"))
+                .first::<BlobTestU8>(&mut conn);
+
+            assert!(err_empty.is_err());
+            assert!(
+                err_empty
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Invalid input size")
+            );
+
+            let err_undersized = blob_test::table
+                .filter(blob_test::size_type.eq("undersized"))
+                .first::<BlobTestU16>(&mut conn);
+
+            assert!(err_undersized.is_err());
+            assert!(
+                err_undersized
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Invalid input size")
+            );
+        }
+
+        // Update with wrong size.
+        table! {
+            update_test (id) {
+                id -> Integer,
+                value -> Binary,
+            }
+        }
+
+        #[derive(Debug, Insertable, Queryable, Identifiable, AsChangeset)]
+        #[diesel(table_name = update_test)]
+        struct UpdateTestU16 {
+            id: i32,
+            value: U16Blob,
+        }
+
+        #[test]
+        fn diesel_update_wrong_size() {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE update_test (id INTEGER PRIMARY KEY, value BLOB NOT NULL)",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            diesel::insert_into(update_test::table)
+                .values(&UpdateTestU16 {
+                    id: 1,
+                    value: U16Blob::from(42),
+                })
+                .execute(&mut conn)
+                .unwrap();
+
+            // DB-level update succeeds.
+            let update_ok = diesel::update(update_test::table.find(1))
+                .set(update_test::value.eq(U32Blob::from(43)))
+                .execute(&mut conn);
+
+            assert!(update_ok.is_ok());
+
+            // Retrieval fails due to wrong blob size.
+            let err = update_test::table.find(1).first::<UpdateTestU16>(&mut conn);
+            assert!(err.is_err());
+            assert!(err.unwrap_err().to_string().contains("Invalid input size"));
+        }
+    }
+
+    #[cfg(test)]
+    mod diesel_query_operations {
+        use super::*;
+
+        table! {
+            blob_query (id) {
+                id -> Integer,
+                category -> Text,
+                value_u8 -> Binary,
+                value_u16 -> Binary,
+                value_u32 -> Binary,
+                value_u64 -> Binary,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = blob_query)]
+        struct BlobQueryEntry {
+            id: i32,
+            category: String,
+            value_u8: U8Blob,
+            value_u16: U16Blob,
+            value_u32: U32Blob,
+            value_u64: U64Blob,
+        }
+
+        fn setup_test_data() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE blob_query (
+                id INTEGER PRIMARY KEY,
+                category TEXT NOT NULL,
+                value_u8 BLOB NOT NULL,
+                value_u16 BLOB NOT NULL,
+                value_u32 BLOB NOT NULL,
+                value_u64 BLOB NOT NULL
+            )",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            let entries = vec![
+                BlobQueryEntry {
+                    id: 1,
+                    category: "A".into(),
+                    value_u8: 10.into(),
+                    value_u16: 1000.into(),
+                    value_u32: 100_000.into(),
+                    value_u64: 10_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 2,
+                    category: "A".into(),
+                    value_u8: 20.into(),
+                    value_u16: 2000.into(),
+                    value_u32: 200_000.into(),
+                    value_u64: 20_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 3,
+                    category: "A".into(),
+                    value_u8: 30.into(),
+                    value_u16: 3000.into(),
+                    value_u32: 300_000.into(),
+                    value_u64: 30_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 4,
+                    category: "B".into(),
+                    value_u8: 100.into(),
+                    value_u16: 10_000.into(),
+                    value_u32: 1_000_000.into(),
+                    value_u64: 40_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 5,
+                    category: "B".into(),
+                    value_u8: 150.into(),
+                    value_u16: 15_000.into(),
+                    value_u32: 1_500_000.into(),
+                    value_u64: 50_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 6,
+                    category: "C".into(),
+                    value_u8: 0.into(),
+                    value_u16: 0.into(),
+                    value_u32: 0.into(),
+                    value_u64: 0.into(),
+                },
+                BlobQueryEntry {
+                    id: 7,
+                    category: "C".into(),
+                    value_u8: 255.into(),
+                    value_u16: u16::MAX.into(),
+                    value_u32: u32::MAX.into(),
+                    value_u64: (i64::MAX as u64).into(),
+                },
+                BlobQueryEntry {
+                    id: 8,
+                    category: "D".into(),
+                    value_u8: 50.into(),
+                    value_u16: 5000.into(),
+                    value_u32: 500_000.into(),
+                    value_u64: 5_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 9,
+                    category: "D".into(),
+                    value_u8: 50.into(),
+                    value_u16: 5000.into(),
+                    value_u32: 600_000.into(),
+                    value_u64: 6_000_000_000.into(),
+                },
+                BlobQueryEntry {
+                    id: 10,
+                    category: "D".into(),
+                    value_u8: 50.into(),
+                    value_u16: 6000.into(),
+                    value_u32: 700_000.into(),
+                    value_u64: 7_000_000_000.into(),
+                },
+            ];
+
+            diesel::insert_into(blob_query::table)
+                .values(&entries)
+                .execute(&mut conn)
+                .unwrap();
+
+            conn
+        }
+
+        #[test]
+        fn test_insertion_and_counting() {
+            let counts: HashMap<String, usize> = blob_query::table
+                .load(&mut setup_test_data())
+                .unwrap()
+                .into_iter()
+                .fold(HashMap::new(), |mut acc, row: BlobQueryEntry| {
+                    *acc.entry(row.category).or_insert(0) += 1;
+                    acc
+                });
+
+            let expected: HashMap<String, usize> = HashMap::from([
+                ("A".to_string(), 3),
+                ("B".to_string(), 2),
+                ("C".to_string(), 2),
+                ("D".to_string(), 3),
+            ]);
+
+            assert_eq!(counts, expected);
+        }
+
+        #[test]
+        fn test_filter_eq() {
+            assert_eq!(
+                blob_query::table
+                    .filter(blob_query::value_u8.eq(U8Blob::from(50)))
+                    .load::<BlobQueryEntry>(&mut setup_test_data())
+                    .unwrap()
+                    .len(),
+                3
+            );
+        }
+
+        #[test]
+        fn test_filter_ne() {
+            assert_eq!(
+                blob_query::table
+                    .filter(blob_query::value_u8.ne(U8Blob::from(50)))
+                    .load::<BlobQueryEntry>(&mut setup_test_data())
+                    .unwrap()
+                    .len(),
+                7
+            );
+        }
+
+        #[test]
+        fn test_filter_range() {
+            assert_eq!(
+                blob_query::table
+                    .filter(blob_query::value_u16.ge(U16Blob::from(2000)))
+                    .filter(blob_query::value_u16.lt(U16Blob::from(10000)))
+                    .load::<BlobQueryEntry>(&mut setup_test_data())
+                    .unwrap()
+                    .len(),
+                5
+            );
+        }
+
+        #[test]
+        fn test_filter_or() {
+            assert_eq!(
+                blob_query::table
+                    .filter(
+                        blob_query::value_u8
+                            .eq(U8Blob::from(0))
+                            .or(blob_query::value_u8.eq(U8Blob::from(255)))
+                    )
+                    .load::<BlobQueryEntry>(&mut setup_test_data())
+                    .unwrap()
+                    .len(),
+                2
+            );
+        }
+
+        #[test]
+        fn test_count_filter() {
+            let count: i64 = blob_query::table
+                .filter(blob_query::value_u8.gt(U8Blob::from(50)))
+                .count()
+                .get_result(&mut setup_test_data())
+                .unwrap();
+            assert_eq!(count, 3);
+        }
+
+        #[test]
+        fn test_group_by() {
+            let results: Vec<(String, i64)> = blob_query::table
+                .group_by(blob_query::category)
+                .select((blob_query::category, count_star()))
+                .order(blob_query::category.asc())
+                .load(&mut setup_test_data())
+                .unwrap();
+            assert_eq!(
+                results,
+                vec![
+                    ("A".into(), 3),
+                    ("B".into(), 2),
+                    ("C".into(), 2),
+                    ("D".into(), 3)
+                ]
+            );
+        }
+
+        #[test]
+        fn test_distinct_values() {
+            let distinct: Vec<U8Blob> = blob_query::table
+                .select(blob_query::value_u8)
+                .filter(blob_query::category.eq("D"))
+                .distinct()
+                .load(&mut setup_test_data())
+                .unwrap();
+            assert_eq!(distinct, vec![U8Blob::from(50)]);
+        }
+
+        #[test]
+        fn test_order_ascending_u16() {
+            let vals: Vec<_> = blob_query::table
+                .filter(blob_query::category.eq("A"))
+                .order(blob_query::value_u16.asc())
+                .load(&mut setup_test_data())
+                .unwrap()
+                .iter()
+                .map(|e: &BlobQueryEntry| e.value_u16.get())
+                .collect();
+            assert_eq!(vals, vec![1000, 2000, 3000]);
+        }
+
+        #[test]
+        fn test_order_descending_u64() {
+            let first = blob_query::table
+                .order(blob_query::value_u64.desc())
+                .limit(1)
+                .first::<BlobQueryEntry>(&mut setup_test_data())
+                .unwrap();
+            assert_eq!(first.value_u64.get(), 9_223_372_036_854_775_807u64);
+        }
+
+        #[test]
+        fn test_complex_filtering() {
+            let mut conn = setup_test_data();
+            let entries = blob_query::table
+                .filter(
+                    blob_query::category
+                        .eq("A")
+                        .and(blob_query::value_u16.lt(U16Blob::from(3000)))
+                        .or(blob_query::category
+                            .eq("B")
+                            .and(blob_query::value_u8.gt(U8Blob::from(100)))),
+                )
+                .order(blob_query::id.asc())
+                .load::<BlobQueryEntry>(&mut conn)
+                .unwrap();
+            assert_eq!(
+                entries.iter().map(|e| e.id).collect::<Vec<_>>(),
+                vec![1, 2, 5]
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod diesel_null_handling {
+        use super::*;
+
+        table! {
+            nullable_blobs (id) {
+                id -> Integer,
+                name -> Text,
+                optional_value -> Nullable<Binary>,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = nullable_blobs)]
+        struct NullableEntry {
+            id: i32,
+            name: String,
+            optional_value: Option<U32Blob>,
+        }
+
+        fn setup_nullable_table() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+            diesel::sql_query(
+                "CREATE TABLE nullable_blobs (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                optional_value BLOB
+            )",
+            )
+            .execute(&mut conn)
+            .unwrap();
+
+            conn
+        }
+
+        #[test]
+        fn test_insert_and_read_null_values() {
+            let mut conn = setup_nullable_table();
+
+            // Insert entries with and without values.
+            let entries = vec![
+                NullableEntry {
+                    id: 1,
+                    name: "Has Value".into(),
+                    optional_value: Some(U32Blob::from(42u32)),
+                },
+                NullableEntry {
+                    id: 2,
+                    name: "No Value".into(),
+                    optional_value: None,
+                },
+            ];
+
+            diesel::insert_into(nullable_blobs::table)
+                .values(&entries)
+                .execute(&mut conn)
+                .unwrap();
+
+            // Test reading entries.
+            let results: Vec<NullableEntry> = nullable_blobs::table
+                .order_by(nullable_blobs::id)
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(results.len(), 2);
+            assert_eq!(results[0].optional_value, Some(U32Blob::from(42u32)));
+            assert_eq!(results[1].optional_value, None);
+        }
+
+        #[test]
+        fn test_filter_null_values() {
+            let mut conn = setup_nullable_table();
+
+            diesel::insert_into(nullable_blobs::table)
+                .values(&vec![
+                    NullableEntry {
+                        id: 1,
+                        name: "One".into(),
+                        optional_value: Some(U32Blob::from(1u32)),
+                    },
+                    NullableEntry {
+                        id: 2,
+                        name: "Two".into(),
+                        optional_value: None,
+                    },
+                    NullableEntry {
+                        id: 3,
+                        name: "Three".into(),
+                        optional_value: Some(U32Blob::from(3u32)),
+                    },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Test filtering for NULL values.
+            let null_entries: Vec<NullableEntry> = nullable_blobs::table
+                .filter(nullable_blobs::optional_value.is_null())
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(null_entries.len(), 1);
+            assert_eq!(null_entries[0].id, 2);
+
+            // Test filtering for non-NULL values.
+            let non_null_entries: Vec<NullableEntry> = nullable_blobs::table
+                .filter(nullable_blobs::optional_value.is_not_null())
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(non_null_entries.len(), 2);
+            assert!(non_null_entries.iter().all(|e| e.optional_value.is_some()));
+        }
+
+        #[test]
+        fn test_update_null_values() {
+            let mut conn = setup_nullable_table();
+
+            diesel::insert_into(nullable_blobs::table)
+                .values(&vec![
+                    NullableEntry {
+                        id: 1,
+                        name: "Initially has value".into(),
+                        optional_value: Some(U32Blob::from(42u32)),
+                    },
+                    NullableEntry {
+                        id: 2,
+                        name: "Initially null".into(),
+                        optional_value: None,
+                    },
+                ])
+                .execute(&mut conn)
+                .unwrap();
+
+            // Update: value -> NULL.
+            diesel::update(nullable_blobs::table.find(1))
+                .set(nullable_blobs::optional_value.eq::<Option<U32Blob>>(None))
+                .execute(&mut conn)
+                .unwrap();
+
+            // Update: NULL -> value
+            diesel::update(nullable_blobs::table.find(2))
+                .set(nullable_blobs::optional_value.eq(Some(U32Blob::from(100u32))))
+                .execute(&mut conn)
+                .unwrap();
+
+            let results: Vec<NullableEntry> = nullable_blobs::table
+                .order_by(nullable_blobs::id)
+                .load(&mut conn)
+                .unwrap();
+
+            assert_eq!(results[0].optional_value, None);
+            assert_eq!(results[1].optional_value, Some(U32Blob::from(100u32)));
+        }
+    }
+
+    #[test]
+    fn test_malicious_looking_blob() {
+        table! {
+            x (id) {
+                id -> Integer,
+                value -> Binary,
+            }
+        }
+
+        #[derive(Debug, PartialEq, Queryable, Insertable)]
+        #[diesel(table_name = x)]
+        struct Row {
+            id: i32,
+            value: U128Blob,
+        }
+
+        const MALICIOUS_LOOKING_BLOB: [u8; 16] = *b"DROP TABLE x;\0\0\0";
+
+        let blob = U128Blob::from_bytes(&MALICIOUS_LOOKING_BLOB).unwrap();
+
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        diesel::sql_query("CREATE TABLE x (id INTEGER PRIMARY KEY, value BLOB NOT NULL)")
+            .execute(&mut conn)
+            .unwrap();
+
+        let inserted = Row { id: 1, value: blob };
+        diesel::insert_into(x::table)
+            .values(&inserted)
+            .execute(&mut conn)
+            .unwrap();
+
+        let retrieved: Row = x::table.filter(x::id.eq(1)).first(&mut conn).unwrap();
+        assert_eq!(inserted, retrieved);
+    }
+}

--- a/bpfman/src/program_loader.rs
+++ b/bpfman/src/program_loader.rs
@@ -1,0 +1,717 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! # Program Loader Module
+//!
+//! This module is responsible for loading and unloading eBPF programs
+//! into and out of the kernel. It handles the parsing of eBPF
+//! bytecode, loading of individual programs (along with any
+//! associated maps), and, if a load error occurs, performing a
+//! best-effort rollback by unloading any programs that were already
+//! loaded. This module uses the [aya] library for interfacing with
+//! the kernel.
+//!
+//! ## Separation of Concerns
+//!
+//! Note: This module focuses solely on kernel-level operations
+//! (loading/unloading eBPF programs). It does not deal with database
+//! (DB) persistence. Database-related actions are handled by a higher
+//! layer (e.g., the public API function that wraps these kernel
+//! operations in a DB transaction). In the event of a DB persistence
+//! failure, the higher layer will use the unload functionality
+//! provided here to roll back the kernel state.
+//!
+//! [aya]: https://github.com/aya-rs/aya
+use std::{collections::HashMap, path::PathBuf};
+
+use aya::{Ebpf, maps::Map};
+use chrono::Utc;
+use derive_builder::Builder;
+use serde::Serialize;
+use serde_json;
+use thiserror::Error;
+
+use crate::{
+    BpfmanError, calc_map_pin_path, create_map_pin_path,
+    db::{BpfMap, BpfProgram, KernelU32, U64Blob},
+    directories::*,
+    init_image_manager,
+    types::{Location, ProgramType},
+    utils::should_map_be_pinned,
+};
+
+/// The `LoadSpec` struct defines the parameters required for loading eBPF
+/// programs.
+///
+/// This struct is used to configure the details for loading eBPF programs,
+/// including program bytecode, function names, global data, metadata, and
+/// other related parameters.
+///
+/// It uses a **builder pattern** to construct instances of `LoadSpec`,
+/// allowing for flexible and incremental configuration of the struct's
+/// fields.
+///
+/// ```rust
+/// use bpfman::program_loader::LoadSpecBuilder;
+/// use bpfman::types::Location;
+///
+/// let load_spec = LoadSpecBuilder::default()
+///     .bytecode_source(Location::File("path/to/program.o".to_string()))
+///     .global_data(vec![("key1".to_string(), b"value1".to_vec())])
+///     .build();
+/// ```
+///
+/// # Notes
+/// - The `global_data` and `metadata` fields are also optional and will
+///   default to `None` if not provided. These fields are serialized to JSON
+///   when the struct is built.
+#[derive(Debug, Builder)]
+#[builder(pattern = "mutable", build_fn(name = "build_partial"))]
+pub struct LoadSpec {
+    #[builder(setter(into))]
+    bytecode_source: Location,
+
+    #[builder(setter(into))]
+    programs: Vec<ProgramType>,
+
+    #[builder(setter(strip_option), default)]
+    global_data: Option<Vec<(String, Vec<u8>)>>,
+
+    #[builder(setter(strip_option), default)]
+    metadata: Option<Vec<(String, String)>>,
+
+    #[builder(default)]
+    map_owner_id: Option<u32>,
+
+    // The following fields are computed in build().
+    #[builder(setter(skip))]
+    global_data_json: Option<String>,
+
+    #[builder(setter(skip))]
+    metadata_json: Option<String>,
+}
+
+/// Represents errors encountered during the construction of a
+/// `LoadSpec`.
+///
+/// These errors may occur during the builder's `build()` process,
+/// either due to missing required fields or failures during
+/// serialisation of data to JSON.
+#[derive(Debug, Error)]
+pub enum LoadSpecError {
+    /// Indicates that one or more required fields were not
+    /// initialised before calling `build()`. The inner string
+    /// describes the missing fields, as reported by `derive_builder`.
+    #[error("failed to build partial LoadSpec: {0}")]
+    UninitialisedFields(String),
+
+    /// An error occurred while serialising the global data map to a
+    /// JSON string.
+    ///
+    /// This usually indicates invalid input in the `global_data`
+    /// field of the builder. The underlying `serde_json::Error` is
+    /// preserved as the source.
+    #[error("error serialising global data to JSON")]
+    GlobalDataSerialisation(#[from] serde_json::Error),
+
+    /// An error occurred while serialising the metadata map to a JSON
+    /// string.
+    ///
+    /// Unlike `GlobalDataSerialisation`, this wraps the source
+    /// explicitly in a named field so that it doesn’t conflict with
+    /// the `#[from]` path used earlier.
+    #[error("error serialising metadata to JSON")]
+    MetadataSerialisation {
+        /// The original error returned by `serde_json::to_string`.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+impl LoadSpecBuilder {
+    /// Finalises the [`LoadSpecBuilder`] into a complete [`LoadSpec`]
+    /// instance.
+    ///
+    /// This method performs the following:
+    ///
+    /// 1. Calls [`Self::build_partial`] to perform structural
+    ///    validation and assemble a `LoadSpec`.
+    /// 2. Serialises the optional
+    ///    [`global_data`](LoadSpecBuilder::global_data) and
+    ///    [`metadata`](LoadSpecBuilder::metadata) fields to JSON
+    ///    strings for storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`LoadSpecError`](crate::program_loader::LoadSpecError) if:
+    ///
+    /// - Required fields are missing ([`LoadSpecError::UninitialisedFields`]).
+    /// - JSON serialisation of global data fails ([`LoadSpecError::GlobalDataSerialisation`]).
+    /// - JSON serialisation of metadata fails ([`LoadSpecError::MetadataSerialisation`]).
+    ///
+    /// # Returns
+    ///
+    /// A fully constructed
+    /// [`LoadSpec`](crate::program_loader::LoadSpec) ready for use in
+    /// loading eBPF programs.
+    pub fn build(&mut self) -> Result<LoadSpec, LoadSpecError> {
+        let mut spec = self
+            .build_partial()
+            .map_err(|e| LoadSpecError::UninitialisedFields(e.to_string()))?;
+
+        spec.global_data_json = match &spec.global_data {
+            Some(data) if !data.is_empty() => {
+                Some(serde_json::to_string(&Self::global_data_to_map(data))?)
+            }
+            _ => None,
+        };
+
+        spec.metadata_json = match &spec.metadata {
+            Some(data) if !data.is_empty() => {
+                Some(serde_json::to_string(&Self::metadata_to_map(data))?)
+            }
+            _ => None,
+        };
+
+        Ok(spec)
+    }
+
+    /// Converts a list of `(key, value)` byte arrays into a
+    /// [`HashMap<String, Vec<u8>>`](std::collections::HashMap).
+    ///
+    /// Used to convert [`LoadSpecBuilder::global_data`] into a
+    /// serialisable map format before encoding it as JSON.
+    fn global_data_to_map(data: &[(String, Vec<u8>)]) -> HashMap<String, Vec<u8>> {
+        data.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    }
+
+    /// Converts a list of `(key, value)` string pairs into a
+    /// [`HashMap<String, String>`](std::collections::HashMap).
+    ///
+    /// Used to convert [`LoadSpecBuilder::metadata`] into a
+    /// serialisable map format before encoding it as JSON.
+    fn metadata_to_map(data: &[(String, String)]) -> HashMap<String, String> {
+        data.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    }
+}
+
+/// Represents a program that was successfully loaded into the kernel,
+/// along with any associated pinned maps.
+///
+/// This structure records the state of an eBPF program at the time of
+/// its successful kernel load. Depending on subsequent operations,
+/// the program may still be live in the kernel, or it may have been
+/// unloaded (rolled back) due to an error in a later phase (such as
+/// database persistence).
+///
+/// In both cases, the information contained in this structure remains
+/// accurate and useful as a historical record of the load operation.
+/// However, whether the program is currently live or not must be
+/// interpreted in the context of subsequent unload operations.
+#[derive(Debug, Serialize)]
+pub struct LoadedProgram {
+    pub kind: ProgramType, // XXX(frobware): do we really need this?
+    pub program: BpfProgram,
+    pub maps: Vec<BpfMap>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UnloadError {
+    #[error("Failed to unload program {program_id}: {source}")]
+    Failure {
+        program_id: KernelU32,
+        #[source]
+        source: BpfmanError,
+    },
+}
+
+/// Converts an [`aya::maps::Map`] into a [`BpfMap`] by extracting
+/// metadata such as ID, type, key/value sizes, and max entries.
+///
+/// This is used during program load to persist map metadata in the
+/// database for later inspection or bookkeeping.
+fn build_bpfmap_from_aya_map(data: &Map, map_name: &str) -> Result<BpfMap, aya::maps::MapError> {
+    let info = match data {
+        Map::Array(d)
+        | Map::BloomFilter(d)
+        | Map::CpuMap(d)
+        | Map::DevMap(d)
+        | Map::DevMapHash(d)
+        | Map::HashMap(d)
+        | Map::LpmTrie(d)
+        | Map::LruHashMap(d)
+        | Map::PerCpuArray(d)
+        | Map::PerCpuHashMap(d)
+        | Map::PerCpuLruHashMap(d)
+        | Map::PerfEventArray(d)
+        | Map::ProgramArray(d)
+        | Map::Queue(d)
+        | Map::RingBuf(d)
+        | Map::SockHash(d)
+        | Map::SockMap(d)
+        | Map::Stack(d)
+        | Map::StackTraceMap(d)
+        | Map::XskMap(d) => d.info()?,
+        Map::Unsupported(d) => d.info()?,
+    };
+
+    Ok(BpfMap {
+        id: info.id().into(),
+        name: map_name.to_string(),
+        map_type: Some(format!("{:?}", info.map_type()?)),
+        key_size: KernelU32::from(info.key_size()),
+        value_size: KernelU32::from(info.value_size()),
+        max_entries: KernelU32::from(info.max_entries()),
+        created_at: Utc::now().naive_utc(),
+        updated_at: None,
+    })
+}
+
+/// Constructs a [`BpfProgram`] from a loaded
+/// [`aya::programs::ProgramInfo`] and the corresponding
+/// [`ProgramType`] and [`LoadSpec`].
+///
+/// This extracts both kernel metadata and user-supplied fields (e.g.,
+/// global data, metadata, source path) to produce a fully populated
+/// `BpfProgram` ready for DB persistence.
+fn build_bpfprogram_from_aya_program(
+    prog_info: &aya::programs::ProgramInfo,
+    program_type: &ProgramType,
+    program_bytes: &[u8],
+    spec: &LoadSpec,
+    map_pin_path_str: &str,
+) -> Result<BpfProgram, BpfmanError> {
+    let (location_type, file_path, image_url, image_pull_policy, username, password) =
+        match &spec.bytecode_source {
+            Location::File(path) => ("file", Some(path.clone()), None, None, None, None),
+            Location::Image(image) => (
+                "image",
+                None,
+                Some(image.image_url.clone()),
+                Some(image.image_pull_policy.to_string()),
+                image.username.clone(),
+                image.password.clone(),
+            ),
+        };
+
+    if location_type == "file" && file_path.is_none() {
+        return Err(BpfmanError::Error(
+            "File-based program requires a file path".to_string(),
+        ));
+    }
+    if location_type == "image" && image_url.is_none() {
+        return Err(BpfmanError::Error(
+            "Image-based program requires an image URL".to_string(),
+        ));
+    }
+
+    let kernel_name = prog_info
+        .name_as_str()
+        .map(|n| n.to_string())
+        .or_else(|| Some(format!("prog_{}", prog_info.id())));
+
+    let kernel_loaded_at = prog_info
+        .loaded_at()
+        .map(|t| chrono::DateTime::<Utc>::from(t).to_rfc3339());
+
+    let prog_name = program_type
+        .function_name()
+        .ok_or_else(|| BpfmanError::BpfFunctionNameNotValid("<none>".to_string()))?;
+
+    Ok(BpfProgram {
+        id: prog_info.id().into(),
+        name: prog_name.to_owned(),
+        kind: program_type.type_str().to_owned(),
+        state: "loaded".to_string(),
+        location_type: location_type.to_owned(),
+        file_path,
+        image_url,
+        image_pull_policy,
+        username,
+        password,
+        map_pin_path: map_pin_path_str.to_owned(),
+        map_owner_id: spec.map_owner_id.map(KernelU32::from),
+        program_bytes: program_bytes.into(),
+        metadata: spec.metadata_json.clone(),
+        global_data: spec.global_data_json.clone(),
+        retprobe: program_type.is_retprobe(),
+        fn_name: program_type.function_name().map(String::from),
+        kernel_name,
+        kernel_program_type: prog_info
+            .program_type()
+            .ok()
+            .map(|pt| KernelU32::from(pt as u32)),
+        kernel_loaded_at,
+        kernel_tag: U64Blob::from(prog_info.tag()),
+        kernel_gpl_compatible: prog_info.gpl_compatible(),
+        kernel_btf_id: prog_info.btf_id().map(KernelU32::from),
+        kernel_bytes_xlated: prog_info.size_translated().map(KernelU32::from),
+        kernel_jited: Some(prog_info.size_jitted() > 0),
+        kernel_bytes_jited: Some(KernelU32::from(prog_info.size_jitted())),
+        kernel_verified_insns: prog_info.verified_instruction_count().map(KernelU32::from),
+        kernel_bytes_memlock: prog_info.memory_locked().ok().map(KernelU32::from),
+        created_at: Utc::now().naive_utc(),
+        updated_at: None,
+    })
+}
+
+/// Converts a generic `aya::programs::Program` into its specific type
+/// and loads it into the kernel.
+///
+/// This function does not handle pinning or metadata extraction.
+///
+/// # Arguments
+///
+/// - `program_type`: The expected type of the eBPF program.
+/// - `ebpf_program`: A mutable reference to the program retrieved from `program_mut()`.
+///
+/// # Returns
+///
+/// - `Ok(())` if the program is successfully converted and loaded.
+/// - `Err(BpfmanError)` if conversion or loading fails.
+fn load_program(
+    program_type: &ProgramType,
+    ebpf_program: &mut aya::programs::Program,
+) -> Result<(), BpfmanError> {
+    match program_type {
+        ProgramType::Xdp { function_name: _ } => {
+            let prog: &mut aya::programs::Xdp = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load().map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Tc | ProgramType::Tcx => {
+            let prog: &mut aya::programs::SchedClassifier = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load().map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Tracepoint { function_name: _ } => {
+            let prog: &mut aya::programs::TracePoint = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load().map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Kprobe { function_name: _ } | ProgramType::Kretprobe { function_name: _ } => {
+            let prog: &mut aya::programs::KProbe = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load().map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Uprobe { function_name: _ } | ProgramType::Uretprobe { function_name: _ } => {
+            let prog: &mut aya::programs::UProbe = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load().map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Fentry {
+            function_name: _,
+            attach_function,
+        } => {
+            let btf = aya::Btf::from_sys_fs().map_err(BpfmanError::BtfError)?;
+            let prog: &mut aya::programs::FEntry = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load(attach_function, &btf)
+                .map_err(BpfmanError::BpfProgramError)?;
+        }
+        ProgramType::Fexit {
+            function_name: _,
+            attach_function,
+        } => {
+            let btf = aya::Btf::from_sys_fs().map_err(BpfmanError::BtfError)?;
+            let prog: &mut aya::programs::FExit = ebpf_program
+                .try_into()
+                .map_err(BpfmanError::BpfProgramError)?;
+            prog.load(attach_function, &btf)
+                .map_err(BpfmanError::BpfProgramError)?;
+        }
+    };
+
+    Ok(())
+}
+
+fn attempt_unload(_lp: &LoadedProgram) -> Result<(), BpfmanError> {
+    // TODO(frobware). Circle back here when we address the `unload`
+    // bpfman command. We may want to go through the public API (i.e.,
+    // the front door).
+
+    Err(BpfmanError::InternalError(
+        "attempt_unload is not yet implemented".into(),
+    ))
+}
+
+/// Loads an individual eBPF program into the kernel and returns
+/// associated metadata.
+///
+/// This function retrieves the eBPF program from the loaded bytecode,
+/// applies necessary configurations, and loads it into the kernel. It
+/// also gathers metadata such as pinned maps and program information.
+///
+/// # Arguments
+///
+/// - `program_type`: The type of eBPF program being loaded (e.g.,
+///   `Xdp`, `Kprobe`).
+/// - `name`: The name of the function within the bytecode.
+/// - `program_bytecode`: A mutable reference to an `Ebpf` instance
+///   containing loaded bytecode.
+///
+/// # Returns
+///
+/// - `Ok(EbpfLoadResult)` containing metadata about the loaded
+///   program.
+/// - `Err(BpfmanError)` if program retrieval or kernel loading fails.
+///
+/// # Errors
+///
+/// - If the function name does not exist in the loaded bytecode.
+/// - If the program fails to convert into its expected type.
+/// - If the kernel rejects the program.
+fn load_program_into_kernel(
+    program: &ProgramType,
+    program_bytes: &[u8],
+    bytecode: &mut Ebpf,
+    spec: &LoadSpec,
+) -> Result<LoadedProgram, BpfmanError> {
+    let prog_name = program
+        .function_name()
+        .ok_or_else(|| BpfmanError::BpfFunctionNameNotValid("<none>".to_string()))?;
+
+    let ebpf_program = bytecode
+        .program_mut(prog_name)
+        .ok_or_else(|| BpfmanError::BpfFunctionNameNotValid(prog_name.to_string()))?;
+
+    load_program(program, ebpf_program)?;
+
+    // Retrieve the program info after loading.
+    let prog_info = ebpf_program.info().map_err(BpfmanError::BpfProgramError)?;
+    let id = prog_info.id();
+
+    // Pin the program.
+    let program_pin_path = format!("{RTDIR_FS}/prog_{id}");
+    ebpf_program
+        .pin(&program_pin_path)
+        .map_err(BpfmanError::UnableToPinProgram)?;
+
+    // Calculate the map pin path and create the directory.
+    let map_pin_path: PathBuf = calc_map_pin_path(id);
+    create_map_pin_path(&map_pin_path)?;
+
+    // Collect map metadata.
+    let mut maps = Vec::new();
+    for (map_name, map) in bytecode.maps_mut() {
+        if !should_map_be_pinned(map_name) {
+            continue;
+        }
+
+        // Pin the map.
+        let map_fs_path = map_pin_path.join(map_name);
+        map.pin(map_fs_path.clone())
+            .map_err(BpfmanError::UnableToPinMap)?;
+
+        maps.push(build_bpfmap_from_aya_map(map, map_name).map_err(BpfmanError::BpfMapInfoError)?);
+    }
+
+    let map_pin_path_str = map_pin_path.to_string_lossy().to_string();
+    let bpf_prog = build_bpfprogram_from_aya_program(
+        &prog_info,
+        program,
+        program_bytes,
+        spec,
+        &map_pin_path_str,
+    );
+
+    Ok(LoadedProgram {
+        kind: program.clone(),
+        program: bpf_prog?,
+        maps,
+    })
+}
+
+/// Loads eBPF programs from a `LoadSpec`, parsing bytecode and
+/// registering programs.
+///
+/// This function takes a `LoadSpec`, which contains information about
+/// the bytecode source, metadata, and other parameters. It performs
+/// the following steps:
+///
+/// 1. Creates an `EbpfLoader` to parse and prepare the bytecode.
+/// 2. Loads the bytecode into an `Ebpf` instance, representing the
+///    set of parsed eBPF programs.
+/// 3. Iterates over the program definitions in the spec, extracting
+///    the function names and types.
+/// 4. Calls `load_into_kernel` to load each program into the kernel
+///    and collect metadata.
+/// 5. Returns a vector of `EbpfLoadResult`, containing details about
+///    the loaded programs.
+///
+/// # Arguments
+///
+/// * `params` - A `LoadSpec` containing eBPF program definitions,
+///   bytecode, and metadata.
+///
+/// # Returns
+///
+/// * `Ok(Vec<EbpfLoadResult>)` - A list of successfully loaded eBPF
+///   programs.
+/// * `Err(BpfmanError)` - If loading the bytecode, parsing programs,
+///   or kernel loading fails.
+///
+/// # Errors
+///
+/// This function may return an error in the following cases:
+/// - The bytecode fails to load (e.g., invalid format, missing
+///   sections).
+/// - A program definition is invalid (e.g., missing function name).
+/// - An attempt to load a program into the kernel fails.
+pub(crate) fn load_from_spec(spec: &LoadSpec) -> Result<Vec<LoadedProgram>, BpfmanError> {
+    let mut image_manager = init_image_manager()?;
+
+    let (program_bytes, _function_names) = spec
+        .bytecode_source
+        .get_program_bytes_no_sled(&mut image_manager)?;
+
+    let mut bytecode_loader = aya::EbpfLoader::new();
+    bytecode_loader.allow_unsupported_maps();
+
+    let mut program_bytecode = bytecode_loader
+        .load(&program_bytes)
+        .map_err(BpfmanError::BpfLoadError)?;
+
+    let mut loaded_programs = Vec::new();
+
+    for program in &spec.programs {
+        match load_program_into_kernel(program, &program_bytes, &mut program_bytecode, spec) {
+            Ok(loaded) => loaded_programs.push(loaded),
+            Err(err) => {
+                let unload_failures = unload_all(&loaded_programs);
+
+                return Err(BpfmanError::ProgramLoadError {
+                    cause: Box::new(err),
+                    loaded_before_failure: loaded_programs,
+                    unload_failures,
+                });
+            }
+        }
+    }
+
+    Ok(loaded_programs)
+}
+
+/// Attempts to unload every program in the provided slice.
+///
+/// For each `LoadedProgram` in `programs`, this function calls
+/// `attempt_unload`. If an unload operation fails, it records an
+/// `UnloadError` containing the program's unique identifier and a
+/// description of the error. The returned vector contains all unload
+/// failures; if all programs are successfully unloaded, the vector
+/// will be empty.
+///
+/// # Arguments
+///
+/// - `programs`: A slice of `LoadedProgram` instances that were
+///   previously loaded into the kernel.
+///
+/// # Returns
+///
+/// A vector of `UnloadError` instances detailing any failures
+/// encountered during the unload process.
+pub(crate) fn unload_all(programs: &[LoadedProgram]) -> Vec<UnloadError> {
+    programs
+        .iter()
+        .filter_map(|lp| {
+            attempt_unload(lp).err().map(|e| UnloadError::Failure {
+                program_id: lp.program.id,
+                source: e,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    mod load_spec {
+        use crate::{
+            program_loader::LoadSpecBuilder,
+            types::{Location, ProgramType},
+        };
+
+        fn valid_programs() -> Vec<ProgramType> {
+            vec![ProgramType::Tcx]
+        }
+
+        #[test]
+        fn test_build_fails_with_no_fields() {
+            let result = LoadSpecBuilder::default().build();
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_build_fails_without_bytecode_source() {
+            let result = LoadSpecBuilder::default()
+                .programs(vec![ProgramType::Tcx])
+                .build();
+            assert!(result.is_err(), "missing bytecode_source should fail");
+        }
+
+        #[test]
+        fn test_build_fails_without_programs() {
+            let result = LoadSpecBuilder::default()
+                .bytecode_source(Location::File("some.o".into()))
+                .build();
+            assert!(result.is_err(), "missing programs should fail");
+        }
+
+        #[test]
+        fn test_build_global_data_serialises_to_json() {
+            let result = LoadSpecBuilder::default()
+                .bytecode_source(Location::File("path/to/bytecode".into()))
+                .global_data(vec![
+                    ("key1".into(), b"value1".to_vec()),
+                    ("key2".into(), b"value2".to_vec()),
+                ])
+                .programs(valid_programs())
+                .build();
+
+            assert!(result.is_ok());
+            let spec = result.unwrap();
+
+            let json_str = spec
+                .global_data_json
+                .as_deref()
+                .expect("global_data_json should be present");
+
+            let json: serde_json::Value =
+                serde_json::from_str(json_str).expect("global_data_json should be valid JSON");
+
+            assert!(json.get("key1").is_some(), "expected key1 in JSON");
+            assert!(json.get("key2").is_some(), "expected key2 in JSON");
+        }
+
+        #[test]
+        fn test_build_metadata_serialises_to_json() {
+            let result = LoadSpecBuilder::default()
+                .bytecode_source(Location::File("path/to/bytecode".into()))
+                .metadata(vec![
+                    ("key1".into(), "value1".to_string()),
+                    ("key2".into(), "value2".to_string()),
+                ])
+                .programs(valid_programs())
+                .build();
+
+            assert!(result.is_ok());
+            let spec = result.unwrap();
+
+            let json_str = spec
+                .metadata_json
+                .as_deref()
+                .expect("metadata_json should be present");
+
+            let json: serde_json::Value =
+                serde_json::from_str(json_str).expect("metadata_json should be valid JSON");
+
+            assert!(json.get("key1").is_some(), "expected key1 in JSON");
+            assert!(json.get("key2").is_some(), "expected key2 in JSON");
+        }
+    }
+}

--- a/dump-programs.sh
+++ b/dump-programs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: ${0##*/} /path/to/sqlite.db"
+    exit 1
+fi
+
+db="$1"
+
+if [ ! -f "$db" ]; then
+    echo "Error: Database file '$db' does not exist." >&2
+    exit 1
+fi
+
+sqlite3 "$db" <<EOF
+.headers on
+.mode column
+SELECT id, name, kind, map_pin_path, kernel_loaded_at FROM bpf_programs ORDER BY created_at;
+EOF
+
+sqlite3 "$db" <<EOF
+.headers on
+.mode column
+SELECT * FROM bpf_maps ORDER BY created_at;
+EOF
+
+sqlite3 "$db" <<EOF
+.headers on
+.mode column
+SELECT * FROM bpf_program_maps ORDER BY program_id ASC;
+EOF

--- a/tests/integration-test/src/tests/e2e.rs
+++ b/tests/integration-test/src/tests/e2e.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::PathBuf, thread::sleep, time::Duration};
 
 use bpfman::{
-    remove_program, setup,
+    establish_database_connection, remove_program, setup,
     types::{AttachInfo, BytecodeImage, Location, TcProceedOn, XdpProceedOn},
 };
 use procfs::sys::kernel::Version;
@@ -1733,4 +1733,15 @@ fn test_netns_delete() {
     drop(namespace_guard);
 
     verify_and_delete_programs(&config, &root_db, progs);
+}
+
+#[test]
+fn test_can_establish_database_connection() {
+    let conn = establish_database_connection(":memory:");
+
+    assert!(
+        conn.is_ok(),
+        "Expected connection to succeed, got error: {:#?}",
+        conn.err()
+    );
 }


### PR DESCRIPTION
This is a copy of the POC I started in https://github.com/frobware/bpfman-hacks/tree/main/s2s. Lots to be done here. Staging this to start the ball rolling.

### **Summary**  
This PR introduces the initial transition from SLED to SQLite by modelling existing SLED key-value stores and trees as structured SQLite tables. The primary objective is to establish a database schema that reflects the current data model while providing a **thin CRUD layer** for interaction. This is the **first step** in enabling `bpfman` to transition to SQLite.

### **Goals**  
- **Model BPF programs, maps, and links as structured SQLite tables and discrete Rust structs.**  
- **Ensure SQLite-backed Rust structures are `serde`-enabled** to support JSON serialisation and emission.  
- **Define relationships** between these entities to allow efficient queries.  
- **Implement a lightweight CRUD layer**: we will use [Diesel](https://diesel.rs/), particularly for its support of schema migrations.

- **Support bulk transactions**, allowing multiple objects (programs, maps, links) to be inserted atomically.  

### **Database Layer Design**  
- **Thin Abstraction:** This implementation provides a lightweight wrapper around Diesel, isolating direct database calls. The functions are intentionally simple, handling only **basic CRUD (Create, Read, Update, Delete) operations**.  
- **No Transaction Management:** These functions do not handle transactions internally. Transaction control should be explicitly managed at a higher level.
- **Incremental Migration Strategy:** This phase focuses on **schema definition and basic persistence**, allowing programs, maps, and links to be constructed in-memory before being committed to the database in a transaction. All functionality is designed to be fully unit-testable.

This PR starts to establish the foundation for replacing SLED with SQLite.

### TODO:
- [X] Drop `sqlite-bundled`, link dynamically
- [X] Flesh out the remaining tables
- [X] Understand where we would get write contention, where do we handle "DB is locked"
- [X] Make u64blob generic for types u8, 16, 32, 64
- [X] Test embedded migrations
- [X] Test round-tripping the `src/model.rs` BPF* types through Serde/SQLite (unit test done)
- [ ] Rework existing integration tests to use new public API
### Testing the SQLite CRUD layer:

```
% cargo test --lib models
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/lib.rs (/home/aim/src/github.com/bpfman/bpfman/target/debug/deps/bpfman-f254ded8642fe2e7)

running 2 tests
test models::tests::test_bpf_program_serde_roundtrip ... ok
test models::tests::test_insert_and_find_bpf_program ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s
```
