### PR TITLE
chore: Unasync all the things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,6 @@ version = "0.5.6"
 dependencies = [
  "anyhow",
  "env_logger",
- "futures",
  "hex",
  "log",
  "netlink-packet-audit",
@@ -497,16 +496,16 @@ dependencies = [
  "comfy-table",
  "env_logger",
  "flate2",
- "futures",
  "hex",
  "lazy_static",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-sys",
  "nix 0.28.0",
  "object",
  "oci-distribution",
  "rand",
- "rtnetlink",
  "serde",
  "serde_json",
  "sha2",
@@ -541,7 +540,6 @@ dependencies = [
  "clap",
  "env_logger",
  "flate2",
- "futures",
  "hex",
  "lazy_static",
  "libsystemd",
@@ -551,7 +549,6 @@ dependencies = [
  "oci-distribution",
  "prost 0.12.6",
  "rand",
- "rtnetlink",
  "serde",
  "serde_json",
  "sha2",
@@ -2658,10 +2655,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
- "futures",
  "libc",
  "log",
- "tokio",
 ]
 
 [[package]]
@@ -3820,24 +3815,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ dialoguer = { version = "0.11", default-features = false }
 diff = { version = "0.1.13", default-features = false }
 env_logger = { version = "0.11.6", default-features = false }
 flate2 = { version = "1.0", default-features = false }
-futures = { version = "0.3.31", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 integration-test-macros = { path = "./tests/integration-test-macros" }
 inventory = { version = "0.3", default-features = false }

--- a/bpf-log-exporter/Cargo.toml
+++ b/bpf-log-exporter/Cargo.toml
@@ -12,7 +12,6 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
-futures = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 log = { workspace = true }
 netlink-packet-audit = { workspace = true }

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -34,7 +34,6 @@ clap = { workspace = true, features = [
 ] }
 env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
-futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
 libsystemd = { workspace = true }
@@ -54,7 +53,6 @@ oci-distribution = { workspace = true, default-features = false, features = [
 ] }
 prost = { workspace = true, features = ["prost-derive", "std"] }
 rand = { workspace = true }
-rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman-api/src/bin/rpc/rpc.rs
+++ b/bpfman-api/src/bin/rpc/rpc.rs
@@ -149,9 +149,7 @@ impl Bpfman for BpfmanLoader {
             ),
         };
 
-        let program = add_program(program)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        let program = add_program(program).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply_entry =
             LoadResponse {
@@ -173,9 +171,7 @@ impl Bpfman for BpfmanLoader {
         let reply = UnloadResponse {};
         let request = request.into_inner();
 
-        remove_program(request.id)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        remove_program(request.id).map_err(|e| Status::aborted(format!("{e}")))?;
 
         Ok(Response::new(reply))
     }
@@ -184,9 +180,7 @@ impl Bpfman for BpfmanLoader {
         let request = request.into_inner();
         let id = request.id;
 
-        let program = get_program(id)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        let program = get_program(id).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply_entry =
             GetResponse {
@@ -215,7 +209,6 @@ impl Bpfman for BpfmanLoader {
 
         // Await the response
         for r in list_programs(filter)
-            .await
             .map_err(|e| Status::aborted(format!("failed to list programs: {e}")))?
         {
             // Populate the response with the Program Info and the Kernel Info.
@@ -246,9 +239,7 @@ impl Bpfman for BpfmanLoader {
             None => return Err(Status::aborted("Empty pull_bytecode request received")),
         };
 
-        pull_bytecode(image)
-            .await
-            .map_err(|e| Status::aborted(format!("{e}")))?;
+        pull_bytecode(image).map_err(|e| Status::aborted(format!("{e}")))?;
 
         let reply = PullBytecodeResponse {};
         Ok(Response::new(reply))

--- a/bpfman-api/src/bin/rpc/storage.rs
+++ b/bpfman-api/src/bin/rpc/storage.rs
@@ -146,7 +146,6 @@ impl Node for CsiNode {
 
                 // Find the Program with the specified *Program CRD name
                 let prog_data = list_programs(ListFilter::default())
-                    .await
                     .map_err(|e| Status::aborted(format!("failed list programs: {e}")))?
                     .into_iter()
                     .find(|p| {

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -39,11 +39,12 @@ clap_mangen = { workspace = true }
 comfy-table = { workspace = true, features = ["tty"] }
 env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
-futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 lazy_static = { workspace = true }
 log = { workspace = true }
+netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
+netlink-sys = { workspace = true }
 nix = { workspace = true, features = [
     "fs",
     "mount",
@@ -59,7 +60,6 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "trust-dns",
 ] }
 rand = { workspace = true }
-rtnetlink = { workspace = true, features = ["tokio_socket"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman/src/bin/cli/get.rs
+++ b/bpfman/src/bin/cli/get.rs
@@ -6,8 +6,8 @@ use log::warn;
 
 use crate::{args::GetArgs, table::ProgTable};
 
-pub(crate) async fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
-    match get_program(args.program_id).await {
+pub(crate) fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
+    match get_program(args.program_id) {
         Ok(program) => {
             if let Ok(p) = ProgTable::new_program(&program) {
                 p.print();

--- a/bpfman/src/bin/cli/image.rs
+++ b/bpfman/src/bin/cli/image.rs
@@ -24,11 +24,11 @@ use crate::args::{
 };
 
 impl ImageSubCommand {
-    pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
         match self {
-            ImageSubCommand::Pull(args) => execute_pull(args).await,
-            ImageSubCommand::Build(args) => execute_build(args).await,
-            ImageSubCommand::GenerateBuildArgs(args) => execute_build_args(args).await,
+            ImageSubCommand::Pull(args) => execute_pull(args),
+            ImageSubCommand::Build(args) => execute_build(args),
+            ImageSubCommand::GenerateBuildArgs(args) => execute_build_args(args),
         }
     }
 }
@@ -67,14 +67,14 @@ pub(crate) struct ImageBuilder {
     pub(crate) build_args: Vec<String>,
 }
 
-pub(crate) async fn execute_pull(args: &PullBytecodeArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_pull(args: &PullBytecodeArgs) -> anyhow::Result<()> {
     let image: BytecodeImage = args.try_into()?;
-    pull_bytecode(image).await?;
+    pull_bytecode(image)?;
 
     Ok(())
 }
 
-pub(crate) async fn execute_build(args: &BuildBytecodeArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_build(args: &BuildBytecodeArgs) -> anyhow::Result<()> {
     let container_tool = if let Some(runtime) = &args.runtime {
         match runtime.as_str() {
             "docker" => ContainerRuntime::Docker,
@@ -284,7 +284,7 @@ pub(crate) fn parse_bytecode_from_cilium_ebpf_project(
     })
 }
 
-pub(crate) async fn execute_build_args(args: &GenerateArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_build_args(args: &GenerateArgs) -> anyhow::Result<()> {
     let build_context = if let Some(project_path) = &args.bytecode.cilium_ebpf_project {
         parse_bytecode_from_cilium_ebpf_project(project_path)?
     } else {

--- a/bpfman/src/bin/cli/list.rs
+++ b/bpfman/src/bin/cli/list.rs
@@ -6,7 +6,7 @@ use bpfman::{list_programs, types::ListFilter};
 
 use crate::{args::ListArgs, table::ProgTable};
 
-pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
     let prog_type_filter = args.program_type.map(|p| p as u32);
 
     let filter = ListFilter::new(
@@ -22,7 +22,7 @@ pub(crate) async fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
 
     let mut table = ProgTable::new_list();
 
-    for r in list_programs(filter).await? {
+    for r in list_programs(filter)? {
         if let Err(e) = table.add_response_prog(r) {
             bail!(e)
         }

--- a/bpfman/src/bin/cli/load.rs
+++ b/bpfman/src/bin/cli/load.rs
@@ -18,15 +18,15 @@ use crate::{
 };
 
 impl LoadSubcommand {
-    pub(crate) async fn execute(&self) -> anyhow::Result<()> {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
         match self {
-            LoadSubcommand::File(l) => execute_load_file(l).await,
-            LoadSubcommand::Image(l) => execute_load_image(l).await,
+            LoadSubcommand::File(l) => execute_load_file(l),
+            LoadSubcommand::Image(l) => execute_load_image(l),
         }
     }
 }
 
-pub(crate) async fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
     let bytecode_source = Location::File(args.path.clone());
 
     let data = ProgramData::new(
@@ -42,14 +42,14 @@ pub(crate) async fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()>
         args.map_owner_id,
     )?;
 
-    let program = add_program(args.command.get_program(data)?).await?;
+    let program = add_program(args.command.get_program(data)?)?;
 
     ProgTable::new_program(&program)?.print();
     ProgTable::new_kernel_info(&program)?.print();
     Ok(())
 }
 
-pub(crate) async fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
+pub(crate) fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
     let bytecode_source = Location::Image((&args.pull_args).try_into()?);
 
     let data = ProgramData::new(
@@ -65,7 +65,7 @@ pub(crate) async fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<(
         args.map_owner_id,
     )?;
 
-    let program = add_program(args.command.get_program(data)?).await?;
+    let program = add_program(args.command.get_program(data)?)?;
 
     ProgTable::new_program(&program)?.print();
     ProgTable::new_kernel_info(&program)?.print();

--- a/bpfman/src/bin/cli/main.rs
+++ b/bpfman/src/bin/cli/main.rs
@@ -19,26 +19,23 @@ mod manpage;
 mod table;
 mod unload;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     env_logger::try_init()?;
     debug!("Log using env_logger");
 
     let cli = crate::args::Cli::parse();
 
-    cli.command.execute().await
+    cli.command.execute()
 }
 
 impl Commands {
-    pub(crate) async fn execute(&self) -> Result<(), anyhow::Error> {
+    pub(crate) fn execute(&self) -> Result<(), anyhow::Error> {
         match self {
-            Commands::Load(l) => l.execute().await,
-            Commands::Unload(args) => execute_unload(args).await,
-            Commands::List(args) => execute_list(args).await,
-            Commands::Get(args) => execute_get(args)
-                .await
-                .map_err(|e| anyhow!("get error: {e}")),
-            Commands::Image(i) => i.execute().await,
+            Commands::Load(l) => l.execute(),
+            Commands::Unload(args) => execute_unload(args),
+            Commands::List(args) => execute_list(args),
+            Commands::Get(args) => execute_get(args).map_err(|e| anyhow!("get error: {e}")),
+            Commands::Image(i) => i.execute(),
             Commands::Man(args) => manpage::generate(args),
             Commands::Completions(args) => completions::generate(args),
         }?;

--- a/bpfman/src/bin/cli/unload.rs
+++ b/bpfman/src/bin/cli/unload.rs
@@ -5,7 +5,7 @@ use bpfman::remove_program;
 
 use crate::args::UnloadArgs;
 
-pub(crate) async fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
-    remove_program(args.program_id).await?;
+pub(crate) fn execute_unload(args: &UnloadArgs) -> Result<(), anyhow::Error> {
+    remove_program(args.program_id)?;
     Ok(())
 }

--- a/bpfman/src/multiprog/mod.rs
+++ b/bpfman/src/multiprog/mod.rs
@@ -27,7 +27,7 @@ pub(crate) enum Dispatcher {
 }
 
 impl Dispatcher {
-    pub async fn new(
+    pub fn new(
         root_db: &Db,
         if_config: Option<&InterfaceConfig>,
         registry_config: &RegistryConfig,
@@ -62,17 +62,14 @@ impl Dispatcher {
                     revision,
                 )?;
 
-                if let Err(res) = x
-                    .load(
-                        root_db,
-                        programs,
-                        old_dispatcher,
-                        image_manager,
-                        registry_config,
-                        p.netns()?,
-                    )
-                    .await
-                {
+                if let Err(res) = x.load(
+                    root_db,
+                    programs,
+                    old_dispatcher,
+                    image_manager,
+                    registry_config,
+                    p.netns()?,
+                ) {
                     let _ = x.delete(root_db, true);
                     return Err(res);
                 }
@@ -89,17 +86,14 @@ impl Dispatcher {
                     revision,
                 )?;
 
-                if let Err(res) = t
-                    .load(
-                        root_db,
-                        programs,
-                        old_dispatcher,
-                        image_manager,
-                        registry_config,
-                        p.netns()?,
-                    )
-                    .await
-                {
+                if let Err(res) = t.load(
+                    root_db,
+                    programs,
+                    old_dispatcher,
+                    image_manager,
+                    registry_config,
+                    p.netns()?,
+                ) {
                     let _ = t.delete(root_db, true);
                     return Err(res);
                 }

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -84,7 +84,7 @@ impl XdpDispatcher {
         }
     }
 
-    pub(crate) async fn load(
+    pub(crate) fn load(
         &mut self,
         root_db: &Db,
         programs: &mut [Program],
@@ -130,15 +130,13 @@ impl XdpDispatcher {
             None,
         );
 
-        let (path, bpf_program_names) = image_manager
-            .get_image(
-                root_db,
-                &image.image_url.clone(),
-                image.image_pull_policy.clone(),
-                image.username.clone(),
-                image.password.clone(),
-            )
-            .await?;
+        let (path, bpf_program_names) = image_manager.get_image(
+            root_db,
+            &image.image_url.clone(),
+            image.image_pull_policy.clone(),
+            image.username.clone(),
+            image.password.clone(),
+        )?;
 
         if !bpf_program_names.contains(&XDP_DISPATCHER_PROGRAM_NAME.to_string()) {
             return Err(BpfmanError::ProgramNotFoundInBytecode {

--- a/bpfman/src/netlink.rs
+++ b/bpfman/src/netlink.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use std::{
+    cell::RefCell,
+    fs::File,
+    os::fd::{FromRawFd, OwnedFd, RawFd},
+};
+
+use anyhow::{anyhow, bail};
+use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_route::{
+    tc::{TcAttribute, TcMessage},
+    RouteNetlinkMessage,
+};
+use netlink_sys::{constants::NETLINK_ROUTE, Socket, SocketAddr};
+use nix::{
+    fcntl::{self, OFlag},
+    sched::{setns, CloneFlags},
+    sys::stat::Mode,
+};
+
+pub struct NetlinkManager {
+    sock: RefCell<Socket>,
+}
+
+impl NetlinkManager {
+    pub(crate) fn new() -> Self {
+        NetlinkManager {
+            sock: RefCell::new(init_sock()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_in_namespace(ns: &str) -> Result<Self, anyhow::Error> {
+        Ok(NetlinkManager {
+            sock: RefCell::new(init_namespace_sock(ns)?),
+        })
+    }
+
+    pub(crate) fn has_qdisc(
+        &self,
+        qdisc_name: String,
+        if_index: i32,
+    ) -> Result<bool, anyhow::Error> {
+        let mut req =
+            NetlinkMessage::from(RouteNetlinkMessage::GetQueueDiscipline(TcMessage::default()));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        req.finalize();
+        let mut buf = vec![0; req.header.length as usize];
+        req.serialize(&mut buf);
+
+        let socket = self.sock.borrow_mut();
+        socket
+            .send(&buf, 0)
+            .expect("failed to send netlink message");
+
+        let mut receive_buffer = vec![0; 4096];
+        let mut found = false;
+        loop {
+            let n = socket.recv(&mut &mut receive_buffer[..], 0)?;
+            let bytes = &receive_buffer[..n];
+            let rx_packet: NetlinkMessage<RouteNetlinkMessage> =
+                NetlinkMessage::deserialize(bytes).unwrap();
+            match rx_packet.payload {
+                NetlinkPayload::Done(_) => break,
+                NetlinkPayload::Error(e) => bail!(e),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::GetQueueDiscipline(
+                    qdisc_message,
+                )) => {
+                    if qdisc_message.header.index == if_index
+                        && qdisc_message
+                            .attributes
+                            .contains(&TcAttribute::Kind(qdisc_name.clone()))
+                    {
+                        found = true;
+                        break;
+                    }
+                    continue;
+                }
+                _ => continue,
+            }
+        }
+        Ok(found)
+    }
+}
+
+fn init_sock() -> Socket {
+    let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
+    socket.bind_auto().unwrap();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+    socket
+}
+
+fn init_namespace_sock(namespace: &str) -> Result<Socket, anyhow::Error> {
+    let current_netns = current_netns()?;
+    change_netns_fd(namespace)?;
+    let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
+    socket.bind_auto().unwrap();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+    change_netns_id(current_netns)?;
+    Ok(socket)
+}
+
+pub fn current_netns() -> Result<OwnedFd, anyhow::Error> {
+    // FD is opened with CLOEXEC so it will be closed once we exit
+    // We need to keep this alive so we can get back home
+
+    let fd = fcntl::open(
+        "/proc/self/ns/net",
+        OFlag::O_CLOEXEC | OFlag::O_RDONLY,
+        Mode::empty(),
+    )
+    .map_err(|e| anyhow!(e))? as RawFd;
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    Ok(fd)
+}
+
+fn change_netns_fd(path: &str) -> Result<(), anyhow::Error> {
+    let f = File::open(path)?;
+    setns(f, CloneFlags::CLONE_NEWNET).map_err(|e| anyhow!(e))
+}
+
+fn change_netns_id(fd: OwnedFd) -> Result<(), anyhow::Error> {
+    setns(fd, CloneFlags::CLONE_NEWNET).map_err(|e| anyhow!(e))
+}

--- a/bpfman/src/oci_utils/cosign.rs
+++ b/bpfman/src/oci_utils/cosign.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, bail};
 use log::{debug, info, warn};
@@ -12,10 +12,13 @@ use sigstore::{
     },
     errors::SigstoreError::RegistryPullManifestError,
     registry::{Auth, ClientConfig, ClientProtocol, OciReference},
+    trust::{sigstore::SigstoreTrustRoot, ManualTrustRoot, TrustRoot as _},
 };
 
+use crate::oci_utils::RUNTIME;
+
 pub struct CosignVerifier {
-    pub client: sigstore::cosign::Client,
+    repo: Arc<ManualTrustRoot<'static>>,
     pub allow_unsigned: bool,
 }
 
@@ -30,38 +33,39 @@ fn get_tuf_path() -> Option<PathBuf> {
 }
 
 impl CosignVerifier {
-    pub(crate) async fn new(allow_unsigned: bool) -> Result<Self, anyhow::Error> {
+    pub(crate) fn new(allow_unsigned: bool) -> Result<Self, anyhow::Error> {
         info!("Starting Cosign Verifier, downloading data from Sigstore TUF repository");
 
-        let oci_config = ClientConfig {
-            protocol: ClientProtocol::Https,
-            ..Default::default()
-        };
-
-        // The cosign is a static ref which needs to live for the rest of the program's
-        // lifecycle so therefore the repo ALSO needs to be static, requiring us
-        // to leak it here.
-        let repo: &dyn sigstore::trust::TrustRoot = Box::leak(fetch_sigstore_tuf_data().await?);
-
-        let cosign_client = ClientBuilder::default()
-            .with_oci_client_config(oci_config)
-            .with_trust_repository(repo)?
-            .enable_registry_caching()
-            .build()?;
+        let repo = RUNTIME.block(fetch_sigstore_tuf_data())?;
 
         Ok(Self {
-            client: cosign_client,
+            repo,
             allow_unsigned,
         })
     }
 
-    pub(crate) async fn verify(
+    fn client(&self) -> anyhow::Result<sigstore::cosign::Client> {
+        let oci_config = ClientConfig {
+            protocol: ClientProtocol::Https,
+            ..Default::default()
+        };
+        let cosign_client = ClientBuilder::default()
+            .with_oci_client_config(oci_config)
+            .with_trust_repository(self.repo.as_ref())?
+            .enable_registry_caching()
+            .build()?;
+
+        Ok(cosign_client)
+    }
+
+    pub(crate) fn verify(
         &mut self,
         image: &str,
         username: Option<&str>,
         password: Option<&str>,
     ) -> Result<(), anyhow::Error> {
         debug!("CosignVerifier::verify()");
+
         let image = OciReference::from_str(image)?;
         let auth = if let (Some(username), Some(password)) = (username, password) {
             Auth::Basic(username.to_string(), password.to_string())
@@ -70,46 +74,78 @@ impl CosignVerifier {
         };
 
         debug!("Triangulating image: {}", image);
-        let (cosign_signature_image, source_image_digest) =
-            self.client.triangulate(&image, &auth).await?;
 
-        debug!("Getting trusted layers");
-        match self
-            .client
-            .trusted_signature_layers(&auth, &source_image_digest, &cosign_signature_image)
-            .await
-        {
-            Ok(trusted_layers) => {
-                debug!("Found trusted layers");
-                debug!("Verifying constraints");
-                info!("The bytecode image: {} is signed", image);
-                // TODO: Add some constraints here
-                let verification_constraints: VerificationConstraintVec = Vec::new();
-                verify_constraints(&trusted_layers, verification_constraints.iter())
-                    .map_err(|e| anyhow!("Error verifying constraints: {}", e))?;
-                Ok(())
-            }
-            Err(e) => match e {
-                RegistryPullManifestError { .. } => {
-                    if !self.allow_unsigned {
-                        bail!("Error triangulating image: {}", e);
-                    } else {
-                        warn!("The bytecode image: {} is unsigned", image);
-                        Ok(())
-                    }
-                }
-                _ => {
-                    bail!("Error triangulating image: {}", e);
-                }
-            },
-        }
+        RUNTIME.block(get_image_and_digest(
+            &mut self.client()?,
+            &image,
+            &auth,
+            self.allow_unsigned,
+        ))?;
+
+        Ok(())
     }
 }
 
-async fn fetch_sigstore_tuf_data() -> anyhow::Result<Box<dyn sigstore::trust::TrustRoot>> {
-    let tuf = sigstore::trust::sigstore::SigstoreTrustRoot::new(get_tuf_path().as_deref())
-        .await
-        .map_err(|e| anyhow!("Error constructing Sigstore trust root: {}", e))?;
+async fn get_image_and_digest(
+    client: &mut sigstore::cosign::Client,
+    image: &OciReference,
+    auth: &Auth,
+    allow_unsigned: bool,
+) -> Result<(OciReference, String), anyhow::Error> {
+    let (cosign_signature_image, source_image_digest) = client.triangulate(image, auth).await?;
 
-    Ok(Box::new(tuf))
+    debug!("Getting trusted layers");
+
+    match client
+        .trusted_signature_layers(auth, &source_image_digest, &cosign_signature_image)
+        .await
+    {
+        Ok(trusted_layers) => {
+            debug!("Found trusted layers");
+            debug!("Verifying constraints");
+            info!("The bytecode image: {} is signed", image);
+            // TODO: Add some constraints here
+            let verification_constraints: VerificationConstraintVec = Vec::new();
+            verify_constraints(&trusted_layers, verification_constraints.iter())
+                .map_err(|e| anyhow!("Error verifying constraints: {}", e))?;
+            Ok((cosign_signature_image, source_image_digest))
+        }
+        Err(e) => match e {
+            RegistryPullManifestError { .. } => {
+                if !allow_unsigned {
+                    bail!("Error triangulating image: {}", e);
+                } else {
+                    warn!("The bytecode image: {} is unsigned", image);
+                    Ok((cosign_signature_image, source_image_digest))
+                }
+            }
+            _ => {
+                bail!("Error triangulating image: {}", e);
+            }
+        },
+    }
+}
+
+async fn fetch_sigstore_tuf_data() -> anyhow::Result<Arc<ManualTrustRoot<'static>>> {
+    let repo = SigstoreTrustRoot::new(get_tuf_path().as_deref()).await?;
+
+    let fulcio_certs = repo
+        .fulcio_certs()
+        .expect("Cannot fetch Fulcio certificates from TUF repository")
+        .into_iter()
+        .map(|c| c.into_owned())
+        .collect();
+
+    let manual_root = ManualTrustRoot {
+        fulcio_certs,
+        rekor_keys: repo
+            .rekor_keys()
+            .expect("Cannot fetch Rekor keys from TUF repository")
+            .iter()
+            .map(|k| k.to_vec())
+            .collect(),
+        ..Default::default()
+    };
+
+    Ok(Arc::new(manual_root))
 }

--- a/bpfman/src/oci_utils/image_manager.rs
+++ b/bpfman/src/oci_utils/image_manager.rs
@@ -24,7 +24,7 @@ use sled::Db;
 use tar::Archive;
 
 use crate::{
-    oci_utils::{cosign::CosignVerifier, ImageError},
+    oci_utils::{cosign::CosignVerifier, ImageError, RUNTIME},
     types::ImagePullPolicy,
     utils::{sled_get, sled_insert},
 };
@@ -67,9 +67,9 @@ pub struct ImageManager {
 }
 
 impl ImageManager {
-    pub async fn new(verify_enabled: bool, allow_unsigned: bool) -> Result<Self, anyhow::Error> {
+    pub fn new(verify_enabled: bool, allow_unsigned: bool) -> Result<Self, anyhow::Error> {
         let cosign_verifier = if verify_enabled {
-            Some(CosignVerifier::new(allow_unsigned).await?)
+            Some(CosignVerifier::new(allow_unsigned)?)
         } else {
             None
         };
@@ -84,7 +84,7 @@ impl ImageManager {
         })
     }
 
-    pub(crate) async fn get_image(
+    pub(crate) fn get_image(
         &mut self,
         root_db: &Db,
         image_url: &str,
@@ -98,9 +98,7 @@ impl ImageManager {
         let image: Reference = image_url.parse().map_err(ImageError::InvalidImageUrl)?;
 
         if let Some(cosign_verifier) = &mut self.cosign_verifier {
-            cosign_verifier
-                .verify(image_url, username.as_deref(), password.as_deref())
-                .await?;
+            cosign_verifier.verify(image_url, username.as_deref(), password.as_deref())?;
         } else {
             info!("Cosign verification is disabled, so skipping verification");
         }
@@ -115,15 +113,13 @@ impl ImageManager {
 
         let image_meta = match pull_policy {
             ImagePullPolicy::Always => {
-                self.pull_image(root_db, image, &image_content_key, username, password)
-                    .await?
+                self.pull_image(root_db, image, &image_content_key, username, password)?
             }
             ImagePullPolicy::IfNotPresent => {
                 if exists {
                     self.load_image_meta(root_db, &image_content_key)?
                 } else {
-                    self.pull_image(root_db, image, &image_content_key, username, password)
-                        .await?
+                    self.pull_image(root_db, image, &image_content_key, username, password)?
                 }
             }
             ImagePullPolicy::Never => {
@@ -153,7 +149,7 @@ impl ImageManager {
         }
     }
 
-    pub async fn pull_image(
+    pub fn pull_image(
         &mut self,
         root_db: &Db,
         image: Reference,
@@ -170,11 +166,23 @@ impl ImageManager {
 
         let auth = self.get_auth_for_registry(image.registry(), username, password);
 
-        let (image_manifest, _, config_contents) = self
-            .client
+        let image_labels =
+            RUNTIME.block(self.get_image_labels(&self.client, root_db, base_key, image, auth))?;
+        Ok(image_labels)
+    }
+
+    async fn get_image_labels(
+        &self,
+        client: &Client,
+        root_db: &Db,
+        base_key: &str,
+        image: Reference,
+        auth: RegistryAuth,
+    ) -> Result<ContainerImageMetadata, ImageError> {
+        let (image_manifest, _, config_contents) = client
             .pull_manifest_and_config(&image.clone(), &auth)
             .await
-            .map_err(ImageError::ImageManifestPullFailure)?;
+            .map_err(ImageError::BytecodeImagePullFailure)?;
 
         trace!("Raw container image manifest {}", image_manifest);
 
@@ -188,6 +196,25 @@ impl ImageManager {
             .map_err(|e| ImageError::ByteCodeImageProcessFailure(e.into()))?;
 
         trace!("Raw container image config {}", image_config);
+
+        let image_content = client
+            .pull(
+                &image,
+                &auth,
+                vec![
+                    manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE,
+                    manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE,
+                ],
+            )
+            .await
+            .map_err(ImageError::BytecodeImagePullFailure)?
+            .layers
+            .into_iter()
+            .next()
+            .map(|layer| layer.data)
+            .ok_or(ImageError::BytecodeImageExtractFailure(
+                "No data in bytecode image layer".to_string(),
+            ))?;
 
         let labels_map = image_config["config"]["Labels"].as_object().ok_or(
             ImageError::ByteCodeImageProcessFailure(anyhow!("Labels not found")),
@@ -220,26 +247,6 @@ impl ImageManager {
             }
         };
 
-        let image_content = self
-            .client
-            .pull(
-                &image,
-                &auth,
-                vec![
-                    manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE,
-                    manifest::IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE,
-                ],
-            )
-            .await
-            .map_err(ImageError::BytecodeImagePullFailure)?
-            .layers
-            .into_iter()
-            .next()
-            .map(|layer| layer.data)
-            .ok_or(ImageError::BytecodeImageExtractFailure(
-                "No data in bytecode image layer".to_string(),
-            ))?;
-
         // Make sure endian target matches that of the system before storing
         let unzipped_content = get_bytecode_from_gzip(image_content.clone());
         let obj_endianness = object::read::File::parse(unzipped_content.as_slice())
@@ -249,8 +256,8 @@ impl ImageManager {
 
         if host_endianness != obj_endianness {
             return Err(ImageError::BytecodeImageExtractFailure(
-                format!("image bytecode endianness: {obj_endianness:?} does not match host {host_endianness:?}"),
-            ));
+                            format!("image bytecode endianness: {obj_endianness:?} does not match host {host_endianness:?}"),
+                        ));
         };
 
         // Update Database to save for later
@@ -470,16 +477,14 @@ mod tests {
     use super::*;
     use crate::{config::SigningConfig, get_db_config, init_database};
 
-    #[tokio::test]
-    async fn image_pull_and_bytecode_verify_legacy() {
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+    #[test]
+    fn image_pull_and_bytecode_verify_legacy() {
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
         let (image_content_key, _) = mgr
             .get_image(
@@ -489,7 +494,6 @@ mod tests {
                 None,
                 None,
             )
-            .await
             .expect("failed to pull bytecode");
 
         let program_bytes = mgr
@@ -499,16 +503,14 @@ mod tests {
         assert!(!program_bytes.is_empty())
     }
 
-    #[tokio::test]
-    async fn image_pull_and_bytecode_verify() {
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+    #[test]
+    fn image_pull_and_bytecode_verify() {
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
         let (image_content_key, _) = mgr
             .get_image(
@@ -518,7 +520,6 @@ mod tests {
                 None,
                 None,
             )
-            .await
             .expect("failed to pull bytecode");
 
         let program_bytes = mgr
@@ -528,43 +529,37 @@ mod tests {
         assert!(!program_bytes.is_empty())
     }
 
-    #[tokio::test]
-    async fn image_pull_policy_never_failure() {
+    #[test]
+    fn image_pull_policy_never_failure() {
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
 
-        let result = mgr
-            .get_image(
-                &root_db,
-                "quay.io/bpfman-bytecode/xdp_pass:latest",
-                ImagePullPolicy::Never,
-                None,
-                None,
-            )
-            .await;
+        let result = mgr.get_image(
+            &root_db,
+            "quay.io/bpfman-bytecode/xdp_pass:latest",
+            ImagePullPolicy::Never,
+            None,
+            None,
+        );
 
         assert_matches!(result, Err(ImageError::ByteCodeImageNotfound(_)));
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic]
-    async fn private_image_pull_failure() {
+    fn private_image_pull_failure() {
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
 
         mgr.get_image(
             &root_db,
@@ -573,21 +568,18 @@ mod tests {
             None,
             None,
         )
-        .await
         .expect("failed to pull bytecode");
     }
 
-    #[tokio::test]
-    async fn private_image_pull_and_bytecode_verify() {
+    #[test]
+    fn private_image_pull_and_bytecode_verify() {
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
 
         let (image_content_key, _) = mgr
             .get_image(
@@ -597,7 +589,6 @@ mod tests {
                 Some("bpfman-bytecode+bpfmancreds".to_owned()),
                 Some("D49CKWI1MMOFGRCAT8SHW5A56FSVP30TGYX54BBWKY2J129XRI6Q5TVH2ZZGTJ1M".to_owned()),
             )
-            .await
             .expect("failed to pull bytecode");
 
         let program_bytes = mgr
@@ -607,27 +598,23 @@ mod tests {
         assert!(!program_bytes.is_empty())
     }
 
-    #[tokio::test]
-    async fn image_pull_failure() {
+    #[test]
+    fn image_pull_failure() {
         let mut mgr = ImageManager::new(
             SigningConfig::default().verify_enabled,
             SigningConfig::default().allow_unsigned,
         )
-        .await
         .unwrap();
-        let root_db = init_database(get_db_config())
-            .await
-            .expect("Unable to open root database for unit test");
+        let root_db =
+            init_database(get_db_config()).expect("Unable to open root database for unit test");
 
-        let result = mgr
-            .get_image(
-                &root_db,
-                "quay.io/bpfman-bytecode/xdp_pass:latest",
-                ImagePullPolicy::Never,
-                None,
-                None,
-            )
-            .await;
+        let result = mgr.get_image(
+            &root_db,
+            "quay.io/bpfman-bytecode/xdp_pass:latest",
+            ImagePullPolicy::Never,
+            None,
+            None,
+        );
 
         assert_matches!(result, Err(ImageError::ByteCodeImageNotfound(_)));
     }

--- a/bpfman/src/oci_utils/mod.rs
+++ b/bpfman/src/oci_utils/mod.rs
@@ -4,7 +4,9 @@
 pub(crate) mod cosign;
 pub mod image_manager;
 
+use lazy_static::lazy_static;
 use thiserror::Error;
+use tokio::runtime::{Builder as RuntimeBuilder, Handle, Runtime};
 
 #[derive(Debug, Error)]
 pub enum ImageError {
@@ -24,4 +26,55 @@ pub enum ImageError {
     DatabaseError(String, String),
     #[error("{0}: {1}")]
     BytecodeImageParseFailure(String, String),
+    #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
+}
+
+lazy_static! {
+    pub(crate) static ref RUNTIME: BlockingWrapper = BlockingWrapper::new();
+}
+
+/// A wrapper to handle blocking execution safely in both sync and async contexts.
+pub(crate) struct BlockingWrapper {
+    handle: Option<Handle>,
+    runtime: Option<Runtime>,
+}
+
+impl BlockingWrapper {
+    /// Creates a new `RuntimeBlocker`, detecting the current runtime if available.
+    fn new() -> Self {
+        match Handle::try_current() {
+            Ok(handle) => Self {
+                handle: Some(handle),
+                runtime: None,
+            },
+            Err(_) => {
+                let runtime = RuntimeBuilder::new_multi_thread()
+                    .worker_threads(1)
+                    .enable_all()
+                    .build()
+                    .expect("Failed to create runtime");
+                Self {
+                    handle: Some(runtime.handle().clone()),
+                    runtime: Some(runtime),
+                }
+            }
+        }
+    }
+
+    /// Runs an async function synchronously, choosing the best blocking strategy.
+    fn block<F, T>(&self, future: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        if let Some(handle) = &self.handle {
+            // Inside an async runtime, use `block_in_place` to avoid blocking the executor.
+            return tokio::task::block_in_place(|| handle.block_on(future));
+        }
+        if let Some(runtime) = &self.runtime {
+            // Inside a runtime, use `block_on` normally.
+            return runtime.block_on(future);
+        }
+        panic!("No runtime available");
+    }
 }

--- a/bpfman/src/static_program.rs
+++ b/bpfman/src/static_program.rs
@@ -97,16 +97,16 @@
 // }
 
 // impl StaticProgramManager {
-//     async fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
-//         if let Ok(mut entries) = fs::read_dir(self.path).await {
-//             while let Some(file) = entries.next_entry().await? {
+//     fn programs_from_directory(mut self) -> Result<(), anyhow::Error> {
+//         if let Ok(mut entries) = fs::read_dir(self.path) {
+//             while let Some(file) = entries.next_entry()? {
 //                 let path = &file.path();
 //                 // ignore directories
 //                 if path.is_dir() {
 //                     continue;
 //                 }
 
-//                 if let Ok(contents) = read_to_string(path).await {
+//                 if let Ok(contents) = read_to_string(path) {
 //                     let program = toml::from_str(&contents)?;
 
 //                     self.programs.push(program);
@@ -120,7 +120,7 @@
 //     }
 // }
 
-// pub(crate) async fn get_static_programs<P: AsRef<Path>>(
+// pub(crate) fn get_static_programs<P: AsRef<Path>>(
 //     path: P,
 // ) -> Result<Vec<Program>, anyhow::Error> {
 //     let static_program_manager = StaticProgramManager {
@@ -131,7 +131,7 @@
 //     static_program_manager
 //         .clone()
 //         .programs_from_directory()
-//         .await?;
+//         ?;
 
 //     let mut programs: Vec<Program> = Vec::new();
 
@@ -199,7 +199,7 @@
 //     use super::*;
 
 //     #[tokio::test]
-//     async fn test_parse_program_from_invalid_path() {
+//     fn test_parse_program_from_invalid_path() {
 //         let static_program_manager = StaticProgramManager {
 //             path: "/tmp/file.toml".into(),
 //             programs: Vec::new(),
@@ -208,7 +208,7 @@
 //         static_program_manager
 //             .clone()
 //             .programs_from_directory()
-//             .await
+//
 //             .unwrap();
 //         assert!(static_program_manager.programs.is_empty())
 //     }

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -296,7 +296,7 @@ pub enum Location {
 }
 
 impl Location {
-    async fn get_program_bytes(
+    fn get_program_bytes(
         &self,
         root_db: &Db,
         image_manager: &mut ImageManager,
@@ -304,15 +304,13 @@ impl Location {
         match self {
             Location::File(l) => Ok((crate::utils::read(l)?, Vec::new())),
             Location::Image(l) => {
-                let (path, bpf_function_names) = image_manager
-                    .get_image(
-                        root_db,
-                        &l.image_url,
-                        l.image_pull_policy.clone(),
-                        l.username.clone(),
-                        l.password.clone(),
-                    )
-                    .await?;
+                let (path, bpf_function_names) = image_manager.get_image(
+                    root_db,
+                    &l.image_url,
+                    l.image_pull_policy.clone(),
+                    l.username.clone(),
+                    l.password.clone(),
+                )?;
                 let bytecode = image_manager.get_bytecode_from_image_store(root_db, path)?;
 
                 Ok((bytecode, bpf_function_names))
@@ -816,13 +814,13 @@ impl ProgramData {
         sled_get(&self.db_tree, PROGRAM_BYTES)
     }
 
-    pub(crate) async fn set_program_bytes(
+    pub(crate) fn set_program_bytes(
         &mut self,
         root_db: &Db,
         image_manager: &mut ImageManager,
     ) -> Result<(), BpfmanError> {
         let loc = self.get_location()?;
-        match loc.get_program_bytes(root_db, image_manager).await {
+        match loc.get_program_bytes(root_db, image_manager) {
             Err(e) => Err(e),
             Ok((v, s)) => {
                 match loc {


### PR DESCRIPTION
When we moved bpfman to be a oneshot commandline program instead of being a daemon we noted that we should run sync and not async given that a lot of the work we do is synchronous.

The blocking factor here was that sigstore and oci_distribution required us to use tokio.

This solve this, we introduce a new wrapper called BlockingWrapper that lets us run:

- Async code from a sync context (i.e oci_utils from bpfman)
- Async code from a sync context from an async context (i.e bpfman-rpc -> bpfman -> oci_utils)

In effect, bpfman can remain sync, while using dependnecies that might require an async runtime like tokio.