### PR TITLE
fix(bpfman-rpc): bpfman-rpc performance issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.98",
  "which 4.4.2",
@@ -488,7 +488,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.28.0",
  "object",
- "oci-distribution",
+ "oci-client",
  "rand",
  "serde",
  "serde_json",
@@ -530,7 +530,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "nix 0.28.0",
- "oci-distribution",
+ "oci-client",
  "prost 0.12.6",
  "rand",
  "serde",
@@ -749,12 +749,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1839,24 +1833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http 1.2.0",
- "hyper 1.6.0",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2631,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -2803,31 +2779,6 @@ dependencies = [
  "jwt",
  "lazy_static",
  "oci-spec",
- "olpc-cjson",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "unicase",
-]
-
-[[package]]
-name = "oci-distribution"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a2c51531af0cb93761f66094044ca6ea879320bccd35ab747ff3fcab3f422"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "http 1.2.0",
- "http-auth",
- "jwt",
- "lazy_static",
  "olpc-cjson",
  "regex",
  "reqwest",
@@ -3544,58 +3495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls",
- "socket2",
- "thiserror 2.0.11",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
-dependencies = [
- "bytes",
- "getrandom 0.2.15",
- "rand",
- "ring",
- "rustc-hash 2.1.1",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.11",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
-dependencies = [
- "cfg_aliases 0.2.1",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,7 +3595,6 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3708,17 +3606,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -3727,7 +3621,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "windows-registry",
 ]
 
@@ -3795,12 +3688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,7 +3731,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3865,9 +3751,6 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-dependencies = [
- "web-time",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4644,16 +4527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,15 +5029,6 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ netlink-packet-route = { version = "^0.19", default-features = false }
 netlink-sys = { version = "^0.8", default-features = false }
 nix = { version = "0.28", default-features = false }
 object = { version = "0.36.7", default-features = false }
-oci-distribution = { version = "0.11", default-features = false }
+oci-client = { version = "0.14", default-features = false }
 opentelemetry = { version = "0.22.0", default-features = false }
 opentelemetry-otlp = { version = "0.15.0", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.14.0" }

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -14,7 +14,9 @@ RUN apt-get update && apt-get install -y\
 
 RUN apt-get update && apt-get install -y\
     gcc-multilib\
-    libssl-dev
+    libssl-dev\
+    libclang-dev\
+    cmake
 
 # Get Rust for Ubuntu base build
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -47,8 +47,8 @@ nix = { workspace = true, features = [
     "socket",
     "user",
 ] }
-oci-distribution = { workspace = true, default-features = false, features = [
-    "rustls-tls",
+oci-client = { workspace = true, default-features = false, features = [
+    "native-tls",
     "trust-dns",
 ] }
 prost = { workspace = true, features = ["prost-derive", "std"] }

--- a/bpfman-api/src/bin/rpc/main.rs
+++ b/bpfman-api/src/bin/rpc/main.rs
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
-use std::{env, fs::create_dir_all, path::PathBuf, str::FromStr};
+use std::{env, fs::create_dir_all, path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::Context;
+use bpfman::{
+    add_program,
+    config::Config,
+    errors::BpfmanError,
+    get_program, list_programs, pull_bytecode, remove_program, setup,
+    types::{BytecodeImage, ListFilter, Program},
+};
 use clap::{Args, Parser};
 use log::debug;
 use systemd_journal_logger::{connected_to_journal, JournalLog};
+use tokio::{sync::Mutex, task::spawn_blocking};
 
 use crate::serve::serve;
 
@@ -83,12 +91,72 @@ fn initialize_rpc(csi_support: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub struct AsyncBpfman {}
+impl AsyncBpfman {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    fn setup(&self) -> anyhow::Result<(Config, sled::Db)> {
+        setup().map_err(|e| e.into())
+    }
+
+    pub(crate) async fn add_program(&self, program: Program) -> anyhow::Result<Program> {
+        let (config, root_db) = self.setup()?;
+        match spawn_blocking(move || add_program(&config, &root_db, program)).await {
+            Ok(result) => result.map_err(|e| e.into()),
+            Err(e) => Err(BpfmanError::InternalError(e.to_string()).into()),
+        }
+    }
+
+    pub(crate) async fn get_program(&self, id: u32) -> anyhow::Result<Program> {
+        let (_, root_db) = self.setup()?;
+        match spawn_blocking(move || get_program(&root_db, id)).await {
+            Ok(result) => result.map_err(|e| e.into()),
+            Err(e) => Err(BpfmanError::InternalError(e.to_string()).into()),
+        }
+    }
+
+    pub(crate) async fn list_programs(&self, filter: ListFilter) -> anyhow::Result<Vec<Program>> {
+        let (_, root_db) = self.setup()?;
+        match spawn_blocking(move || list_programs(&root_db, filter)).await {
+            Ok(result) => result.map_err(|e| e.into()),
+            Err(e) => Err(BpfmanError::InternalError(e.to_string()).into()),
+        }
+    }
+
+    pub(crate) async fn remove_program(&self, id: u32) -> anyhow::Result<()> {
+        let (config, root_db) = self.setup()?;
+        match spawn_blocking(move || remove_program(&config, &root_db, id)).await {
+            Ok(result) => result.map_err(|e| e.into()),
+            Err(e) => Err(BpfmanError::InternalError(e.to_string()).into()),
+        }
+    }
+
+    pub(crate) async fn pull_bytecode(&self, image: BytecodeImage) -> anyhow::Result<()> {
+        let (_, root_db) = self.setup()?;
+        match spawn_blocking(move || pull_bytecode(&root_db, image)).await {
+            Ok(result) => result,
+            Err(e) => Err(BpfmanError::InternalError(e.to_string()).into()),
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Rpc::parse();
+    let async_bpfman = AsyncBpfman::new();
+    let bpfman_lock: Arc<Mutex<_>> = Arc::new(Mutex::new(async_bpfman));
+
     initialize_rpc(args.csi_support)?;
     //TODO https://github.com/bpfman/bpfman/issues/881
-    serve(args.csi_support, args.timeout, &args.socket_path).await?;
+    serve(
+        bpfman_lock,
+        args.csi_support,
+        args.timeout,
+        &args.socket_path,
+    )
+    .await?;
 
     Ok(())
 }

--- a/bpfman-api/src/bin/rpc/serve.rs
+++ b/bpfman-api/src/bin/rpc/serve.rs
@@ -5,6 +5,7 @@ use std::{
     fs::remove_file,
     os::unix::prelude::{FromRawFd, IntoRawFd},
     path::Path,
+    sync::Arc,
 };
 
 use anyhow::anyhow;
@@ -16,20 +17,25 @@ use tokio::{
     join,
     net::UnixListener,
     signal::unix::{signal, SignalKind},
-    sync::broadcast,
+    sync::{broadcast, Mutex},
     task::{JoinHandle, JoinSet},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
 
-use crate::{rpc::BpfmanLoader, storage::StorageManager};
+use crate::{rpc::BpfmanLoader, storage::StorageManager, AsyncBpfman};
 
-pub async fn serve(csi_support: bool, timeout: u64, socket_path: &Path) -> anyhow::Result<()> {
+pub async fn serve(
+    db_lock: Arc<Mutex<AsyncBpfman>>,
+    csi_support: bool,
+    timeout: u64,
+    socket_path: &Path,
+) -> anyhow::Result<()> {
     let (shutdown_tx, shutdown_rx1) = broadcast::channel(32);
     let shutdown_rx3 = shutdown_tx.subscribe();
     let shutdown_handle = tokio::spawn(shutdown_handler(timeout, shutdown_tx));
 
-    let loader = BpfmanLoader::new();
+    let loader = BpfmanLoader::new(db_lock.clone());
     let service = BpfmanServer::new(loader);
 
     let mut listeners: Vec<_> = Vec::new();
@@ -38,7 +44,7 @@ pub async fn serve(csi_support: bool, timeout: u64, socket_path: &Path) -> anyho
     listeners.push(handle);
 
     if csi_support {
-        let storage_manager = StorageManager::new();
+        let storage_manager = StorageManager::new(db_lock.clone());
         let storage_manager_handle =
             tokio::spawn(async move { storage_manager.run(shutdown_rx3).await });
         let (_, res_storage, _) = join!(

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -55,7 +55,7 @@ nix = { workspace = true, features = [
     "user",
 ] }
 object = { workspace = true, features = ["elf", "read_core"] }
-oci-distribution = { workspace = true, default-features = false, features = [
+oci-client = { workspace = true, default-features = false, features = [
     "native-tls",
     "trust-dns",
 ] }


### PR DESCRIPTION
@Billy99 reported that bpfman-rpc was performing poorly since the changes to use only sync code inside bpfman.

There were 2 reasons for this:

1. There's a possibility that the CSI code and the RPC code can both acquire the database lock at the same time. The lock is now protected with a Mutex to ensure this can't happen
2. Within the BlockingWrapper, calling `block_on` with the future performed poorly. Instead, we spawn the future on the runtime and then await it within the block_on

With these changes, bpfman-rpc performance is back where it should be. In debugging this I also noticed that error logs don't propagate to the bpfman-rpc logs in Kubernetes. I've adjusted the code there to ensure that errors are appropriately logged before being returned to the RPC client.