### PR TITLE
Update examples to use new ClusterBpfApplication

### DIFF
--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -1,56 +1,60 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: BpfApplication
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: bpfapplication
   name: app-counter
 spec:
   # Select all nodes
-  nodeselector: {}
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-app-counter:latest
-      imagepullpolicy: Always
+      imagePullPolicy: Always
   programs:
-    - type: Kprobe
-      kprobe:
-        bpffunctionname: kprobe_counter
-        func_name: try_to_wake_up
-        offset: 0
-        retprobe: false
-    - type: Tracepoint
-      tracepoint:
-        bpffunctionname: tracepoint_kill_recorder
-        names: [syscalls/sys_enter_kill]
-    - type: TC
-      tc:
-        bpffunctionname: stats
-        interfaceselector:
-          primarynodeinterface: true
-        priority: 55
-        direction: ingress
-    - type: TCX
-      tcx:
-        bpffunctionname: tcx_stats
-        interfaceselector:
-          primarynodeinterface: true
-        priority: 500
-        direction: ingress
-    - type: Uprobe
-      uprobe:
-        bpffunctionname: uprobe_counter
-        func_name: main.getCount
-        target: /go-target
-        retprobe: false
-        containers:
-          namespace: go-target
-          pods: {}
-          containernames:
-            - go-target
-    - type: XDP
-      xdp:
-        bpffunctionname: xdp_stats
-        interfaceselector:
-          primarynodeinterface: true
-        priority: 55
+    - name: kprobe_counter
+      type: kprobe
+      kprobeInfo:
+        links:
+          - function: try_to_wake_up
+            offset: 0
+    - name: tracepoint_kill_recorder
+      type: tracepoint
+      tracepointInfo:
+        links:
+          - name: syscalls/sys_enter_kill
+    - name: stats
+      type: tc
+      tcInfo:
+        links:
+          - interfaceSelector:
+              primaryNodeInterface: true
+            priority: 55
+            direction: ingress
+    - name: tcx_stats
+      type: tcx
+      tcxInfo:
+        links:
+          - interfaceSelector:
+              primaryNodeInterface: true
+            priority: 500
+            direction: ingress
+    - name: uprobe_counter
+      type: uprobe
+      uprobeInfo:
+        links:
+          - function: main.getCount
+            target: /go-target
+            containers:
+              namespace: go-target
+              pods: {}
+              containerNames:
+                - go-target
+    - name: xdp_stats
+      type: xdp
+      xdpInfo:
+        links:
+          - interfaceSelector:
+              primaryNodeInterface: true
+            priority: 55

--- a/examples/config/base/go-kprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-kprobe-counter/bytecode.yaml
@@ -1,18 +1,21 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: KprobeProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: kprobeprogram
   name: go-kprobe-counter-example
 spec:
-  bpffunctionname: kprobe_counter
   # Select all nodes
-  nodeselector: {}
-  func_name: try_to_wake_up
-  offset: 0
-  retprobe: false
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-kprobe-counter:latest
-      imagepullpolicy: IfNotPresent
+      imagePullPolicy: IfNotPresent
+  programs:
+    - name: kprobe_counter
+      type: kprobe
+      kprobeInfo:
+        links:
+          - function: try_to_wake_up
+            offset: 0

--- a/examples/config/base/go-tcx-counter/bytecode.yaml
+++ b/examples/config/base/go-tcx-counter/bytecode.yaml
@@ -1,18 +1,22 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: TcxProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: tcxprogram
   name: go-tcx-counter-example
 spec:
-  bpffunctionname: tcx_stats
   # Select all nodes
-  nodeselector: {}
-  interfaceselector:
-    primarynodeinterface: true
-  priority: 55
-  direction: ingress
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-tcx-counter:latest
+  programs:
+    - name: tcx_stats
+      type: tcx
+      tcxInfo:
+        links:
+          - interfaceSelector:
+              primaryNodeInterface: true
+            priority: 55
+            direction: ingress

--- a/examples/config/base/go-tracepoint-counter/bytecode.yaml
+++ b/examples/config/base/go-tracepoint-counter/bytecode.yaml
@@ -1,16 +1,20 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: TracepointProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: tracepointprogram
   name: go-tracepoint-counter-example
 spec:
-  bpffunctionname: tracepoint_kill_recorder
   # Select all nodes
-  nodeselector: {}
-  names: [syscalls/sys_enter_kill]
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-tracepoint-counter:latest
-      imagepullpolicy: IfNotPresent
+      imagePullPolicy: IfNotPresent
+  programs:
+    - name: tracepoint_kill_recorder
+      type: tracepoint
+      tracepointInfo:
+        links:
+          - name: syscalls/sys_enter_kill

--- a/examples/config/base/go-uprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-uprobe-counter/bytecode.yaml
@@ -1,23 +1,26 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: UprobeProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: uprobeprogram
   name: go-uprobe-counter-example
 spec:
-  bpffunctionname: uprobe_counter
   # Select all nodes
-  nodeselector: {}
-  func_name: main.getCount
-  target: /go-target
-  retprobe: false
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-uprobe-counter:latest
-      imagepullpolicy: IfNotPresent
-  containers:
-    namespace: go-target
-    pods: {}
-    containernames:
-      - go-target
+      imagePullPolicy: IfNotPresent
+  programs:
+    - name: uprobe_counter
+      type: uprobe
+      uprobeInfo:
+        links:
+          - function: main.getCount
+            target: /go-target
+            containers:
+              namespace: go-target
+              pods: {}
+              containerNames:
+                - go-target

--- a/examples/config/base/go-uretprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-uretprobe-counter/bytecode.yaml
@@ -1,23 +1,26 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: UprobeProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: uretprobeprogram
   name: go-uretprobe-counter-example
 spec:
-  bpffunctionname: uretprobe_counter
   # Select all nodes
-  nodeselector: {}
-  func_name: main.getCount
-  target: /go-target
-  retprobe: true
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-uretprobe-counter:latest
-      imagepullpolicy: IfNotPresent
-  containers:
-    namespace: go-target
-    pods: {}
-    containernames:
-      - go-target
+      imagePullPolicy: IfNotPresent
+  programs:
+    - name: uretprobe_counter
+      type: uretprobe
+      uretprobeInfo:
+        links:
+          - function: main.getCount
+            target: /go-target
+            containers:
+              namespace: go-target
+              pods: {}
+              containerNames:
+                - go-target

--- a/examples/config/base/go-xdp-counter/bytecode.yaml
+++ b/examples/config/base/go-xdp-counter/bytecode.yaml
@@ -1,17 +1,21 @@
 ---
 apiVersion: bpfman.io/v1alpha1
-kind: XdpProgram
+kind: ClusterBpfApplication
 metadata:
   labels:
     app.kubernetes.io/name: xdpprogram
   name: go-xdp-counter-example
 spec:
-  bpffunctionname: xdp_stats
   # Select all nodes
-  nodeselector: {}
-  interfaceselector:
-    primarynodeinterface: true
-  priority: 55
-  bytecode:
+  nodeSelector: {}
+  byteCode:
     image:
       url: quay.io/bpfman-bytecode/go-xdp-counter:latest
+  programs:
+    - name: xdp_stats
+      type: xdp
+      xdpInfo:
+        links:
+          - interfaceSelector:
+              primaryNodeInterface: true
+            priority: 55


### PR DESCRIPTION
Update all the bytecode.yaml files in the examples directory, which are responsible for loading the bytecode, to use the new ClusterBpfApplication CRDs instead of the *Program CRDs which have been removed.