### PR TITLE
update examples based on recent APIs review changes

### DIFF
--- a/examples/config/base/go-app-counter/bytecode.yaml
+++ b/examples/config/base/go-app-counter/bytecode.yaml
@@ -14,35 +14,35 @@ spec:
       imagePullPolicy: Always
   programs:
     - name: kprobe_counter
-      type: kprobe
-      kprobeInfo:
+      type: KProbe
+      kprobe:
         links:
           - function: try_to_wake_up
             offset: 0
     - name: tracepoint_kill_recorder
-      type: tracepoint
-      tracepointInfo:
+      type: TracePoint
+      tracepoint:
         links:
           - name: syscalls/sys_enter_kill
     - name: stats
-      type: tc
-      tcInfo:
+      type: TC
+      tc:
         links:
           - interfaceSelector:
               primaryNodeInterface: true
             priority: 55
-            direction: ingress
+            direction: Ingress
     - name: tcx_stats
-      type: tcx
-      tcxInfo:
+      type: TCX
+      tcx:
         links:
           - interfaceSelector:
               primaryNodeInterface: true
             priority: 500
-            direction: ingress
+            direction: Ingress
     - name: uprobe_counter
-      type: uprobe
-      uprobeInfo:
+      type: UProbe
+      uprobe:
         links:
           - function: main.getCount
             target: /go-target
@@ -52,8 +52,8 @@ spec:
               containerNames:
                 - go-target
     - name: xdp_stats
-      type: xdp
-      xdpInfo:
+      type: XDP
+      xdp:
         links:
           - interfaceSelector:
               primaryNodeInterface: true

--- a/examples/config/base/go-kprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-kprobe-counter/bytecode.yaml
@@ -14,8 +14,8 @@ spec:
       imagePullPolicy: IfNotPresent
   programs:
     - name: kprobe_counter
-      type: kprobe
-      kprobeInfo:
+      type: KProbe
+      kprobe:
         links:
           - function: try_to_wake_up
             offset: 0

--- a/examples/config/base/go-tc-counter/bytecode.yaml
+++ b/examples/config/base/go-tc-counter/bytecode.yaml
@@ -13,10 +13,10 @@ spec:
       url: quay.io/bpfman-bytecode/go-tc-counter:latest
   programs:
     - name: stats
-      type: tc
-      tcInfo:
+      type: TC
+      tc:
         links:
           - interfaceSelector:
               primaryNodeInterface: true
             priority: 55
-            direction: ingress
+            direction: Ingress

--- a/examples/config/base/go-tcx-counter/bytecode.yaml
+++ b/examples/config/base/go-tcx-counter/bytecode.yaml
@@ -13,10 +13,10 @@ spec:
       url: quay.io/bpfman-bytecode/go-tcx-counter:latest
   programs:
     - name: tcx_stats
-      type: tcx
-      tcxInfo:
+      type: TCX
+      tcx:
         links:
           - interfaceSelector:
               primaryNodeInterface: true
             priority: 55
-            direction: ingress
+            direction: Ingress

--- a/examples/config/base/go-tracepoint-counter/bytecode.yaml
+++ b/examples/config/base/go-tracepoint-counter/bytecode.yaml
@@ -14,7 +14,7 @@ spec:
       imagePullPolicy: IfNotPresent
   programs:
     - name: tracepoint_kill_recorder
-      type: tracepoint
-      tracepointInfo:
+      type: TracePoint
+      tracepoint:
         links:
           - name: syscalls/sys_enter_kill

--- a/examples/config/base/go-uprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-uprobe-counter/bytecode.yaml
@@ -14,8 +14,8 @@ spec:
       imagePullPolicy: IfNotPresent
   programs:
     - name: uprobe_counter
-      type: uprobe
-      uprobeInfo:
+      type: UProbe
+      uprobe:
         links:
           - function: main.getCount
             target: /go-target

--- a/examples/config/base/go-uretprobe-counter/bytecode.yaml
+++ b/examples/config/base/go-uretprobe-counter/bytecode.yaml
@@ -14,8 +14,8 @@ spec:
       imagePullPolicy: IfNotPresent
   programs:
     - name: uretprobe_counter
-      type: uretprobe
-      uretprobeInfo:
+      type: URetProbe
+      uretprobe:
         links:
           - function: main.getCount
             target: /go-target

--- a/examples/config/base/go-xdp-counter/bytecode.yaml
+++ b/examples/config/base/go-xdp-counter/bytecode.yaml
@@ -13,8 +13,8 @@ spec:
       url: quay.io/bpfman-bytecode/go-xdp-counter:latest
   programs:
     - name: xdp_stats
-      type: xdp
-      xdpInfo:
+      type: XDP
+      xdp:
         links:
           - interfaceSelector:
               primaryNodeInterface: true


### PR DESCRIPTION
required based on https://github.com/bpfman/bpfman-operator/pull/413 new apis changes

UT
- `make deploy-app`

```sh
oc get clusterbpfapplication
NAME          NODESELECTOR   STATUS    AGE
app-counter                  Success   51s
```
- `make deploy-kprobe`
```sh
oc get clusterbpfapplication
NAME                        NODESELECTOR   STATUS    AGE
go-kprobe-counter-example                  Success   17s
```
- `make deploy-tcx`
```sh
oc get clusterbpfapplication
NAME                     NODESELECTOR   STATUS    AGE
go-tcx-counter-example                  Success   20s
```
- `make deploy-tracepoint`
```sh
oc get clusterbpfapplication
NAME                            NODESELECTOR   STATUS    AGE
go-tracepoint-counter-example                  Success   25s
```
- `make deploy-xdp`
```sh
oc get clusterbpfapplication 
NAME                     NODESELECTOR   STATUS    AGE
go-xdp-counter-example                  Success   40s

```
- `make deploy-uprobe`
```sh
oc get clusterbpfapplication 
NAME                        NODESELECTOR   STATUS    AGE
go-uprobe-counter-example                  Success   20s

```
