### PR TITLE
chore: Remove aws-lc-rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,27 +204,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-fips-sys"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29003a681b2b9465c1139bfb726da452a841a8b025f35953f3bce71139f10b21"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "paste",
- "regex",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
- "aws-lc-fips-sys",
  "aws-lc-sys",
  "untrusted 0.7.1",
  "zeroize",
@@ -511,7 +495,6 @@ version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
- "aws-lc-rs",
  "aya",
  "base16ct",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ anyhow = { version = "1", default-features = false }
 assert_cmd = { version = "2", default-features = false }
 assert_matches = { version = "1", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-aws-lc-rs = { version = "1.12.6", default-features = false }
 aya = { version = "0.13.1", default-features = false }
 aya-obj = { version = "0.2.1", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }

--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -22,6 +22,11 @@ RUN apt-get update && apt-get install -y\
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
 
+# Install bindgen-cli (required for aws-lc-sys on some architectures)
+RUN --mount=type=cache,target=/usr/src/bpfman/target/ \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo install bindgen-cli
+
 WORKDIR /usr/src/bpfman
 COPY ./ /usr/src/bpfman
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,10 @@
 [build]
 default-target = "x86_64-unknown-linux-gnu" # use this target if none is explicitly provided
 pre-build = [                               # additional commands to run prior to building the package
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable",
+    ". $HOME/.cargo/env",
+    "cargo install --force --locked bindgen-cli && mv $HOME/.cargo/bin/bindgen /usr/bin",
+    "rm -rf $HOME/.cargo",
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
 ]

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/bin/rpc/main.rs"
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }
-aws-lc-rs = { workspace = true, features = ["bindgen"] }
 aya = { workspace = true }
 base16ct = { workspace = true, features = ["alloc"] }
 base64 = { workspace = true }

--- a/bpfman.spec
+++ b/bpfman.spec
@@ -34,6 +34,7 @@ BuildRequires:  pkgconfig(zlib)
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  clang-devel
+BuildRequires:  bindgen-cli
 
 # TODO: Generate Provides for all of the vendored dependencies
 


### PR DESCRIPTION
See: https://aws.github.io/aws-lc-rs/requirements/linux.html

We can install bindgen-cli on any target that requires it. This avoid having to manage a direct dependency on aws-lc-rs.