### PR TITLE
chore: Update to Rust 2024 Edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
+checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
 dependencies = [
  "bindgen",
  "cc",
@@ -280,7 +280,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "libc",
  "log",
@@ -344,9 +344,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bindgen"
@@ -354,7 +354,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -379,9 +379,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -399,15 +399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2",
 ]
 
 [[package]]
@@ -471,7 +462,7 @@ dependencies = [
  "nix 0.28.0",
  "object",
  "oci-client",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "sha2",
@@ -514,7 +505,7 @@ dependencies = [
  "nix 0.28.0",
  "oci-client",
  "prost 0.12.6",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "sha2",
@@ -578,9 +569,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cached"
@@ -696,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -793,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
 dependencies = [
  "clap",
 ]
@@ -866,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -957,7 +948,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "parking_lot 0.12.3",
  "rustix 0.38.44",
@@ -980,7 +971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -992,7 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1105,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1192,9 +1183,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -1228,7 +1219,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1237,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1256,7 +1247,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1295,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1317,11 +1308,11 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1380,9 +1371,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1548,21 +1539,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded738faa0e88d3abc9d1a13cb11adc2073c400969eeb8793cf7132589959fc"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1584,9 +1575,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1602,7 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1618,7 +1609,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1707,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1743,27 +1734,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1804,7 +1795,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1851,7 +1842,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -2042,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2053,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -2082,7 +2073,7 @@ dependencies = [
  "log",
  "predicates",
  "procfs",
- "rand",
+ "rand 0.9.0",
  "regex",
  "sled",
 ]
@@ -2137,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -2318,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -2344,9 +2335,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
 ]
 
 [[package]]
@@ -2369,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2386,15 +2377,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2475,9 +2466,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -2501,9 +2492,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -2605,7 +2596,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
  "memoffset",
@@ -2617,7 +2608,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2646,7 +2637,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2696,8 +2687,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.15",
- "http 1.2.0",
- "rand",
+ "http 1.3.1",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -2708,18 +2699,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
 name = "objc2"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
 dependencies = [
- "objc-sys",
  "objc2-encode",
 ]
 
@@ -2731,13 +2715,11 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
- "bitflags 2.8.0",
- "block2",
- "libc",
+ "bitflags 2.9.0",
  "objc2",
 ]
 
@@ -2749,7 +2731,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "memchr",
 ]
 
@@ -2762,7 +2744,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-auth",
  "jwt",
  "lazy_static",
@@ -2808,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "opaque-debug"
@@ -2829,13 +2811,13 @@ dependencies = [
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http 1.2.0",
+ "http 1.3.1",
  "itertools 0.10.5",
  "log",
  "oauth2",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde-value",
@@ -2851,11 +2833,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2883,9 +2865,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -3049,7 +3031,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3061,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3083,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -3113,7 +3095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -3123,23 +3105,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3192,15 +3174,15 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "pkcs5",
- "rand_core",
+ "rand_core 0.6.4",
  "spki",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -3221,11 +3203,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3246,9 +3228,9 @@ checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -3311,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -3324,7 +3306,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -3337,7 +3319,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hex",
 ]
 
@@ -3430,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b318f733603136dcc61aa9e77c928d67f87d2436c34ec052ba3f1b5ca219de"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
  "base64 0.22.1",
  "once_cell",
@@ -3492,14 +3474,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3509,7 +3508,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3519,6 +3528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -3532,11 +3550,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3570,16 +3588,16 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -3644,9 +3662,9 @@ checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -3655,7 +3673,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3702,7 +3720,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3711,28 +3729,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.0",
  "subtle",
  "zeroize",
 ]
@@ -3758,6 +3776,17 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
@@ -3775,15 +3804,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "ryu-js"
@@ -3856,7 +3885,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3875,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -3926,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -3945,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3985,7 +4014,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4055,7 +4084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4090,12 +4119,12 @@ dependencies = [
  "pem",
  "pkcs1",
  "pkcs8",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "ring",
  "rsa",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "scrypt",
  "serde",
  "serde_json",
@@ -4182,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "snafu"
@@ -4348,14 +4377,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -4401,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -4416,15 +4445,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4442,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4555,7 +4584,7 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4577,7 +4606,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4670,7 +4699,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4752,9 +4781,9 @@ checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicase"
@@ -4764,9 +4793,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -4855,9 +4884,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "serde",
 ]
@@ -4901,9 +4930,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -5014,11 +5043,10 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9fe1ebb156110ff855242c1101df158b822487e4957b0556d9ffce9db0f535"
+checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
 dependencies = [
- "block2",
  "core-foundation 0.10.0",
  "home",
  "jni",
@@ -5096,38 +5124,37 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -5181,11 +5208,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5201,6 +5244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,6 +5260,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5225,10 +5280,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5243,6 +5310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,6 +5326,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5267,6 +5346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5279,10 +5364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.2"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -5295,11 +5386,11 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5376,8 +5467,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -5392,19 +5491,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.5"
+name = "zerocopy-derive"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ resolver = "2"
 
 [workspace.package]
 documentation = "https://bpfman.io/main/getting-started/overview/"
-edition = "2021"
+edition = "2024"
 homepage = "https://bpfman.io"
 license = "Apache-2.0"
 repository = "https://github.com/bpfman/bpfman"
+rust-version = "1.85.0"
 version = "0.5.6"
 
 [workspace.dependencies]
@@ -75,7 +76,7 @@ procfs = { version = "0.16.0", default-features = false }
 prost = { version = "0.12.6", default-features = false }
 prost-types = { version = "0.12.6", default-features = false }
 quote = { version = "1", default-features = false }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.9", default-features = false }
 regex = { version = "1.11.1", default-features = false }
 rtnetlink = { version = "0.14", default-features = false }
 rustdoc-json = { version = "0.8.9", default-features = false }
@@ -108,3 +109,9 @@ platforms = [
     "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
 ]
+
+[workspace.lints.clippy]
+unused_trait_names = "warn"
+
+[workspace.lints.rust]
+unused-extern-crates = "warn"

--- a/bpf-log-exporter/Cargo.toml
+++ b/bpf-log-exporter/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 description = "Binary for exporting eBPF events via logs"
+name = "bpf-log-exporter"
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpf-log-exporter"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
-
 
 [dependencies]
 anyhow = { workspace = true }

--- a/bpf-log-exporter/src/main.rs
+++ b/bpf-log-exporter/src/main.rs
@@ -3,11 +3,11 @@
 
 use std::{cell::RefCell, num::NonZeroI32, str::from_utf8};
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use log::{debug, info};
 use netlink_packet_audit::AuditMessage;
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
-use netlink_sys::{protocols::NETLINK_AUDIT, Socket, SocketAddr};
+use netlink_sys::{Socket, SocketAddr, protocols::NETLINK_AUDIT};
 use regex::Regex;
 
 fn main() -> anyhow::Result<()> {
@@ -67,7 +67,7 @@ impl NetlinkAudit {
             Err(_) => {
                 return Err(anyhow!(
                     "unable to create socket, make sure audit is enabled"
-                ))
+                ));
             }
         };
         if sock.bind_auto().is_err() {

--- a/bpf-metrics-exporter/Cargo.toml
+++ b/bpf-metrics-exporter/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 description = "Binary for exporting eBPF subsystem metrics via prometheus"
+name = "bpf-metrics-exporter"
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpf-metrics-exporter"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/bpf-metrics-exporter/src/main.rs
+++ b/bpf-metrics-exporter/src/main.rs
@@ -4,18 +4,18 @@
 use std::time::SystemTime;
 
 use aya::{
-    maps::{loaded_maps, MapType as AyaMapType},
-    programs::{loaded_links, loaded_programs, ProgramType as AyaProgramType},
+    maps::{MapType as AyaMapType, loaded_maps},
+    programs::{ProgramType as AyaProgramType, loaded_links, loaded_programs},
 };
 use bpfman::types::{BpfProgType, MapType};
-use chrono::{prelude::DateTime, Utc};
+use chrono::{Utc, prelude::DateTime};
 use clap::Parser;
 use opentelemetry::{
-    metrics::{MeterProvider as _, Unit},
     KeyValue,
+    metrics::{MeterProvider as _, Unit},
 };
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::{metrics::SdkMeterProvider, runtime, Resource};
+use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider, runtime};
 use tokio::signal::ctrl_c;
 
 fn init_meter_provider(grpc_endpoint: &str) -> SdkMeterProvider {

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 description = "gRPC bindings to the bpfman API"
+name = "bpfman-api"
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpfman-api"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
-
 
 [[bin]]
 name = "bpfman-rpc"

--- a/bpfman-api/src/bin/rpc/main.rs
+++ b/bpfman-api/src/bin/rpc/main.rs
@@ -13,7 +13,7 @@ use bpfman::{
 };
 use clap::{Args, Parser};
 use log::debug;
-use systemd_journal_logger::{connected_to_journal, JournalLog};
+use systemd_journal_logger::{JournalLog, connected_to_journal};
 use tokio::{sync::Mutex, task::spawn_blocking};
 
 use crate::serve::serve;

--- a/bpfman-api/src/bin/rpc/rpc.rs
+++ b/bpfman-api/src/bin/rpc/rpc.rs
@@ -10,11 +10,11 @@ use bpfman::types::{
     XdpProceedOn, XdpProgram,
 };
 use bpfman_api::v1::{
+    AttachRequest, AttachResponse, BpfmanProgramType, DetachRequest, DetachResponse, GetRequest,
+    GetResponse, ListRequest, ListResponse, LoadRequest, LoadResponse, LoadResponseInfo,
+    ProgSpecificInfo, PullBytecodeRequest, PullBytecodeResponse, UnloadRequest, UnloadResponse,
     attach_info::Info, bpfman_server::Bpfman, bytecode_location::Location as RpcLocation,
-    list_response::ListResult, AttachRequest, AttachResponse, BpfmanProgramType, DetachRequest,
-    DetachResponse, GetRequest, GetResponse, ListRequest, ListResponse, LoadRequest, LoadResponse,
-    LoadResponseInfo, ProgSpecificInfo, PullBytecodeRequest, PullBytecodeResponse, UnloadRequest,
-    UnloadResponse,
+    list_response::ListResult,
 };
 use log::error;
 use tokio::sync::Mutex;

--- a/bpfman-api/src/bin/rpc/serve.rs
+++ b/bpfman-api/src/bin/rpc/serve.rs
@@ -9,21 +9,21 @@ use std::{
 };
 
 use anyhow::anyhow;
-use bpfman::utils::{set_file_permissions, SOCK_MODE};
+use bpfman::utils::{SOCK_MODE, set_file_permissions};
 use bpfman_api::v1::bpfman_server::BpfmanServer;
 use libsystemd::activation::IsType;
 use log::{debug, error, info};
 use tokio::{
     join,
     net::UnixListener,
-    signal::unix::{signal, SignalKind},
-    sync::{broadcast, Mutex},
+    signal::unix::{SignalKind, signal},
+    sync::{Mutex, broadcast},
     task::{JoinHandle, JoinSet},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
 
-use crate::{rpc::BpfmanLoader, storage::StorageManager, AsyncBpfman};
+use crate::{AsyncBpfman, rpc::BpfmanLoader, storage::StorageManager};
 
 pub async fn serve(
     db_lock: Arc<Mutex<AsyncBpfman>>,

--- a/bpfman-api/src/bin/rpc/storage.rs
+++ b/bpfman-api/src/bin/rpc/storage.rs
@@ -14,28 +14,29 @@ use async_trait::async_trait;
 use aya::maps::MapData;
 use bpfman::{
     types::ListFilter,
-    utils::{create_bpffs, set_dir_permissions, set_file_permissions, SOCK_MODE},
+    utils::{SOCK_MODE, create_bpffs, set_dir_permissions, set_file_permissions},
 };
 use bpfman_csi::v1::{
+    GetPluginCapabilitiesRequest, GetPluginCapabilitiesResponse, GetPluginInfoRequest,
+    GetPluginInfoResponse, NodeExpandVolumeRequest, NodeExpandVolumeResponse,
+    NodeGetCapabilitiesRequest, NodeGetCapabilitiesResponse, NodeGetInfoRequest,
+    NodeGetInfoResponse, NodeGetVolumeStatsRequest, NodeGetVolumeStatsResponse,
+    NodePublishVolumeRequest, NodePublishVolumeResponse, NodeServiceCapability,
+    NodeStageVolumeRequest, NodeStageVolumeResponse, NodeUnpublishVolumeRequest,
+    NodeUnpublishVolumeResponse, NodeUnstageVolumeRequest, NodeUnstageVolumeResponse, ProbeRequest,
+    ProbeResponse,
     identity_server::{Identity, IdentityServer},
     node_server::{Node, NodeServer},
-    node_service_capability, volume_capability, GetPluginCapabilitiesRequest,
-    GetPluginCapabilitiesResponse, GetPluginInfoRequest, GetPluginInfoResponse,
-    NodeExpandVolumeRequest, NodeExpandVolumeResponse, NodeGetCapabilitiesRequest,
-    NodeGetCapabilitiesResponse, NodeGetInfoRequest, NodeGetInfoResponse,
-    NodeGetVolumeStatsRequest, NodeGetVolumeStatsResponse, NodePublishVolumeRequest,
-    NodePublishVolumeResponse, NodeServiceCapability, NodeStageVolumeRequest,
-    NodeStageVolumeResponse, NodeUnpublishVolumeRequest, NodeUnpublishVolumeResponse,
-    NodeUnstageVolumeRequest, NodeUnstageVolumeResponse, ProbeRequest, ProbeResponse,
+    node_service_capability, volume_capability,
 };
 use log::{debug, error, info, warn};
-use nix::mount::{mount, umount, MsFlags};
+use nix::mount::{MsFlags, mount, umount};
 use tokio::{
     net::UnixListener,
-    sync::{broadcast, Mutex},
+    sync::{Mutex, broadcast},
 };
 use tokio_stream::wrappers::UnixListenerStream;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{Request, Response, Status, transport::Server};
 
 use crate::AsyncBpfman;
 

--- a/bpfman-api/src/lib.rs
+++ b/bpfman-api/src/lib.rs
@@ -8,10 +8,10 @@ use bpfman::{
 use v1::FentryAttachInfo;
 
 use crate::v1::{
-    attach_info::Info, bytecode_location::Location as V1Location, AttachInfo,
-    BytecodeImage as V1BytecodeImage, BytecodeLocation, KernelProgramInfo as V1KernelProgramInfo,
-    KprobeAttachInfo, ProgramInfo, ProgramInfo as V1ProgramInfo, TcAttachInfo, TcxAttachInfo,
-    TracepointAttachInfo, UprobeAttachInfo, XdpAttachInfo,
+    AttachInfo, BytecodeImage as V1BytecodeImage, BytecodeLocation,
+    KernelProgramInfo as V1KernelProgramInfo, KprobeAttachInfo, ProgramInfo,
+    ProgramInfo as V1ProgramInfo, TcAttachInfo, TcxAttachInfo, TracepointAttachInfo,
+    UprobeAttachInfo, XdpAttachInfo, attach_info::Info, bytecode_location::Location as V1Location,
 };
 
 #[path = "bpfman.v1.rs"]

--- a/bpfman-ns/Cargo.toml
+++ b/bpfman-ns/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 description = "An executable to attach an eBPF program inside a container"
+name = "bpfman-ns"
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpfman-ns"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [[bin]]

--- a/bpfman-ns/src/main.rs
+++ b/bpfman-ns/src/main.rs
@@ -3,11 +3,11 @@
 
 use std::{fs::File, process};
 
-use anyhow::{bail, Context};
-use aya::programs::{links::FdLink, uprobe::UProbeLink, ProbeKind, UProbe};
+use anyhow::{Context, bail};
+use aya::programs::{ProbeKind, UProbe, links::FdLink, uprobe::UProbeLink};
 use clap::{Args, Parser, Subcommand};
 use log::debug;
-use nix::sched::{setns, CloneFlags};
+use nix::sched::{CloneFlags, setns};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 description = "An eBPF Program Manager"
+name = "bpfman"
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpfman"
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lib]
@@ -59,7 +61,7 @@ oci-client = { workspace = true, default-features = false, features = [
     "native-tls",
     "trust-dns",
 ] }
-rand = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sha2 = { workspace = true }

--- a/bpfman/src/bin/cli/args.rs
+++ b/bpfman/src/bin/cli/args.rs
@@ -505,7 +505,10 @@ impl FromStr for GoArch {
             "ppc64le" => Ok(GoArch::Ppc64le),
             "riscv64" => Ok(GoArch::Riscv64),
             "s390x" => Ok(GoArch::S390x),
-            _ => Err(std::io::Error::new(ErrorKind::InvalidInput, "not a valid bytecode arch, please refer to https://go.dev/doc/install/source#environment for valid GOARCHes when GOOS=linux.")),
+            _ => Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "not a valid bytecode arch, please refer to https://go.dev/doc/install/source#environment for valid GOARCHes when GOOS=linux.",
+            )),
         }
     }
 }
@@ -572,7 +575,10 @@ impl GoArch {
         } else if s.contains("s390") && s.contains("bpfeb") && s.contains(".o") {
             Ok(GoArch::S390x)
         } else {
-            Err(std::io::Error::new(ErrorKind::InvalidInput, "not a valid cilium/ebpf bytecode filename, please refer to https://github.com/cilium/ebpf/blob/main/cmd/bpf2go/gen/target.go#L14"))
+            Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "not a valid cilium/ebpf bytecode filename, please refer to https://github.com/cilium/ebpf/blob/main/cmd/bpf2go/gen/target.go#L14",
+            ))
         }
     }
 }

--- a/bpfman/src/bin/cli/image.rs
+++ b/bpfman/src/bin/cli/image.rs
@@ -9,10 +9,10 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use aya::Endianness;
 use aya_obj::Object;
-use base64::{engine::general_purpose, Engine};
+use base64::{Engine, engine::general_purpose};
 use bpfman::{
     pull_bytecode, setup,
     types::{BpfProgType, BytecodeImage, ImagePullPolicy, MapType},
@@ -313,7 +313,7 @@ pub(crate) fn execute_build_args(args: &GenerateArgs) -> anyhow::Result<()> {
         None => {
             return Err(anyhow!(
                 "An S390 bytecode file cannot be used to generate build args"
-            ))
+            ));
         }
     };
 

--- a/bpfman/src/bin/cli/manpage.rs
+++ b/bpfman/src/bin/cli/manpage.rs
@@ -2,13 +2,13 @@
 // Copyright Authors of bpfman
 
 use std::{
-    fs::{create_dir_all, File},
+    fs::{File, create_dir_all},
     io::Write as _,
     path::{Path, PathBuf},
 };
 
 use clap::{CommandFactory, Parser};
-use flate2::{write::GzEncoder, Compression};
+use flate2::{Compression, write::GzEncoder};
 
 use crate::args::Cli;
 

--- a/bpfman/src/bin/cli/table.rs
+++ b/bpfman/src/bin/cli/table.rs
@@ -11,10 +11,12 @@ impl ProgTable {
         let mut table = Table::new();
 
         table.load_preset(comfy_table::presets::NOTHING);
-        table.set_header(vec![Cell::new("Bpfman State")
-            .add_attribute(comfy_table::Attribute::Bold)
-            .add_attribute(comfy_table::Attribute::Underlined)
-            .fg(Color::Green)]);
+        table.set_header(vec![
+            Cell::new("Bpfman State")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .add_attribute(comfy_table::Attribute::Underlined)
+                .fg(Color::Green),
+        ]);
 
         let data = program.get_data();
 
@@ -122,10 +124,12 @@ impl ProgTable {
         let mut table = Table::new();
 
         table.load_preset(comfy_table::presets::NOTHING);
-        table.set_header(vec![Cell::new("Kernel State")
-            .add_attribute(comfy_table::Attribute::Bold)
-            .add_attribute(comfy_table::Attribute::Underlined)
-            .fg(Color::Green)]);
+        table.set_header(vec![
+            Cell::new("Kernel State")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .add_attribute(comfy_table::Attribute::Underlined)
+                .fg(Color::Green),
+        ]);
 
         let p = r.get_data();
         let name = p.get_kernel_name()?;

--- a/bpfman/src/config.rs
+++ b/bpfman/src/config.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, str::FromStr};
 use aya::programs::XdpFlags;
 use serde::{Deserialize, Serialize};
 
-use crate::{errors::ParseError, TC_DISPATCHER_IMAGE, XDP_DISPATCHER_IMAGE};
+use crate::{TC_DISPATCHER_IMAGE, XDP_DISPATCHER_IMAGE, errors::ParseError};
 
 #[derive(Debug, Default, Deserialize, Clone)]
 pub struct Config {

--- a/bpfman/src/errors.rs
+++ b/bpfman/src/errors.rs
@@ -35,12 +35,16 @@ pub enum BpfmanError {
     DispatcherNotRequired,
     #[error(transparent)]
     BpfBytecodeError(#[from] ImageError),
-    #[error("Bytecode image bpf function name: {image_prog_name} isn't equal to the provided bpf function name {provided_prog_name}")]
+    #[error(
+        "Bytecode image bpf function name: {image_prog_name} isn't equal to the provided bpf function name {provided_prog_name}"
+    )]
     BytecodeMetaDataMismatch {
         image_prog_name: String,
         provided_prog_name: String,
     },
-    #[error("Program {expected_prog_name} not found in bytecode image {bytecode_image} with program names {program_names:?}")]
+    #[error(
+        "Program {expected_prog_name} not found in bytecode image {bytecode_image} with program names {program_names:?}"
+    )]
     ProgramNotFoundInBytecode {
         bytecode_image: String,
         expected_prog_name: String,

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -11,7 +11,10 @@ use std::{
 
 use anyhow::anyhow;
 use aya::{
+    Btf, Ebpf, EbpfLoader,
     programs::{
+        Extension, FEntry, FExit, KProbe, LinkOrder as AyaLinkOrder, ProbeKind, SchedClassifier,
+        TcAttachType, TracePoint, UProbe,
         fentry::FEntryLink,
         fexit::FExitLink,
         kprobe::KProbeLink,
@@ -20,10 +23,7 @@ use aya::{
         tc::{SchedClassifierLink, TcAttachOptions},
         trace_point::TracePointLink,
         uprobe::UProbeLink,
-        Extension, FEntry, FExit, KProbe, LinkOrder as AyaLinkOrder, ProbeKind, SchedClassifier,
-        TcAttachType, TracePoint, UProbe,
     },
-    Btf, Ebpf, EbpfLoader,
 };
 use log::{debug, error, info, warn};
 use multiprog::{TcDispatcher, XdpDispatcher};
@@ -38,8 +38,8 @@ use crate::{
     multiprog::{Dispatcher, DispatcherId, DispatcherInfo},
     oci_utils::image_manager::ImageManager,
     types::{
-        BpfProgType, BytecodeImage, Direction, ListFilter, Program, ProgramData, LINKS_LINK_PREFIX,
-        PROGRAM_PREFIX,
+        BpfProgType, BytecodeImage, Direction, LINKS_LINK_PREFIX, ListFilter, PROGRAM_PREFIX,
+        Program, ProgramData,
     },
     utils::{
         bytes_to_string, bytes_to_u32, enter_netns, get_error_msg_from_stderr, open_config_file,
@@ -374,7 +374,9 @@ pub fn remove_program(config: &Config, root_db: &Db, id: u32) -> Result<(), Bpfm
     let prog = match get(root_db, &id) {
         Some(p) => p,
         None => {
-            error!("Error: Request to unload program with id {id} but id does not exist or was not created by bpfman");
+            error!(
+                "Error: Request to unload program with id {id} but id does not exist or was not created by bpfman"
+            );
             return Err(BpfmanError::Error(format!(
                 "Program {0} does not exist or was not created by bpfman",
                 id,
@@ -439,7 +441,9 @@ pub fn attach_program(
     let mut prog = match get(root_db, &id) {
         Some(p) => p,
         None => {
-            error!("Error: Request to attach program with id {id} but id does not exist or was not created by bpfman");
+            error!(
+                "Error: Request to attach program with id {id} but id does not exist or was not created by bpfman"
+            );
             return Err(BpfmanError::Error(format!(
                 "Program {0} does not exist or was not created by bpfman",
                 id,
@@ -1688,7 +1692,7 @@ pub(crate) fn attach_multi_attach_program(
 
     let old_dispatcher = get_dispatcher(&did, root_db)?;
 
-    let if_config = if let Some(ref i) = config.interfaces() {
+    let if_config = if let Some(i) = config.interfaces() {
         i.get(&if_name)
     } else {
         None
@@ -1759,7 +1763,7 @@ fn detach_multi_attach_program(
     // Intentionally don't add filter program here
     let mut programs = get_multi_attach_links(root_db, program_type, if_index, direction, nsid)?;
 
-    let if_config = if let Some(ref i) = config.interfaces() {
+    let if_config = if let Some(i) = config.interfaces() {
         i.get(&if_name)
     } else {
         None

--- a/bpfman/src/multiprog/tc.rs
+++ b/bpfman/src/multiprog/tc.rs
@@ -9,12 +9,12 @@ use std::{
 };
 
 use aya::{
+    Ebpf, EbpfLoader,
     programs::{
+        Extension, Link as _, SchedClassifier, TcAttachType,
         links::FdLink,
         tc::{self, NlOptions, SchedClassifierLink, TcAttachOptions},
-        Extension, Link as _, SchedClassifier, TcAttachType,
     },
-    Ebpf, EbpfLoader,
 };
 use log::debug;
 use sled::Db;

--- a/bpfman/src/multiprog/xdp.rs
+++ b/bpfman/src/multiprog/xdp.rs
@@ -7,11 +7,11 @@ use std::{
 };
 
 use aya::{
-    programs::{
-        links::{FdLink, PinnedLink},
-        Extension, Xdp,
-    },
     Ebpf, EbpfLoader,
+    programs::{
+        Extension, Xdp,
+        links::{FdLink, PinnedLink},
+    },
 };
 use aya_obj::programs::XdpAttachType;
 use log::{debug, info};
@@ -273,7 +273,10 @@ impl XdpDispatcher {
             let mut link = dispatcher.attach(&iface, flags);
             if let Err(e) = link {
                 if mode != XdpMode::Skb {
-                    info!("Unable to attach on interface {} mode {}, falling back to Skb and retrying.", iface, mode);
+                    info!(
+                        "Unable to attach on interface {} mode {}, falling back to Skb and retrying.",
+                        iface, mode
+                    );
                     flags = XdpMode::Skb.as_flags();
                     link = dispatcher.attach(&iface, flags);
                     if let Err(e) = link {

--- a/bpfman/src/netlink.rs
+++ b/bpfman/src/netlink.rs
@@ -8,15 +8,15 @@ use std::{
 };
 
 use anyhow::{anyhow, bail};
-use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_core::{NLM_F_DUMP, NLM_F_REQUEST, NetlinkMessage, NetlinkPayload};
 use netlink_packet_route::{
-    tc::{TcAttribute, TcMessage},
     RouteNetlinkMessage,
+    tc::{TcAttribute, TcMessage},
 };
-use netlink_sys::{constants::NETLINK_ROUTE, Socket, SocketAddr};
+use netlink_sys::{Socket, SocketAddr, constants::NETLINK_ROUTE};
 use nix::{
     fcntl::{self, OFlag},
-    sched::{setns, CloneFlags},
+    sched::{CloneFlags, setns},
     sys::stat::Mode,
 };
 

--- a/bpfman/src/oci_utils/cosign.rs
+++ b/bpfman/src/oci_utils/cosign.rs
@@ -7,12 +7,12 @@ use anyhow::{anyhow, bail};
 use log::{debug, info, warn};
 use sigstore::{
     cosign::{
-        verification_constraint::VerificationConstraintVec, verify_constraints, ClientBuilder,
-        CosignCapabilities,
+        ClientBuilder, CosignCapabilities, verification_constraint::VerificationConstraintVec,
+        verify_constraints,
     },
     errors::SigstoreError::RegistryPullManifestError,
     registry::{Auth, ClientConfig, ClientProtocol, OciReference},
-    trust::{sigstore::SigstoreTrustRoot, ManualTrustRoot, TrustRoot as _},
+    trust::{ManualTrustRoot, TrustRoot as _, sigstore::SigstoreTrustRoot},
 };
 
 use crate::oci_utils::rt;

--- a/bpfman/src/oci_utils/image_manager.rs
+++ b/bpfman/src/oci_utils/image_manager.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::HashMap,
-    io::{copy, Read},
+    io::{Read, copy},
 };
 
 use anyhow::anyhow;
@@ -11,11 +11,11 @@ use flate2::read::GzDecoder;
 use log::{debug, error, info, trace};
 use object::{Endianness, Object};
 use oci_client::{
+    Client, Reference,
     client::{ClientConfig, ClientProtocol},
     manifest,
     manifest::OciImageManifest,
     secrets::RegistryAuth,
-    Client, Reference,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -25,8 +25,9 @@ use tar::Archive;
 
 use crate::{
     oci_utils::{
-        cosign::{fetch_sigstore_tuf_data, CosignVerifier},
-        rt, ImageError,
+        ImageError,
+        cosign::{CosignVerifier, fetch_sigstore_tuf_data},
+        rt,
     },
     types::ImagePullPolicy,
     utils::{sled_get, sled_insert},
@@ -638,15 +639,30 @@ mod tests {
             output: &'static str,
         }
         let tt = vec![
-            Case{input: "busybox", output: "docker.io_library_busybox_latest"},
-            Case{input:"quay.io/busybox", output: "quay.io_busybox_latest"},
-            Case{input:"docker.io/test:tag", output: "docker.io_library_test_tag"},
-            Case{input:"quay.io/test:5000", output: "quay.io_test_5000"},
-            Case{input:"test.com/repo:tag", output: "test.com_repo_tag"},
-            Case{
-                input:"test.com/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            Case {
+                input: "busybox",
+                output: "docker.io_library_busybox_latest",
+            },
+            Case {
+                input: "quay.io/busybox",
+                output: "quay.io_busybox_latest",
+            },
+            Case {
+                input: "docker.io/test:tag",
+                output: "docker.io_library_test_tag",
+            },
+            Case {
+                input: "quay.io/test:5000",
+                output: "quay.io_test_5000",
+            },
+            Case {
+                input: "test.com/repo:tag",
+                output: "test.com_repo_tag",
+            },
+            Case {
+                input: "test.com/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 output: "test.com_repo_sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            }
+            },
         ];
 
         for t in tt {

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -18,7 +18,7 @@ use aya::{
         ProgramType as AyaProgramType,
     },
 };
-use chrono::{prelude::DateTime, Local};
+use chrono::{Local, prelude::DateTime};
 use clap::ValueEnum;
 use log::{debug, info, warn};
 use rand::Rng;
@@ -169,8 +169,8 @@ impl LinkData {
             .open()
             .expect("unable to open temporary database");
 
-        let mut rng = rand::thread_rng();
-        let id_rand = rng.gen::<u32>();
+        let mut rng = rand::rng();
+        let id_rand = rng.random::<u32>();
 
         let db_tree = db
             .open_tree(LINKS_PRE_ATTACH_LINK_PREFIX.to_string() + &id_rand.to_string())
@@ -286,43 +286,43 @@ pub struct XdpLink(pub(crate) LinkData);
 
 impl XdpLink {
     pub(crate) fn set_priority(&mut self, priority: i32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_PRIORITY, &priority.to_ne_bytes())
+        sled_insert(&self.0.0, XDP_PRIORITY, &priority.to_ne_bytes())
     }
 
     pub fn get_priority(&self) -> Result<i32, BpfmanError> {
-        sled_get(&self.0 .0, XDP_PRIORITY).map(bytes_to_i32)
+        sled_get(&self.0.0, XDP_PRIORITY).map(bytes_to_i32)
     }
 
     pub(crate) fn set_iface(&mut self, iface: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_IFACE, iface.as_bytes())
+        sled_insert(&self.0.0, XDP_IFACE, iface.as_bytes())
     }
 
     pub fn get_iface(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, XDP_IFACE).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, XDP_IFACE).map(|v| bytes_to_string(&v))
     }
 
     pub(crate) fn set_current_position(&mut self, pos: usize) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_CURRENT_POSITION, &pos.to_ne_bytes())
+        sled_insert(&self.0.0, XDP_CURRENT_POSITION, &pos.to_ne_bytes())
     }
 
     pub fn get_current_position(&self) -> Result<Option<usize>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, XDP_CURRENT_POSITION)?.map(bytes_to_usize))
+        Ok(sled_get_option(&self.0.0, XDP_CURRENT_POSITION)?.map(bytes_to_usize))
     }
 
     pub(crate) fn set_ifindex(&mut self, ifindex: u32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_IF_INDEX, &ifindex.to_ne_bytes())
+        sled_insert(&self.0.0, XDP_IF_INDEX, &ifindex.to_ne_bytes())
     }
 
     pub fn get_ifindex(&self) -> Result<Option<u32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, XDP_IF_INDEX)?.map(bytes_to_u32))
+        Ok(sled_get_option(&self.0.0, XDP_IF_INDEX)?.map(bytes_to_u32))
     }
 
     pub(crate) fn set_attached(&mut self, attached: bool) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_ATTACHED, &bool_to_bytes(attached))
+        sled_insert(&self.0.0, XDP_ATTACHED, &bool_to_bytes(attached))
     }
 
     pub fn get_attached(&self) -> Result<bool, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, XDP_ATTACHED)?
+        Ok(sled_get_option(&self.0.0, XDP_ATTACHED)?
             .map(bytes_to_bool)
             .unwrap_or(false))
     }
@@ -334,7 +334,7 @@ impl XdpLink {
             .enumerate()
             .try_for_each(|(i, v)| {
                 sled_insert(
-                    &self.0 .0,
+                    &self.0.0,
                     format!("{PREFIX_XDP_PROCEED_ON}{i}").as_str(),
                     &v.to_ne_bytes(),
                 )
@@ -343,7 +343,7 @@ impl XdpLink {
 
     pub fn get_proceed_on(&self) -> Result<XdpProceedOn, BpfmanError> {
         self.0
-             .0
+            .0
             .scan_prefix(PREFIX_XDP_PROCEED_ON)
             .map(|n| {
                 n.map(|(_, v)| XdpProceedOnEntry::try_from(bytes_to_i32(v.to_vec())))
@@ -361,19 +361,19 @@ impl XdpLink {
     }
 
     pub(crate) fn set_netns(&mut self, netns: PathBuf) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_NETNS, netns.as_os_str().as_bytes())
+        sled_insert(&self.0.0, XDP_NETNS, netns.as_os_str().as_bytes())
     }
 
     pub fn get_netns(&self) -> Result<Option<PathBuf>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, XDP_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
+        Ok(sled_get_option(&self.0.0, XDP_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
     }
 
     pub(crate) fn set_nsid(&mut self, offset: u64) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, XDP_NSID, &offset.to_ne_bytes())
+        sled_insert(&self.0.0, XDP_NSID, &offset.to_ne_bytes())
     }
 
     pub fn get_nsid(&self) -> Result<u64, BpfmanError> {
-        sled_get(&self.0 .0, XDP_NSID).map(bytes_to_u64)
+        sled_get(&self.0.0, XDP_NSID).map(bytes_to_u64)
     }
 
     pub fn attach(&mut self, info: AttachInfo) -> Result<(), BpfmanError> {
@@ -407,53 +407,53 @@ pub struct TcLink(pub(crate) LinkData);
 
 impl TcLink {
     pub(crate) fn set_priority(&mut self, priority: i32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_PRIORITY, &priority.to_ne_bytes())
+        sled_insert(&self.0.0, TC_PRIORITY, &priority.to_ne_bytes())
     }
 
     pub fn get_priority(&self) -> Result<i32, BpfmanError> {
-        sled_get(&self.0 .0, TC_PRIORITY).map(bytes_to_i32)
+        sled_get(&self.0.0, TC_PRIORITY).map(bytes_to_i32)
     }
 
     pub(crate) fn set_iface(&mut self, iface: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_IFACE, iface.as_bytes())
+        sled_insert(&self.0.0, TC_IFACE, iface.as_bytes())
     }
 
     pub fn get_iface(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, TC_IFACE).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, TC_IFACE).map(|v| bytes_to_string(&v))
     }
 
     pub(crate) fn set_current_position(&mut self, pos: usize) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_CURRENT_POSITION, &pos.to_ne_bytes())
+        sled_insert(&self.0.0, TC_CURRENT_POSITION, &pos.to_ne_bytes())
     }
 
     pub fn get_current_position(&self) -> Result<Option<usize>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TC_CURRENT_POSITION)?.map(bytes_to_usize))
+        Ok(sled_get_option(&self.0.0, TC_CURRENT_POSITION)?.map(bytes_to_usize))
     }
 
     pub(crate) fn set_ifindex(&mut self, ifindex: u32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_IF_INDEX, &ifindex.to_ne_bytes())
+        sled_insert(&self.0.0, TC_IF_INDEX, &ifindex.to_ne_bytes())
     }
 
     pub fn get_ifindex(&self) -> Result<Option<u32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TC_IF_INDEX)?.map(bytes_to_u32))
+        Ok(sled_get_option(&self.0.0, TC_IF_INDEX)?.map(bytes_to_u32))
     }
 
     pub(crate) fn set_attached(&mut self, attached: bool) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_ATTACHED, &bool_to_bytes(attached))
+        sled_insert(&self.0.0, TC_ATTACHED, &bool_to_bytes(attached))
     }
 
     pub fn get_attached(&self) -> Result<bool, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TC_ATTACHED)?
+        Ok(sled_get_option(&self.0.0, TC_ATTACHED)?
             .map(bytes_to_bool)
             .unwrap_or(false))
     }
 
     pub(crate) fn set_direction(&mut self, direction: Direction) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_DIRECTION, direction.to_string().as_bytes())
+        sled_insert(&self.0.0, TC_DIRECTION, direction.to_string().as_bytes())
     }
 
     pub fn get_direction(&self) -> Result<Direction, BpfmanError> {
-        sled_get(&self.0 .0, TC_DIRECTION)
+        sled_get(&self.0.0, TC_DIRECTION)
             .map(|v| bytes_to_string(&v).to_string().try_into().unwrap())
     }
 
@@ -464,7 +464,7 @@ impl TcLink {
             .enumerate()
             .try_for_each(|(i, v)| {
                 sled_insert(
-                    &self.0 .0,
+                    &self.0.0,
                     format!("{PREFIX_TC_PROCEED_ON}{i}").as_str(),
                     &v.to_ne_bytes(),
                 )
@@ -473,7 +473,7 @@ impl TcLink {
 
     pub fn get_proceed_on(&self) -> Result<TcProceedOn, BpfmanError> {
         self.0
-             .0
+            .0
             .scan_prefix(PREFIX_TC_PROCEED_ON)
             .map(|n| n.map(|(_, v)| TcProceedOnEntry::try_from(bytes_to_i32(v.to_vec())).unwrap()))
             .map(|n| {
@@ -488,19 +488,19 @@ impl TcLink {
     }
 
     pub(crate) fn set_netns(&mut self, netns: PathBuf) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_NETNS, netns.as_os_str().as_bytes())
+        sled_insert(&self.0.0, TC_NETNS, netns.as_os_str().as_bytes())
     }
 
     pub fn get_netns(&self) -> Result<Option<PathBuf>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TC_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
+        Ok(sled_get_option(&self.0.0, TC_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
     }
 
     pub(crate) fn set_nsid(&mut self, offset: u64) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TC_NSID, &offset.to_ne_bytes())
+        sled_insert(&self.0.0, TC_NSID, &offset.to_ne_bytes())
     }
 
     pub fn get_nsid(&self) -> Result<u64, BpfmanError> {
-        sled_get(&self.0 .0, TC_NSID).map(bytes_to_u64)
+        sled_get(&self.0.0, TC_NSID).map(bytes_to_u64)
     }
 
     pub fn attach(&mut self, info: AttachInfo) -> Result<(), BpfmanError> {
@@ -535,43 +535,43 @@ pub struct TcxLink(pub(crate) LinkData);
 
 impl TcxLink {
     pub(crate) fn set_priority(&mut self, priority: i32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_PRIORITY, &priority.to_ne_bytes())
+        sled_insert(&self.0.0, TCX_PRIORITY, &priority.to_ne_bytes())
     }
 
     pub fn get_priority(&self) -> Result<i32, BpfmanError> {
-        sled_get(&self.0 .0, TCX_PRIORITY).map(bytes_to_i32)
+        sled_get(&self.0.0, TCX_PRIORITY).map(bytes_to_i32)
     }
 
     pub(crate) fn set_current_position(&mut self, pos: usize) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_CURRENT_POSITION, &pos.to_ne_bytes())
+        sled_insert(&self.0.0, TCX_CURRENT_POSITION, &pos.to_ne_bytes())
     }
 
     pub fn get_current_position(&self) -> Result<Option<usize>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TCX_CURRENT_POSITION)?.map(bytes_to_usize))
+        Ok(sled_get_option(&self.0.0, TCX_CURRENT_POSITION)?.map(bytes_to_usize))
     }
 
     pub(crate) fn set_iface(&mut self, iface: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_IFACE, iface.as_bytes())
+        sled_insert(&self.0.0, TCX_IFACE, iface.as_bytes())
     }
 
     pub fn get_iface(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, TCX_IFACE).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, TCX_IFACE).map(|v| bytes_to_string(&v))
     }
 
     pub(crate) fn set_ifindex(&mut self, ifindex: u32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_IF_INDEX, &ifindex.to_ne_bytes())
+        sled_insert(&self.0.0, TCX_IF_INDEX, &ifindex.to_ne_bytes())
     }
 
     pub fn get_ifindex(&self) -> Result<Option<u32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TCX_IF_INDEX)?.map(bytes_to_u32))
+        Ok(sled_get_option(&self.0.0, TCX_IF_INDEX)?.map(bytes_to_u32))
     }
 
     pub(crate) fn set_direction(&mut self, direction: Direction) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_DIRECTION, direction.to_string().as_bytes())
+        sled_insert(&self.0.0, TCX_DIRECTION, direction.to_string().as_bytes())
     }
 
     pub fn get_direction(&self) -> Result<Direction, BpfmanError> {
-        sled_get(&self.0 .0, TCX_DIRECTION).and_then(|v| {
+        sled_get(&self.0.0, TCX_DIRECTION).and_then(|v| {
             bytes_to_string(&v)
                 .to_string()
                 .try_into()
@@ -580,19 +580,19 @@ impl TcxLink {
     }
 
     pub(crate) fn set_netns(&mut self, netns: PathBuf) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_NETNS, netns.as_os_str().as_bytes())
+        sled_insert(&self.0.0, TCX_NETNS, netns.as_os_str().as_bytes())
     }
 
     pub fn get_netns(&self) -> Result<Option<PathBuf>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, TCX_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
+        Ok(sled_get_option(&self.0.0, TCX_NETNS)?.map(|v| PathBuf::from(OsStr::from_bytes(&v))))
     }
 
     pub(crate) fn set_nsid(&mut self, offset: u64) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TCX_NSID, &offset.to_ne_bytes())
+        sled_insert(&self.0.0, TCX_NSID, &offset.to_ne_bytes())
     }
 
     pub fn get_nsid(&self) -> Result<u64, BpfmanError> {
-        sled_get(&self.0 .0, TCX_NSID).map(bytes_to_u64)
+        sled_get(&self.0.0, TCX_NSID).map(bytes_to_u64)
     }
 
     pub fn attach(&mut self, info: AttachInfo) -> Result<(), BpfmanError> {
@@ -639,11 +639,11 @@ impl TracepointLink {
     }
 
     pub(crate) fn set_tracepoint(&mut self, tracepoint: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, TRACEPOINT_NAME, tracepoint.as_bytes())
+        sled_insert(&self.0.0, TRACEPOINT_NAME, tracepoint.as_bytes())
     }
 
     pub fn get_tracepoint(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, TRACEPOINT_NAME).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, TRACEPOINT_NAME).map(|v| bytes_to_string(&v))
     }
 }
 
@@ -652,31 +652,31 @@ pub struct KprobeLink(pub(crate) LinkData);
 
 impl KprobeLink {
     pub(crate) fn set_fn_name(&mut self, fn_name: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, KPROBE_FN_NAME, fn_name.as_bytes())
+        sled_insert(&self.0.0, KPROBE_FN_NAME, fn_name.as_bytes())
     }
 
     pub fn get_fn_name(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, KPROBE_FN_NAME).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, KPROBE_FN_NAME).map(|v| bytes_to_string(&v))
     }
 
     pub(crate) fn set_offset(&mut self, offset: u64) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, KPROBE_OFFSET, &offset.to_ne_bytes())
+        sled_insert(&self.0.0, KPROBE_OFFSET, &offset.to_ne_bytes())
     }
 
     pub fn get_offset(&self) -> Result<u64, BpfmanError> {
-        sled_get(&self.0 .0, KPROBE_OFFSET).map(bytes_to_u64)
+        sled_get(&self.0.0, KPROBE_OFFSET).map(bytes_to_u64)
     }
 
     pub(crate) fn set_container_pid(&mut self, container_pid: i32) -> Result<(), BpfmanError> {
         sled_insert(
-            &self.0 .0,
+            &self.0.0,
             KPROBE_CONTAINER_PID,
             &container_pid.to_ne_bytes(),
         )
     }
 
     pub fn get_container_pid(&self) -> Result<Option<i32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, KPROBE_CONTAINER_PID)?.map(bytes_to_i32))
+        Ok(sled_get_option(&self.0.0, KPROBE_CONTAINER_PID)?.map(bytes_to_i32))
     }
 
     pub fn attach(&mut self, info: AttachInfo) -> Result<(), BpfmanError> {
@@ -704,47 +704,47 @@ pub struct UprobeLink(pub(crate) LinkData);
 
 impl UprobeLink {
     pub(crate) fn set_fn_name(&mut self, fn_name: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, UPROBE_FN_NAME, fn_name.as_bytes())
+        sled_insert(&self.0.0, UPROBE_FN_NAME, fn_name.as_bytes())
     }
 
     pub fn get_fn_name(&self) -> Result<Option<String>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, UPROBE_FN_NAME)?.map(|v| bytes_to_string(&v)))
+        Ok(sled_get_option(&self.0.0, UPROBE_FN_NAME)?.map(|v| bytes_to_string(&v)))
     }
 
     pub(crate) fn set_offset(&mut self, offset: u64) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, UPROBE_OFFSET, &offset.to_ne_bytes())
+        sled_insert(&self.0.0, UPROBE_OFFSET, &offset.to_ne_bytes())
     }
 
     pub fn get_offset(&self) -> Result<u64, BpfmanError> {
-        sled_get(&self.0 .0, UPROBE_OFFSET).map(bytes_to_u64)
+        sled_get(&self.0.0, UPROBE_OFFSET).map(bytes_to_u64)
     }
 
     pub(crate) fn set_container_pid(&mut self, container_pid: i32) -> Result<(), BpfmanError> {
         sled_insert(
-            &self.0 .0,
+            &self.0.0,
             UPROBE_CONTAINER_PID,
             &container_pid.to_ne_bytes(),
         )
     }
 
     pub fn get_container_pid(&self) -> Result<Option<i32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, UPROBE_CONTAINER_PID)?.map(bytes_to_i32))
+        Ok(sled_get_option(&self.0.0, UPROBE_CONTAINER_PID)?.map(bytes_to_i32))
     }
 
     pub(crate) fn set_pid(&mut self, pid: i32) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, UPROBE_PID, &pid.to_ne_bytes())
+        sled_insert(&self.0.0, UPROBE_PID, &pid.to_ne_bytes())
     }
 
     pub fn get_pid(&self) -> Result<Option<i32>, BpfmanError> {
-        Ok(sled_get_option(&self.0 .0, UPROBE_PID)?.map(bytes_to_i32))
+        Ok(sled_get_option(&self.0.0, UPROBE_PID)?.map(bytes_to_i32))
     }
 
     pub(crate) fn set_target(&mut self, target: String) -> Result<(), BpfmanError> {
-        sled_insert(&self.0 .0, UPROBE_TARGET, target.as_bytes())
+        sled_insert(&self.0.0, UPROBE_TARGET, target.as_bytes())
     }
 
     pub fn get_target(&self) -> Result<String, BpfmanError> {
-        sled_get(&self.0 .0, UPROBE_TARGET).map(|v| bytes_to_string(&v))
+        sled_get(&self.0.0, UPROBE_TARGET).map(|v| bytes_to_string(&v))
     }
 
     pub fn attach(&mut self, info: AttachInfo) -> Result<(), BpfmanError> {
@@ -1474,8 +1474,8 @@ impl ProgramData {
             .open()
             .expect("unable to open temporary database");
 
-        let mut rng = rand::thread_rng();
-        let id_rand = rng.gen::<u32>();
+        let mut rng = rand::rng();
+        let id_rand = rng.random::<u32>();
 
         let db_tree = db
             .open_tree(PROGRAM_PRE_LOAD_PREFIX.to_string() + &id_rand.to_string())
@@ -2550,7 +2550,7 @@ impl Program {
             Program::Fentry(_) => LinkType::Fentry,
             Program::Fexit(_) => LinkType::Fexit,
             Program::Unsupported(_) => {
-                return Err(BpfmanError::Error("Unsupported program type".to_string()))
+                return Err(BpfmanError::Error("Unsupported program type".to_string()));
             }
         };
 
@@ -2954,7 +2954,7 @@ impl TryFrom<String> for BpfProgType {
             other => {
                 return Err(ParseError::InvalidProgramType {
                     program: other.to_string(),
-                })
+                });
             }
         })
     }
@@ -3001,7 +3001,7 @@ impl TryFrom<u32> for BpfProgType {
             other => {
                 return Err(ParseError::InvalidProgramType {
                     program: other.to_string(),
-                })
+                });
             }
         })
     }
@@ -3150,7 +3150,7 @@ impl TryFrom<i32> for ProbeType {
             other => {
                 return Err(ParseError::InvalidProbeType {
                     probe: other.to_string(),
-                })
+                });
             }
         })
     }
@@ -3221,7 +3221,7 @@ impl TryFrom<String> for XdpProceedOnEntry {
             proceedon => {
                 return Err(ParseError::InvalidProceedOn {
                     proceedon: proceedon.to_string(),
-                })
+                });
             }
         })
     }
@@ -3240,7 +3240,7 @@ impl TryFrom<i32> for XdpProceedOnEntry {
             proceedon => {
                 return Err(ParseError::InvalidProceedOn {
                     proceedon: proceedon.to_string(),
-                })
+                });
             }
         })
     }
@@ -3350,7 +3350,7 @@ impl TryFrom<String> for TcProceedOnEntry {
             proceedon => {
                 return Err(ParseError::InvalidProceedOn {
                     proceedon: proceedon.to_string(),
-                })
+                });
             }
         })
     }
@@ -3374,7 +3374,7 @@ impl TryFrom<i32> for TcProceedOnEntry {
             proceedon => {
                 return Err(ParseError::InvalidProceedOn {
                     proceedon: proceedon.to_string(),
-                })
+                });
             }
         })
     }
@@ -3510,7 +3510,7 @@ impl TryFrom<i32> for ImagePullPolicy {
             policy => {
                 return Err(ParseError::InvalidBytecodeImagePullPolicy {
                     pull_policy: policy.to_string(),
-                })
+                });
             }
         })
     }
@@ -3526,7 +3526,7 @@ impl TryFrom<&str> for ImagePullPolicy {
             policy => {
                 return Err(ParseError::InvalidBytecodeImagePullPolicy {
                     pull_policy: policy.to_string(),
-                })
+                });
             }
         })
     }
@@ -3685,7 +3685,7 @@ impl TryFrom<u32> for BpfAttachType {
             other => {
                 return Err(ParseError::InvalidAttachType {
                     link_type: other.to_string(),
-                })
+                });
             }
         })
     }

--- a/bpfman/src/utils.rs
+++ b/bpfman/src/utils.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs,
-    fs::{create_dir_all, set_permissions, File, OpenOptions},
+    fs::{File, OpenOptions, create_dir_all, set_permissions},
     io::{BufRead, BufReader, Read},
     option::Option,
     os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
@@ -11,14 +11,14 @@ use std::{
     process,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use log::{debug, info, warn};
 use nix::{
     libc::RLIM_INFINITY,
-    mount::{mount, MsFlags},
+    mount::{MsFlags, mount},
     net::if_::if_nametoindex,
-    sched::{setns, CloneFlags},
-    sys::resource::{setrlimit, Resource},
+    sched::{CloneFlags, setns},
+    sys::resource::{Resource, setrlimit},
 };
 use sled::Tree;
 

--- a/csi/Cargo.toml
+++ b/csi/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 description = "gRPC bindings to the CSI spec"
+name = "bpfman-csi"
+version = "1.8.0"
+
+documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "bpfman-csi"
 repository.workspace = true
-version = "1.8.0"
+rust-version.workspace = true
 
 [dependencies]
 prost = { workspace = true, features = ["prost-derive", "std"] }

--- a/tests/integration-test/Cargo.toml
+++ b/tests/integration-test/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
+name = "integration-test"
+publish = false
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "integration-test"
-publish = false
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -10,9 +10,9 @@ use bpfman::{
 use rand::Rng;
 
 use crate::tests::{
-    e2e::{GLOBAL_U32, GLOBAL_U8},
-    utils::*,
     RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP,
+    e2e::{GLOBAL_U8, GLOBAL_U32},
+    utils::*,
 };
 
 #[test]
@@ -41,7 +41,7 @@ fn test_load_unload_xdp() {
     ])
     .unwrap();
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Install a few xdp programs
     let image = Location::Image(BytecodeImage {
@@ -64,7 +64,7 @@ fn test_load_unload_xdp() {
             None,
             AttachInfo::Xdp {
                 iface: DEFAULT_BPFMAN_IFACE.to_string(),
-                priority: rng.gen_range(1..255),
+                priority: rng.random_range(1..255),
                 proceed_on: proceed_on.clone(),
                 netns: None,
                 metadata: HashMap::new(),
@@ -157,16 +157,20 @@ fn test_map_sharing_load_unload_xdp() {
     // Order of programs is not guarenteed.
     let prog_2_id = prog_2.get_data().get_id().unwrap();
 
-    assert!(prog_2
-        .get_data()
-        .get_maps_used_by()
-        .unwrap()
-        .contains(&prog_1_id));
-    assert!(prog_2
-        .get_data()
-        .get_maps_used_by()
-        .unwrap()
-        .contains(&prog_2_id));
+    assert!(
+        prog_2
+            .get_data()
+            .get_maps_used_by()
+            .unwrap()
+            .contains(&prog_1_id)
+    );
+    assert!(
+        prog_2
+            .get_data()
+            .get_maps_used_by()
+            .unwrap()
+            .contains(&prog_2_id)
+    );
 
     // Verify the "Map Owner Id:" is set to the first program.
     assert_eq!(
@@ -230,7 +234,7 @@ fn test_load_unload_tc() {
     ])
     .expect("Failed to create TcProceedOn");
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let file = Location::File(TC_PASS_FILE_LOC.to_string());
     let image = Location::Image(BytecodeImage {
@@ -252,7 +256,7 @@ fn test_load_unload_tc() {
             None,
             AttachInfo::Tc {
                 iface: DEFAULT_BPFMAN_IFACE.to_string(),
-                priority: rng.gen_range(1..255),
+                priority: rng.random_range(1..255),
                 direction: "ingress".to_string(),
                 proceed_on: proceed_on.clone(),
                 netns: None,
@@ -544,7 +548,7 @@ fn test_list_with_metadata() {
     ])
     .unwrap();
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Install a few xdp programs
     let image = Location::Image(BytecodeImage {
@@ -568,7 +572,7 @@ fn test_list_with_metadata() {
             None,
             AttachInfo::Xdp {
                 iface: DEFAULT_BPFMAN_IFACE.to_string(),
-                priority: rng.gen_range(1..255),
+                priority: rng.random_range(1..255),
                 proceed_on: proceed_on.clone(),
                 netns: None,
                 metadata: HashMap::new(),
@@ -591,7 +595,7 @@ fn test_list_with_metadata() {
         None,
         AttachInfo::Xdp {
             iface: DEFAULT_BPFMAN_IFACE.to_string(),
-            priority: rng.gen_range(1..255),
+            priority: rng.random_range(1..255),
             proceed_on: proceed_on.clone(),
             netns: None,
             metadata: HashMap::new(),
@@ -737,7 +741,7 @@ fn test_load_unload_cosign_disabled() {
     verify_and_delete_programs(&config, &root_db, progs);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 pub extern "C" fn trigger_bpf_program() {
     core::hint::black_box(trigger_bpf_program);

--- a/tests/integration-test/src/tests/e2e.rs
+++ b/tests/integration-test/src/tests/e2e.rs
@@ -7,7 +7,7 @@ use bpfman::{
 use procfs::sys::kernel::Version;
 
 use crate::tests::{
-    basic::trigger_bpf_program, utils::*, RTDIR_FS_TC_EGRESS, RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP,
+    RTDIR_FS_TC_EGRESS, RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP, basic::trigger_bpf_program, utils::*,
 };
 
 pub(crate) const GLOBAL_U8: &str = "GLOBAL_u8";

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use bpfman::{
     add_programs, attach_program,
     config::Config,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
+name = "xtask"
+publish = false
+
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "xtask"
-publish = false
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use clap::Parser;
 
 use crate::workspace::WORKSPACE_ROOT;

--- a/xtask/src/integration_test.rs
+++ b/xtask/src/integration_test.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Child, Command, Stdio},
 };
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use cargo_metadata::{Artifact, CompilerMessage, Message, Target};
 use clap::Parser;
 

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -3,7 +3,7 @@ use std::{os::unix::process::CommandExt, path::PathBuf, process::Command};
 use anyhow::Context as _;
 use clap::Parser;
 
-use crate::build_ebpf::{build_ebpf, Options as BuildOptions};
+use crate::build_ebpf::{Options as BuildOptions, build_ebpf};
 
 #[derive(Debug, Parser)]
 pub struct Options {


### PR DESCRIPTION
This allows us to take advantage of new language features. More importantly, the next Aya release will have a MSRV of 1.85 since it's also moved to 2024 edition rust, so we need to migrate to remain compatible.