### PR TITLE
support SecurityProfilesOperator v0.9.1

### DIFF
--- a/examples/config/selinux/go-app-counter/kustomization.yaml
+++ b/examples/config/selinux/go-app-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
     target:
       kind: DaemonSet
       name: go-app-counter-ds
-  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-app-counter.process"
+  - patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-app-counter.process"
     target:
       kind: DaemonSet
       name: go-app-counter-ds

--- a/examples/config/selinux/go-app-counter/selinux.yaml
+++ b/examples/config/selinux/go-app-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-app-counter
+  name: bpfman-secure-go-app-counter
 spec:
   allow:
     "@self":

--- a/examples/config/selinux/go-kprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-kprobe-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-kprobe-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-kprobe-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-kprobe-counter.process"
   target:
     kind: DaemonSet
     name: go-kprobe-counter-ds

--- a/examples/config/selinux/go-kprobe-counter/selinux.yaml
+++ b/examples/config/selinux/go-kprobe-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-kprobe-counter
+  name: bpfman-secure-go-kprobe-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-tc-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tc-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-tc-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tc-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-tc-counter.process"
   target:
     kind: DaemonSet
     name: go-tc-counter-ds

--- a/examples/config/selinux/go-tc-counter/selinux.yaml
+++ b/examples/config/selinux/go-tc-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-tc-counter
+  name: bpfman-secure-go-tc-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-tcx-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tcx-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-tcx-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tcx-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-tcx-counter.process"
   target:
     kind: DaemonSet
     name: go-tcx-counter-ds

--- a/examples/config/selinux/go-tcx-counter/selinux.yaml
+++ b/examples/config/selinux/go-tcx-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-tcx-counter
+  name: bpfman-secure-go-tcx-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-tracepoint-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-tracepoint-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-tracepoint-counter.process"
   target:
     kind: DaemonSet
     name: go-tracepoint-counter-ds

--- a/examples/config/selinux/go-tracepoint-counter/selinux.yaml
+++ b/examples/config/selinux/go-tracepoint-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-tracepoint-counter
+  name: bpfman-secure-go-tracepoint-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-uprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uprobe-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-uprobe-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uprobe-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-uprobe-counter.process"
   target:
     kind: DaemonSet
     name: go-uprobe-counter-ds

--- a/examples/config/selinux/go-uprobe-counter/selinux.yaml
+++ b/examples/config/selinux/go-uprobe-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-uprobe-counter
+  name: bpfman-secure-go-uprobe-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-uretprobe-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-uretprobe-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-uretprobe-counter.process"
   target:
     kind: DaemonSet
     name: go-uretprobe-counter-ds

--- a/examples/config/selinux/go-uretprobe-counter/selinux.yaml
+++ b/examples/config/selinux/go-uretprobe-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-uretprobe-counter
+  name: bpfman-secure-go-uretprobe-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/kustomization.yaml
@@ -27,7 +27,7 @@ patches:
     - op: add
       path: "/spec/template/spec/containers/0/securityContext/seLinuxOptions/type"
       value:
-        bpfman-secure_go-xdp-counter.process
+        bpfman-secure-go-xdp-counter.process
   target:
     kind: DaemonSet
     name: go-xdp-counter-ds

--- a/examples/config/selinux/go-xdp-counter-sharing-map/selinux.yaml
+++ b/examples/config/selinux/go-xdp-counter-sharing-map/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-xdp-counter
+  name: bpfman-secure-go-xdp-counter
 spec:
   allow:
     '@self':

--- a/examples/config/selinux/go-xdp-counter/kustomization.yaml
+++ b/examples/config/selinux/go-xdp-counter/kustomization.yaml
@@ -29,7 +29,7 @@ patches:
   target:
     kind: DaemonSet
     name: go-xdp-counter-ds
-- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure_go-xdp-counter.process"
+- patch: "- op: add\n  path: \"/spec/template/spec/containers/0/securityContext/seLinuxOptions/type\"\n  value: \n    bpfman-secure-go-xdp-counter.process"
   target:
     kind: DaemonSet
     name: go-xdp-counter-ds

--- a/examples/config/selinux/go-xdp-counter/selinux.yaml
+++ b/examples/config/selinux/go-xdp-counter/selinux.yaml
@@ -1,8 +1,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
-  name: bpfman-secure
-  namespace: go-xdp-counter
+  name: bpfman-secure-go-xdp-counter
 spec:
   allow:
     '@self':


### PR DESCRIPTION
The SecurityProfileOperator (SPO) created a new release, v0.9.0. This release was pushed to OperatorHub (2/25/25) but has failed to merge. https://github.com/k8s-operatorhub/community-operators/pull/5799 As part of the release, the SeLinux Profiles CRDs moved from namespace scoped to cluster scoped. This effects bpfman two ways:
* The SeLinux Profiles bpfman creates in the examples need to remove the namespace field.
* In the examples DaemonSet, when deploying with SeLinux, in the container Security Context, the yaml points to the SeLinux Profile using <SeLinuxProfileName>_<Namespace>.process. With the change to namespace scoped CRD, this becomes <SeLinuxProfileName>.process.

This commit adjusts the SeLinux deployment Kustomize files to account for these changes. Because the SeLinux Profile was namespace scoped, all the profiles were originally named `bpfman-secure`. Now that they are cluster scoped, they need unique names. So this PR just made the SeLinux Profile name `bpfman-secure-<ExampleNamespace>` to keep them unique.

In v0.9.0, there was a bug in the SPO code. When the namespace was dropped, the logic processing the SeLinux Profile did not drop the namespace, but the namespace was empty. As a result, the code in v0.9.0 expects <SeLinuxProfileName>_.process (extra "_" at the end). This was fixed with:
https://github.com/kubernetes-sigs/security-profiles-operator/issues/2745 https://github.com/kubernetes-sigs/security-profiles-operator/pull/2746 There is another fix bpfman needs:
https://github.com/kubernetes-sigs/security-profiles-operator/issues/2699 https://github.com/kubernetes-sigs/security-profiles-operator/pull/2746

SPO plans to cut a new release, resumably v0.9.1 with these changes. When that happens, bpfman needs this PR. If v0.9.1 does not happen, this PR needs to be updates to include an "_" in the form of <SeLinuxProfileName>_.process.