### PR TITLE
fix: add binaries to container PATH

### DIFF
--- a/Containerfile.bpfman.local
+++ b/Containerfile.bpfman.local
@@ -54,6 +54,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/\* /tmp/\* /var/tmp/*
 
-COPY --from=bpfman-build  ./usr/src/bpfman/bpfman .
+COPY --from=bpfman-build  ./usr/src/bpfman/bpfman /usr/local/sbin/
 
-ENTRYPOINT ["./bpfman-rpc", "--timeout=0"]
+ENTRYPOINT ["bpfman-rpc", "--timeout=0"]

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -1530,6 +1530,9 @@ pub(crate) fn attach_single_attach_program(root_db: &Db, l: &mut Link) -> Result
                         }
                         Err(e) => {
                             info!("bpfman-ns returned error: {:?}", e);
+                            if let std::io::ErrorKind::NotFound = e.kind() {
+                                info!("bpfman-ns binary was not found. Please check your PATH.");
+                            }
                             Err(BpfmanError::ContainerAttachError {
                                 program_type: "uprobe".to_string(),
                                 container_pid: link.get_container_pid()?.unwrap(),


### PR DESCRIPTION
This closes #1451 

Two changes:

- `Containerfile.bpfman.local`: copy binaries to `/usr/local/sbin/` instead of `/`. This means the binaries are always found, regardless of changes to the current `WORKDIR`.
  - The entrypoint was updated accordingly.
  - For some reason, the build was failing for me unless I also installed `cmake` and `clang` so I went ahead and added those two packages to the last `apt-get install` command.

- `bpfman/src/lib.rs`: print out one additional message when the `bpfman-ns` binary is not found.