### PR TITLE
chore(vscode): use path relative to workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "rust-analyzer.check.allTargets": true,
   "yaml.schemas": {
-    "https://json.schemastore.org/github-workflow.json": "file:///home/dave/dev/bpfman/.github/workflows/build.yml"
+    "https://json.schemastore.org/github-workflow.json": "/.github/workflows/build.yml"
   },
   "rust-analyzer.check.command": "clippy"
 }


### PR DESCRIPTION
This closes #1475 

According to RedHat's [vscode-yaml](https://github.com/redhat-developer/vscode-yaml?tab=readme-ov-file#associating-a-schema-to-a-glob-pattern-via-yamlschemas), the path is relative to the workspace and with this change, yaml validation seems to work for me. Please take a look at it and let me know if it works for you as well...