### PR TITLE
cli: add get and list link

### DIFF
--- a/bpfman-api/src/bin/rpc/main.rs
+++ b/bpfman-api/src/bin/rpc/main.rs
@@ -9,7 +9,7 @@ use bpfman::{
     detach,
     errors::BpfmanError,
     get_program, list_programs, pull_bytecode, remove_program, setup,
-    types::{AttachInfo, BytecodeImage, ListFilter, Program},
+    types::{AttachInfo, BytecodeImage, Link, ListFilter, Program},
 };
 use clap::{Args, Parser};
 use log::debug;
@@ -113,7 +113,7 @@ impl AsyncBpfman {
         }
     }
 
-    pub(crate) async fn attach(&self, id: u32, attach_info: AttachInfo) -> anyhow::Result<u32> {
+    pub(crate) async fn attach(&self, id: u32, attach_info: AttachInfo) -> anyhow::Result<Link> {
         let (config, root_db) = self.setup()?;
         match spawn_blocking(move || attach_program(&config, &root_db, id, attach_info)).await {
             Ok(result) => result.map_err(|e| e.into()),

--- a/bpfman-api/src/bin/rpc/rpc.rs
+++ b/bpfman-api/src/bin/rpc/rpc.rs
@@ -248,7 +248,8 @@ impl BpfmanLoader {
         };
 
         let bpfman_lock = self.lock.lock().await;
-        let link_id = bpfman_lock.attach(request.id, attach_info).await?;
+        let link = bpfman_lock.attach(request.id, attach_info).await?;
+        let link_id = link.get_id()?;
 
         Ok(AttachResponse { link_id })
     }

--- a/bpfman/src/bin/cli/attach.rs
+++ b/bpfman/src/bin/cli/attach.rs
@@ -10,27 +10,29 @@ use log::warn;
 
 use crate::{
     args::{AttachArgs, AttachCommands},
+    load::parse_metadata,
     table::ProgTable,
 };
 
 pub(crate) fn execute_attach(args: &AttachArgs) -> anyhow::Result<()> {
     let (config, root_db) = setup()?;
-    attach_program(
-        &config,
-        &root_db,
-        args.program_id,
-        args.command.get_attach_info()?,
-    )?;
 
     match get_program(&root_db, args.program_id) {
         Ok(program) => {
-            if let Ok(p) = ProgTable::new_program(&program) {
+            let link = attach_program(
+                &config,
+                &root_db,
+                args.program_id,
+                args.command
+                    .get_attach_info(&program.get_data().get_application_from_metadata())?,
+            )?;
+
+            if let Ok(p) = ProgTable::new_link(&program, &link) {
                 p.print();
             }
-            ProgTable::new_kernel_info(&program)?.print();
         }
         Err(e) => {
-            warn!("BPFMAN get error: {}", e);
+            warn!("unable to retrieve program {}: {}", args.program_id, e);
             bail!(e)
         }
     }
@@ -38,7 +40,10 @@ pub(crate) fn execute_attach(args: &AttachArgs) -> anyhow::Result<()> {
 }
 
 impl AttachCommands {
-    pub(crate) fn get_attach_info(&self) -> Result<AttachInfo, anyhow::Error> {
+    pub(crate) fn get_attach_info(
+        &self,
+        application: &Option<String>,
+    ) -> Result<AttachInfo, anyhow::Error> {
         match self {
             AttachCommands::Xdp {
                 iface,
@@ -56,12 +61,7 @@ impl AttachCommands {
                     iface: iface.to_string(),
                     proceed_on: proc_on,
                     netns: netns.clone(),
-                    metadata: metadata
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                        .collect(),
+                    metadata: parse_metadata(metadata, application),
                 })
             }
             AttachCommands::Tc {
@@ -86,12 +86,7 @@ impl AttachCommands {
                     direction: direction.to_string(),
                     proceed_on: proc_on,
                     netns: netns.clone(),
-                    metadata: metadata
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                        .collect(),
+                    metadata: parse_metadata(metadata, application),
                 })
             }
             AttachCommands::Tcx {
@@ -110,12 +105,7 @@ impl AttachCommands {
                     iface: iface.to_string(),
                     direction: direction.to_string(),
                     netns: netns.clone(),
-                    metadata: metadata
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                        .collect(),
+                    metadata: parse_metadata(metadata, application),
                 })
             }
             AttachCommands::Tracepoint {
@@ -123,12 +113,7 @@ impl AttachCommands {
                 metadata,
             } => Ok(AttachInfo::Tracepoint {
                 tracepoint: tracepoint.to_string(),
-                metadata: metadata
-                    .clone()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                    .collect(),
+                metadata: parse_metadata(metadata, application),
             }),
             AttachCommands::Kprobe {
                 fn_name,
@@ -144,12 +129,7 @@ impl AttachCommands {
                     fn_name: fn_name.to_string(),
                     offset,
                     container_pid: *container_pid,
-                    metadata: metadata
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                        .collect(),
+                    metadata: parse_metadata(metadata, application),
                 })
             }
             AttachCommands::Uprobe {
@@ -167,29 +147,14 @@ impl AttachCommands {
                     target: target.to_string(),
                     pid: *pid,
                     container_pid: *container_pid,
-                    metadata: metadata
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                        .collect(),
+                    metadata: parse_metadata(metadata, application),
                 })
             }
             AttachCommands::Fentry { metadata } => Ok(AttachInfo::Fentry {
-                metadata: metadata
-                    .clone()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                    .collect(),
+                metadata: parse_metadata(metadata, application),
             }),
             AttachCommands::Fexit { metadata } => Ok(AttachInfo::Fexit {
-                metadata: metadata
-                    .clone()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                    .collect(),
+                metadata: parse_metadata(metadata, application),
             }),
         }
     }

--- a/bpfman/src/bin/cli/get.rs
+++ b/bpfman/src/bin/cli/get.rs
@@ -1,19 +1,76 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use bpfman::{errors::BpfmanError, get_program, setup};
+use anyhow::anyhow;
+use bpfman::{errors::BpfmanError, get_link, get_program, setup, types::Link};
 use log::warn;
 
-use crate::{args::GetArgs, table::ProgTable};
+use crate::{
+    args::{GetLinkArgs, GetProgramArgs, GetSubcommand},
+    table::ProgTable,
+};
 
-pub(crate) fn execute_get(args: &GetArgs) -> Result<(), BpfmanError> {
+impl GetSubcommand {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
+        match self {
+            GetSubcommand::Program(args) => {
+                execute_get_program(args).map_err(|e| anyhow!("get error: {e}"))
+            }
+            GetSubcommand::Link(args) => {
+                execute_get_link(args).map_err(|e| anyhow!("get error: {e}"))
+            }
+        }
+    }
+}
+
+pub(crate) fn execute_get_program(args: &GetProgramArgs) -> Result<(), BpfmanError> {
     let (_, root_db) = setup()?;
     match get_program(&root_db, args.program_id) {
         Ok(program) => {
-            if let Ok(p) = ProgTable::new_program(&program) {
-                p.print();
+            let mut links: Vec<Link> = vec![];
+            let data = program.get_data();
+
+            // If the Name does not exist, then it wasn't loaded by bpfman and
+            // skip the `Bpfman State` table section.
+            if data.get_name().is_ok() {
+                if let Ok(link_ids) = data.get_link_ids() {
+                    if !link_ids.is_empty() {
+                        for link_id in link_ids {
+                            match get_link(&root_db, link_id) {
+                                Ok(link) => {
+                                    links.push(link);
+                                }
+                                Err(e) => {
+                                    warn!("BPFMAN get error: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Ok(p) = ProgTable::new_program(&program, links) {
+                    p.print();
+                }
             }
             ProgTable::new_kernel_info(&program)?.print();
+            Ok(())
+        }
+        Err(e) => {
+            warn!("BPFMAN get error: {}", e);
+            Err(e)
+        }
+    }
+}
+
+pub(crate) fn execute_get_link(args: &GetLinkArgs) -> Result<(), BpfmanError> {
+    let (_, root_db) = setup()?;
+    match get_link(&root_db, args.link_id) {
+        Ok(link) => {
+            let program = link.get_program(&root_db)?;
+
+            if let Ok(p) = ProgTable::new_link(&program, &link) {
+                p.print();
+            }
             Ok(())
         }
         Err(e) => {

--- a/bpfman/src/bin/cli/list.rs
+++ b/bpfman/src/bin/cli/list.rs
@@ -1,32 +1,110 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
+use std::collections::HashMap;
+
 use anyhow::bail;
-use bpfman::{list_programs, setup, types::ListFilter};
+use bpfman::{
+    get_link, list_programs, setup,
+    types::{ListFilter, METADATA_APPLICATION_TAG},
+};
+use log::warn;
 
-use crate::{args::ListArgs, table::ProgTable};
+use crate::{
+    args::{ListLinkArgs, ListProgramArgs, ListSubcommand},
+    table::ProgTable,
+};
 
-pub(crate) fn execute_list(args: &ListArgs) -> anyhow::Result<()> {
+impl ListSubcommand {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
+        match self {
+            ListSubcommand::Programs(args) => execute_program_list(args),
+            ListSubcommand::Program(args) => execute_program_list(args),
+            ListSubcommand::Links(args) => execute_link_list(args),
+            ListSubcommand::Link(args) => execute_link_list(args),
+        }
+    }
+}
+
+pub(crate) fn execute_program_list(args: &ListProgramArgs) -> anyhow::Result<()> {
     let prog_type_filter = args.program_type.map(|p| p as u32);
 
     let filter = ListFilter::new(
         prog_type_filter,
-        args.metadata_selector
-            .clone()
-            .unwrap_or_default()
-            .iter()
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect(),
+        parse_metadata(&args.metadata_selector, &args.application),
         !args.all,
     );
 
-    let mut table = ProgTable::new_list();
+    let mut table = ProgTable::new_program_list();
     let (_, root_db) = setup()?;
     for r in list_programs(&root_db, filter)? {
-        if let Err(e) = table.add_response_prog(r) {
+        if let Err(e) = table.add_program_response(r) {
             bail!(e)
         }
     }
     table.print();
     Ok(())
+}
+
+pub(crate) fn execute_link_list(args: &ListLinkArgs) -> anyhow::Result<()> {
+    let prog_type_filter = args.program_type.map(|p| p as u32);
+
+    let filter = ListFilter::new(
+        prog_type_filter,
+        parse_metadata(&args.metadata_selector, &args.application),
+        true,
+    );
+
+    let mut table = ProgTable::new_link_list();
+    let (_, root_db) = setup()?;
+    for program in list_programs(&root_db, filter)? {
+        let data = program.get_data();
+        if let Ok(link_ids) = data.get_link_ids() {
+            if !link_ids.is_empty() {
+                for link_id in link_ids {
+                    match get_link(&root_db, link_id) {
+                        Ok(link) => {
+                            if let Err(e) = table.add_link_response(&program, &link) {
+                                bail!(e)
+                            }
+                        }
+                        Err(e) => {
+                            warn!("BPFMAN get error: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    table.print();
+    Ok(())
+}
+
+fn parse_metadata(
+    metadata: &Option<Vec<(String, String)>>,
+    application: &Option<String>,
+) -> HashMap<String, String> {
+    let mut data: HashMap<String, String> = HashMap::new();
+    let mut found = false;
+
+    if let Some(metadata) = metadata {
+        for (k, v) in metadata {
+            if k == METADATA_APPLICATION_TAG {
+                found = true;
+            }
+            data.insert(k.to_string(), v.to_string());
+        }
+    }
+    if let Some(app) = application {
+        if found {
+            warn!(
+                "application entered but {} already in metadata, ignoring application",
+                METADATA_APPLICATION_TAG
+            );
+        } else {
+            data.insert(METADATA_APPLICATION_TAG.to_string(), app.to_string());
+        }
+    }
+
+    data
 }

--- a/bpfman/src/bin/cli/load.rs
+++ b/bpfman/src/bin/cli/load.rs
@@ -7,10 +7,11 @@ use anyhow::bail;
 use bpfman::{
     add_programs, setup,
     types::{
-        FentryProgram, FexitProgram, KprobeProgram, Location, Program, ProgramData, TcProgram,
-        TcxProgram, TracepointProgram, UprobeProgram, XdpProgram,
+        FentryProgram, FexitProgram, KprobeProgram, Link, Location, METADATA_APPLICATION_TAG,
+        Program, ProgramData, TcProgram, TcxProgram, TracepointProgram, UprobeProgram, XdpProgram,
     },
 };
+use log::warn;
 
 use crate::{
     args::{GlobalArg, LoadFileArgs, LoadImageArgs, LoadSubcommand},
@@ -42,12 +43,7 @@ pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
         let data = ProgramData::new(
             bytecode_source.clone(),
             name.clone(),
-            args.metadata
-                .clone()
-                .unwrap_or_default()
-                .iter()
-                .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                .collect(),
+            parse_metadata(&args.metadata, &args.application),
             parse_global(&args.global),
             args.map_owner_id,
         )?;
@@ -75,12 +71,13 @@ pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
     let programs = add_programs(&config, &root_db, progs)?;
 
     if programs.len() == 1 {
-        ProgTable::new_program(&programs[0])?.print();
+        let links: Vec<Link> = vec![];
+        ProgTable::new_program(&programs[0], links)?.print();
         ProgTable::new_kernel_info(&programs[0])?.print();
     } else {
-        let mut table = ProgTable::new_list();
+        let mut table = ProgTable::new_program_list();
         for program in programs {
-            if let Err(e) = table.add_response_prog(program) {
+            if let Err(e) = table.add_program_response(program) {
                 bail!(e)
             }
         }
@@ -105,12 +102,7 @@ pub(crate) fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
         let data = ProgramData::new(
             bytecode_source.clone(),
             name.clone(),
-            args.metadata
-                .clone()
-                .unwrap_or_default()
-                .iter()
-                .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                .collect(),
+            parse_metadata(&args.metadata, &args.application),
             parse_global(&args.global),
             args.map_owner_id,
         )?;
@@ -140,18 +132,48 @@ pub(crate) fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
     let programs = add_programs(&config, &root_db, progs)?;
 
     if programs.len() == 1 {
-        ProgTable::new_program(&programs[0])?.print();
+        let links: Vec<Link> = vec![];
+        ProgTable::new_program(&programs[0], links)?.print();
         ProgTable::new_kernel_info(&programs[0])?.print();
     } else {
-        let mut table = ProgTable::new_list();
+        let mut table = ProgTable::new_program_list();
         for program in programs {
-            if let Err(e) = table.add_response_prog(program) {
+            if let Err(e) = table.add_program_response(program) {
                 bail!(e)
             }
         }
         table.print();
     }
     Ok(())
+}
+
+pub(crate) fn parse_metadata(
+    metadata: &Option<Vec<(String, String)>>,
+    application: &Option<String>,
+) -> HashMap<String, String> {
+    let mut data: HashMap<String, String> = HashMap::new();
+    let mut found = false;
+
+    if let Some(metadata) = metadata {
+        for (k, v) in metadata {
+            if k == METADATA_APPLICATION_TAG {
+                found = true;
+            }
+            data.insert(k.to_string(), v.to_string());
+        }
+    }
+    if let Some(app) = application {
+        if found {
+            warn!(
+                "application entered but {} already in metadata, ignoring application",
+                METADATA_APPLICATION_TAG
+            );
+        } else {
+            data.insert(METADATA_APPLICATION_TAG.to_string(), app.to_string());
+        }
+    }
+
+    data
 }
 
 fn parse_global(global: &Option<Vec<GlobalArg>>) -> HashMap<String, Vec<u8>> {

--- a/bpfman/src/bin/cli/load.rs
+++ b/bpfman/src/bin/cli/load.rs
@@ -51,7 +51,7 @@ pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
             parse_global(&args.global),
             args.map_owner_id,
         )?;
-        // Need to determin the program type here (XDP, TC, etc)
+        // Need to determine the program type here (XDP, TC, etc)
         // This would not be required if we had a generic "load" function
         let prog = match prog_type.as_str() {
             "xdp" => Program::Xdp(XdpProgram::new(data)?),
@@ -73,9 +73,18 @@ pub(crate) fn execute_load_file(args: &LoadFileArgs) -> anyhow::Result<()> {
         progs.push(prog);
     }
     let programs = add_programs(&config, &root_db, progs)?;
-    for program in programs {
-        ProgTable::new_program(&program)?.print();
-        ProgTable::new_kernel_info(&program)?.print();
+
+    if programs.len() == 1 {
+        ProgTable::new_program(&programs[0])?.print();
+        ProgTable::new_kernel_info(&programs[0])?.print();
+    } else {
+        let mut table = ProgTable::new_list();
+        for program in programs {
+            if let Err(e) = table.add_response_prog(program) {
+                bail!(e)
+            }
+        }
+        table.print();
     }
     Ok(())
 }
@@ -129,11 +138,19 @@ pub(crate) fn execute_load_image(args: &LoadImageArgs) -> anyhow::Result<()> {
         progs.push(prog);
     }
     let programs = add_programs(&config, &root_db, progs)?;
-    for program in programs {
-        ProgTable::new_program(&program)?.print();
-        ProgTable::new_kernel_info(&program)?.print();
-    }
 
+    if programs.len() == 1 {
+        ProgTable::new_program(&programs[0])?.print();
+        ProgTable::new_kernel_info(&programs[0])?.print();
+    } else {
+        let mut table = ProgTable::new_list();
+        for program in programs {
+            if let Err(e) = table.add_response_prog(program) {
+                bail!(e)
+            }
+        }
+        table.print();
+    }
     Ok(())
 }
 

--- a/bpfman/src/bin/cli/main.rs
+++ b/bpfman/src/bin/cli/main.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of bpfman
 
-use anyhow::anyhow;
 use args::Commands;
 use attach::execute_attach;
 use clap::Parser;
 use detach::execute_detach;
-use get::execute_get;
-use list::execute_list;
 use log::debug;
 use unload::execute_unload;
 
@@ -39,8 +36,8 @@ impl Commands {
             Commands::Unload(args) => execute_unload(args),
             Commands::Attach(args) => execute_attach(args),
             Commands::Detach(args) => execute_detach(args),
-            Commands::List(args) => execute_list(args),
-            Commands::Get(args) => execute_get(args).map_err(|e| anyhow!("get error: {e}")),
+            Commands::List(l) => l.execute(),
+            Commands::Get(g) => g.execute(),
             Commands::Image(i) => i.execute(),
             Commands::Man(args) => manpage::generate(args),
             Commands::Completions(args) => completions::generate(args),

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -146,7 +146,7 @@ pub fn get_db_config() -> SledConfig {
 ///     // information (similar to Kubernetes labels) to an eBPF program
 ///     // when it is loaded. This metadata consists of key-value pairs
 ///     // (e.g., `owner=acme`) and can be used for filtering or selecting
-///     // programs later, for instance, using commands like `bpfman list
+///     // programs later, for instance, using commands like `bpfman list programs
 ///     // --metadata-selector owner=acme`.
 ///     let mut metadata = HashMap::new();
 ///     metadata.insert("owner".to_string(), "acme".to_string());
@@ -437,7 +437,7 @@ pub fn attach_program(
     root_db: &Db,
     id: u32,
     attach_info: AttachInfo,
-) -> Result<u32, BpfmanError> {
+) -> Result<Link, BpfmanError> {
     let mut prog = match get(root_db, &id) {
         Some(p) => p,
         None => {
@@ -467,7 +467,10 @@ pub fn attach_program(
     let result = attach_program_internal(config, root_db, &prog, link.clone());
 
     match result {
-        Ok(_) => info!("Success: attached {kind} program named \"{name}\" with id {id}"),
+        Ok(ref link) => info!(
+            "Success: attached {kind} program named \"{name}\" with program id {id} with link {}",
+            link.get_id().unwrap_or_default(),
+        ),
         Err(ref e) => {
             error!("Error: failed to attach {kind} program named \"{name}\": {e}");
             if let Err(e) = prog.remove_link(root_db, link.clone()) {
@@ -485,7 +488,7 @@ fn attach_program_internal(
     root_db: &Db,
     program: &Program,
     mut link: Link,
-) -> Result<u32, BpfmanError> {
+) -> Result<Link, BpfmanError> {
     let program_type = program.kind();
 
     if let Err(e) = match program {
@@ -507,7 +510,7 @@ fn attach_program_internal(
     // write it to the database from the temp tree
     link.finalize(root_db)?;
 
-    link.get_id()
+    Ok(link)
 }
 
 fn detach_program_internal(
@@ -745,6 +748,63 @@ pub fn get_program(root_db: &Db, id: u32) -> Result<Program, BpfmanError> {
                 id
             ))),
     }
+}
+
+/// Retrieves information about a currently loaded eBPF program.
+///
+/// Attempts to retrieve detailed information about an eBPF program
+/// identified by the given kernel `id`. If the program was loaded by
+/// `bpfman`, it uses that information; otherwise, it queries all
+/// loaded eBPF programs through the Aya library. If a match is found,
+/// the program is converted into an unsupported program object.
+///
+/// The `Location` of the program indicates whether the program's
+/// bytecode was provided via a fully qualified local path or through
+/// an OCI-compliant container image tag.
+///
+/// # Arguments
+///
+/// * `id` - A `u32` representing the unique identifier of the eBPF program.
+///
+/// # Returns
+///
+/// * `Ok(Program)` - On successful retrieval of the program
+///   information, returns a `Program` object encapsulating the
+///   program details.
+///
+/// * `Err(BpfmanError)` - Returns an error if the setup fails, the
+///   program is not found, or there is an issue opening the database
+///   tree or setting kernel information.
+///
+/// # Errors
+///
+/// This function can return several types of errors:
+/// * `BpfmanError::SetupError` - If the setup function fails.
+/// * `BpfmanError::DatabaseError` - If there is an issue opening the
+///   database tree for the program.
+/// * `BpfmanError::KernelInfoError` - If there is an issue setting
+///   the kernel information for the program data.
+/// * `BpfmanError::Error` - If the program with the specified `id`
+///   does not exist.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use bpfman::{get_link,setup};
+///
+/// let (_, root_db) = setup().unwrap();
+/// match get_link(&root_db, 42) {
+///     Ok(link) => println!("Link info: {:?}", link),
+///     Err(e) => eprintln!("Error fetching link: {:?}", e),
+/// }
+///
+/// ```
+pub fn get_link(root_db: &Db, id: u32) -> Result<Link, BpfmanError> {
+    let tree = root_db
+        .open_tree(format!("{LINKS_LINK_PREFIX}{id}"))
+        .expect("Unable to open link database tree");
+    let link = Link::new_from_db(tree)?;
+    Ok(link)
 }
 
 /// Pulls an OCI-compliant image containing eBPF bytecode from a

--- a/bpfman/src/types.rs
+++ b/bpfman/src/types.rs
@@ -36,6 +36,9 @@ use crate::{
     },
 };
 
+// Special metadata tag used to group programs loaded under the same load request
+pub const METADATA_APPLICATION_TAG: &str = "bpfman_application";
+
 // These constants define the key of SLED DB
 // Program database layout
 //
@@ -966,6 +969,44 @@ impl Link {
         }
     }
 
+    pub fn get_metadata(&self) -> Result<HashMap<String, String>, BpfmanError> {
+        match self {
+            Link::Xdp(p) => p.0.get_metadata(),
+            Link::Tc(p) => p.0.get_metadata(),
+            Link::Tcx(p) => p.0.get_metadata(),
+            Link::Tracepoint(p) => p.0.get_metadata(),
+            Link::Kprobe(p) => p.0.get_metadata(),
+            Link::Uprobe(p) => p.0.get_metadata(),
+            Link::Fentry(p) => p.0.get_metadata(),
+            Link::Fexit(p) => p.0.get_metadata(),
+        }
+    }
+
+    /// Loops through the metadata of the link and if the
+    /// application tag exists, returns the value, otherwise
+    /// returns None.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Option<String>`.
+    ///
+    /// # Errors
+    ///
+    /// This function does not return an error.
+    pub fn get_application_from_metadata(&self) -> Option<String> {
+        let mut application: Option<String> = None;
+
+        if let Ok(metadata) = Self::get_metadata(self) {
+            for (k, v) in metadata {
+                if k == METADATA_APPLICATION_TAG {
+                    application = Some(v);
+                    break;
+                }
+            }
+        }
+        application
+    }
+
     pub fn get_current_position(&self) -> Result<Option<usize>, BpfmanError> {
         match self {
             Link::Xdp(p) => p.get_current_position(),
@@ -1865,6 +1906,31 @@ impl ProgramData {
                 })
             })
             .collect()
+    }
+
+    /// Loops through the metadata of the program and if the
+    /// application tag exists, returns the value, otherwise
+    /// returns None.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Option<String>`.
+    ///
+    /// # Errors
+    ///
+    /// This function does not return an error.
+    pub fn get_application_from_metadata(&self) -> Option<String> {
+        let mut application: Option<String> = None;
+
+        if let Ok(metadata) = Self::get_metadata(self) {
+            for (k, v) in metadata {
+                if k == METADATA_APPLICATION_TAG {
+                    application = Some(v);
+                    break;
+                }
+            }
+        }
+        application
     }
 
     pub(crate) fn set_map_owner_id(&mut self, id: u32) -> Result<(), BpfmanError> {

--- a/scripts/nsadd.sh
+++ b/scripts/nsadd.sh
@@ -6,14 +6,26 @@
 # netns option for intsalling the programs inside a network namespace.
 #
 # non-ns load tests:
-# bpfman load image --image-url quay.io/bpfman-bytecode/tcx_test:latest -n tcx_pass tcx -d ingress -i bpfman-host -p 20
-# bpfman load image --image-url quay.io/bpfman-bytecode/tc_pass:latest -n pass tc -d ingress -i bpfman-host -p 50
-# bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest -n pass xdp -i bpfman-host -p 100
+# ------------------
+# bpfman load image --image-url quay.io/bpfman-bytecode/tcx_test:latest --programs tcx:tcx_pass
+# bpfman attach <PROGRAM_ID> tcx -d ingress -i bpfman-host -p 20
+#
+# bpfman load image --image-url quay.io/bpfman-bytecode/tc_pass:latest --programs tc:pass
+# bpfman attach <PROGRAM_ID> tc -d ingress -i bpfman-host -p 50
+#
+# bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --programs xdp:pass
+# bpfman attach <PROGRAM_ID> xdp -i bpfman-host -p 100
 #
 # netns load tests:
-# bpfman load image --image-url quay.io/bpfman-bytecode/tcx_test:latest -n tcx_pass tcx -d ingress -i bpfman-ns -n bpfman-test -p 20
-# bpfman load image --image-url quay.io/bpfman-bytecode/tc_pass:latest -n pass tc -d ingress -i bpfman-ns -n bpfman-test -p 50
-# bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest -n pass xdp -i bpfman-ns -n bpfman-test -p 100
+# -----------------
+# bpfman load image --image-url quay.io/bpfman-bytecode/tcx_test:latest --programs tcx:tcx_pass
+# bpfman attach <PROGRAM_ID> tcx -d ingress -i bpfman-ns -n bpfman-test -p 20
+#
+# bpfman load image --image-url quay.io/bpfman-bytecode/tc_pass:latest --programs tc:pass
+# bpfman attach <PROGRAM_ID> tc -d ingress -i bpfman-ns -n bpfman-test -p 50
+#
+# bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --programs xdp:pass
+# bpfman attach <PROGRAM_ID> xdp -i bpfman-ns -n bpfman-test -p 100
 
 NS_NAME="bpfman-test"
 HOST_VETH="bpfman-host"


### PR DESCRIPTION
Add to the CLI the ability to get and list link data. This requires adding `program` and `link` subcommands to the `bpfman get` and `bpfman list` commands.

Resolves: #1415 
Resolves: #1426