### PR TITLE
docs: update docs to match the load/attach changes

### DIFF
--- a/docs/developer-guide/xdp-overview.md
+++ b/docs/developer-guide/xdp-overview.md
@@ -12,8 +12,8 @@ The dispatcher program contains a list of 10 stub functions.
 When XDP programs wish to be loaded, they are loaded as extension programs
 which are then called in place of one of the stub functions.
 
-bpfman is leveraging the libxdp protocol to allow it's users to load up to 10
-XDP programs on a given interface.
+bpfman is leveraging the libxdp protocol and dispatcher program to allow it's
+users to load up to 10 XDP programs on a given interface.
 This tutorial will show you how to use `bpfman` to load multiple XDP programs
 on an interface.
 
@@ -22,10 +22,7 @@ on an interface.
     Within bpfman, TC is implemented in a similar fashion to XDP in that it uses a dispatcher with
     stub functions.
     TCX is a fairly new kernel feature that improves how the kernel handles multiple TC programs
-    on a given interface.
-    bpfman is on the process of integrating TCX support, which will replace the dispatcher logic
-    for TC.
-    Until then, assume TC behaves in a similar fashion to XDP.
+    on a given interface and does not use the dispatcher program.
 
 See [Launching bpfman](../getting-started/launching-bpfman.md)
 for more detailed instructions on building and loading bpfman.
@@ -33,257 +30,252 @@ This tutorial assumes bpfman has been built and the `bpfman` CLI is in $PATH.
 
 ## Load XDP program
 
-We will load the simple `xdp-pass` program, which permits all traffic to the attached interface,
-`eno3` in this example.
+We will load and attach the simple `xdp-pass` program, which permits all traffic to
+the attached interface, `eno3` in this example.
 We will use the priority of 100.
 Find a deeper dive into CLI syntax in [CLI Guide](../getting-started/cli-guide.md).
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name pass \
-  xdp --iface eno3 --priority 100
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --application XdpPassProgram \
+     --programs xdp:pass
  Bpfman State
 ---------------
  Name:          pass
  Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
  Pull Policy:   IfNotPresent
  Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6213
+ Metadata:      bpfman_application=XdpPassProgram
+ Map Pin Path:  /run/bpfman/fs/maps/63336
  Map Owner ID:  None
- Map Used By:   6213
- Priority:      100
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
+ Maps Used By:  63336
+ Links:         None
 
  Kernel State
 ----------------------------------
- Program ID:                       6213
+ Program ID:                       63336
  Name:                             pass
  Type:                             xdp
- Loaded At:                        2023-07-17T17:48:10-0400
+ Loaded At:                        2025-03-31T17:49:22-0400
  Tag:                              4b9d1b2c140e87ce
  GPL Compatible:                   true
- Map IDs:                          [2724]
- BTF ID:                           2834
+ Map IDs:                          [21009]
+ BTF ID:                           31179
  Size Translated (bytes):          96
- JITed:                            true
- Size JITed (bytes):               67
+ JITted:                           true
+ Size JITted:                      75
  Kernel Allocated Memory (bytes):  4096
  Verified Instruction Count:       9
 ```
 
-`bpfman load image` returns the same data as a `bpfman get` command.
-From the output, the Program Id of `6213` can be found in the `Kernel State` section.
-This id can be used to perform a `bpfman get` to retrieve all relevant program
+Using the `Program ID` from the output from the `bpfman load` command,
+the eBPF Program can then be attached to the interface.
+
+```console
+sudo bpfman attach 63336 xdp --iface eno3 --priority 100
+ Bpfman State
+---------------
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            3736854134
+ Interface:          eno3
+ Priority:           100
+ Position:           0
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
+```
+
+`bpfman load image` returns the same data as a `bpfman get program` command and the
+`bpfman attach` returns the same data as a `bpfman get link` command.
+From the output, the `Program ID` of `63336` can be found in the `Kernel State` section.
+This id can be used to perform a `bpfman get program` to retrieve all relevant program
 data and a `bpfman unload` when the program needs to be unloaded.
 
 ```console
-sudo bpfman list
- Program ID  Name  Type  Load Time
- 6213        pass  xdp   2023-07-17T17:48:10-0400
+sudo bpfman list programs
+ Program ID  Application     Type  Function Name  Links
+ 63336       XdpPassProgram  xdp   pass           (1) 3736854134
 ```
 
-We can recheck the details about the loaded program with the `bpfman get` command:
+We can recheck the details about the loaded program with the `bpfman get program` command:
 
 ```console
-sudo bpfman get 6213
+sudo bpfman get program 63336
  Bpfman State
 ---------------
  Name:          pass
  Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
  Pull Policy:   IfNotPresent
  Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6213
+ Metadata:      bpfman_application=XdpPassProgram
+ Map Pin Path:  /run/bpfman/fs/maps/63336
  Map Owner ID:  None
- Map Used By:   6213
- Priority:      100
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
+ Maps Used By:  63336
+ Links:         3736854134 (eno3 pos-0)
 
  Kernel State
 ----------------------------------
- Program ID:                       6213
+ Program ID:                       63336
  Name:                             pass
  Type:                             xdp
- Loaded At:                        2023-07-17T17:48:10-0400
+ Loaded At:                        2025-03-31T17:49:22-0400
  Tag:                              4b9d1b2c140e87ce
  GPL Compatible:                   true
- Map IDs:                          [2724]
- BTF ID:                           2834
+ Map IDs:                          [21009]
+ BTF ID:                           31179
  Size Translated (bytes):          96
- JITed:                            true
- Size JITed (bytes):               67
+ JITted:                           true
+ Size JITted:                      75
  Kernel Allocated Memory (bytes):  4096
  Verified Instruction Count:       9
 ```
 
-From the output above you can see the program was loaded to position 0 on our
+We can also recheck the details about the attached program with the `bpfman get link` command:
+
+```console
+sudo bpfman get link 3736854134
+ Bpfman State
+---------------
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            3736854134
+ Interface:          eno3
+ Priority:           100
+ Position:           0
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
+```
+
+From the link output above you can see the program was loaded to position 0 on our
 interface and thus will be executed first.
 
 ## Loading Additional XDP Programs
 
-We will now load 2 more programs with different priorities to demonstrate how bpfman
+We will now attach 2 more programs with different priorities to demonstrate how bpfman
 will ensure they are ordered correctly:
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name pass \
-  xdp --iface eno3 --priority 50
+sudo bpfman attach 63336 xdp --iface eno3 --priority 50
  Bpfman State
 ---------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6215
- Map Owner ID:  None
- Map Used By:   6215
- Priority:      50
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6215
- Name:                             pass
- Type:                             xdp
-:
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            155072461
+ Interface:          eno3
+ Priority:           50
+ Position:           0
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name pass \
-  xdp --iface eno3 --priority 200
+sudo bpfman attach 63336 xdp --iface eno3 --priority 200
  Bpfman State
 ---------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6217
- Map Owner ID:  None
- Map Used By:   6217
- Priority:      200
- Iface:         eno3
- Position:      2
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6217
- Name:                             pass
- Type:                             xdp
-:
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            454777406
+ Interface:          eno3
+ Priority:           200
+ Position:           2
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
-Using `bpfman list` we can see all the programs that were loaded.
+Using `bpfman list links` we can see all the programs that were attached.
 
 ```console
-sudo bpfman list
- Program ID  Name  Type  Load Time
- 6213        pass  xdp   2023-07-17T17:48:10-0400
- 6215        pass  xdp   2023-07-17T17:52:46-0400
- 6217        pass  xdp   2023-07-17T17:53:57-0400
+sudo bpfman list links --application XdpPassProgram
+ Program ID  Link ID     Application     Type  Function Name  Attachment
+ 63336       155072461   XdpPassProgram  xdp   pass           eno3 pos-0
+ 63336       3736854134  XdpPassProgram  xdp   pass           eno3 pos-1
+ 63336       454777406   XdpPassProgram  xdp   pass           eno3 pos-2
 ```
 
 The lowest priority program is executed first, while the highest is executed last.
 As can be seen from the detailed output for each command below:
 
-* Program `6215` is at position `0` with a priority of `50`
-* Program `6213` is at position `1` with a priority of `100`
-* Program `6217` is at position `2` with a priority of `200`
+* Link `155072461` is at position `0` with a priority of `50`
+* Link `3736854134` is at position `1` with a priority of `100`
+* Link `454777406` is at position `2` with a priority of `200`
 
 ```console
-sudo bpfman get 6213
+sudo bpfman get link 3736854134
  Bpfman State
 ---------------
- Name:          pass
-:
- Priority:      100
- Iface:         eno3
- Position:      1
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6213
- Name:                             pass
- Type:                             xdp
-:
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            3736854134
+ Interface:          eno3
+ Priority:           100
+ Position:           1
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
 ```console
-sudo bpfman get 6215
+sudo bpfman get link 155072461
  Bpfman State
 ---------------
- Name:          pass
-:
- Priority:      50
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            155072461
+ Interface:          eno3
+ Priority:           50
+ Position:           0
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 
- Kernel State
-----------------------------------
- Program ID:                       6215
- Name:                             pass
- Type:                             xdp
-:
 ```
 
 ```console
-sudo bpfman get 6217
+sudo bpfman get link 454777406
  Bpfman State
 ---------------
- Name:          pass
-:
- Priority:      200
- Iface:         eno3
- Position:      2
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6217
- Name:                             pass
- Type:                             xdp
-:
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            454777406
+ Interface:          eno3
+ Priority:           200
+ Position:           2
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
 By default, the next program in the chain will only be executed if a given program returns
-`pass` (see `proceed-on` field in the `bpfman get` output above).
+`pass` (see `proceed-on` field in the `bpfman get link` output above).
 If the next program in the chain should be called even if a different value is returned,
 then the program can be loaded with those additional return values using the `proceed-on`
-parameter (see `bpfman load image xdp --help` for list of valid values):
+parameter (see `bpfman load attach xdp --help` for list of valid values):
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name pass \
-  xdp --iface eno3 --priority 150 --proceed-on "pass" --proceed-on "dispatcher_return"
+sudo bpfman attach 63336 xdp --iface eno3 --priority 150 \
+   --proceed-on pass --proceed-on dispatcher_return --proceed-on drop
  Bpfman State
 ---------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6219
- Map Owner ID:  None
- Map Used By:   6219
- Priority:      150
- Iface:         eno3
- Position:      2
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6219
- Name:                             pass
- Type:                             xdp
-:
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63336
+ Link ID:            702908334
+ Interface:          eno3
+ Priority:           150
+ Position:           2
+ Proceed On:         pass, dispatcher_return, drop
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
 Which results in being loaded in position `2` because it was loaded at priority `150`,
@@ -291,102 +283,27 @@ which is lower than the previous program at that position with a priority of `20
 
 ## Delete XDP Program
 
-Let's remove the program at position 1.
+Let's detach the program at position 1.
 
 ```console
-sudo bpfman list
- Program ID  Name  Type  Load Time
- 6213        pass  xdp   2023-07-17T17:48:10-0400
- 6215        pass  xdp   2023-07-17T17:52:46-0400
- 6217        pass  xdp   2023-07-17T17:53:57-0400
- 6219        pass  xdp   2023-07-17T17:59:41-0400
+sudo bpfman list links --application XdpPassProgram
+ Program ID  Link ID     Application     Type  Function Name  Attachment 
+ 63336       155072461   XdpPassProgram  xdp   pass           eno3 pos-0
+ 63336       3736854134  XdpPassProgram  xdp   pass           eno3 pos-1
+ 63336       454777406   XdpPassProgram  xdp   pass           eno3 pos-3
+ 63336       702908334   XdpPassProgram  xdp   pass           eno3 pos-2
 ```
 
 ```console
-sudo bpfman unload 6213
+sudo bpfman detach 3736854134
 ```
 
 And we can verify that it has been removed and the other programs re-ordered:
 
 ```console
-sudo bpfman list
- Program ID  Name  Type  Load Time
- 6215        pass  xdp   2023-07-17T17:52:46-0400
- 6217        pass  xdp   2023-07-17T17:53:57-0400
- 6219        pass  xdp   2023-07-17T17:59:41-0400
-```
-
-```console
-bpfman get 6215
- Bpfman State
----------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6215
- Map Owner ID:  None
- Map Used By:   6215
- Priority:      50
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6215
- Name:                             pass
- Type:                             xdp
-:
-```
-
-```
-bpfman get 6217
- Bpfman State
----------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6217
- Map Owner ID:  None
- Map Used By:   6217
- Priority:      200
- Iface:         eno3
- Position:      2
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6217
- Name:                             pass
- Type:                             xdp
-:
-```
-
-```
-bpfman get 6219
- Bpfman State
----------------
- Name:          pass
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
- Pull Policy:   IfNotPresent
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6219
- Map Owner ID:  None
- Map Used By:   6219
- Priority:      150
- Iface:         eno3
- Position:      1
- Proceed On:    pass, dispatcher_return
-
- Kernel State
-----------------------------------
- Program ID:                       6219
- Name:                             pass
- Type:                             xdp
-:
+sudo bpfman list links --application XdpPassProgram
+ Program ID  Link ID    Application     Type  Function Name  Attachment
+ 63336       155072461  XdpPassProgram  xdp   pass           eno3 pos-0
+ 63336       454777406  XdpPassProgram  xdp   pass           eno3 pos-2
+ 63336       702908334  XdpPassProgram  xdp   pass           eno3 pos-1
 ```

--- a/docs/getting-started/building-bpfman.md
+++ b/docs/getting-started/building-bpfman.md
@@ -369,14 +369,14 @@ sudo cp .output/manpage/bpfman*.1 /usr/local/share/man/man1/.
 Once installed, use `man` to view the pages.
 
 ```console
-man bpfman list
+man bpfman attach
 ```
 
 !!! Note
-    `bpfman` commands with subcommands (specifically `bpfman load`) have `-` in the
-    manpage subcommand generation.
+    `bpfman` commands with subcommands (specifically `bpfman load`, `bpfman list` and `bpfman get`)
+    have `-` in the manpage subcommand generation.
     So use `man bpfman load-file`, `man bpfman load-image`, `man bpfman load-image-xdp`,
-    etc. to display the subcommand manpage files.
+    `man bpfman list-programs`, etc. to display the subcommand manpage files.
 
 ## Building bpfman-operator
 

--- a/docs/getting-started/cli-guide.md
+++ b/docs/getting-started/cli-guide.md
@@ -1,7 +1,7 @@
 # CLI Guide
 
-`bpfman` offers several CLI commands to interact with the `bpfman` daemon.
-The CLI allows you to `load`, `unload`, `get` and `list` eBPF programs.
+`bpfman` offers several CLI commands to manage eBPF programs.
+The CLI allows you to `load`, `attach`, `detach`, `unload`, `get` and `list` eBPF programs.
 
 ## Notes For This Guide
 
@@ -12,7 +12,7 @@ development branch and will require `sudo`.
 Example:
 
 ```console
-sudo ./target/debug/bpfman list
+sudo ./target/debug/bpfman list programs
 ```
 
 If run as a systemd service, `bpfman` will most likely be installed in your $PATH,
@@ -20,7 +20,7 @@ and will also require `sudo`.
 Example:
 
 ```console
-sudo bpfman list
+sudo bpfman list programs
 ```
 
 The examples here use `sudo bpfman` in place of `sudo ./target/debug/bpfman` for readability,
@@ -36,6 +36,7 @@ from the `bpfman` repository.
 Below are the commands supported by `bpfman`.
 
 ```console
+sudo bpfman --help
 An eBPF manager focusing on simplifying the deployment and administration of eBPF programs.
 
 Usage: bpfman <COMMAND>
@@ -43,8 +44,10 @@ Usage: bpfman <COMMAND>
 Commands:
   load    Load an eBPF program on the system
   unload  Unload an eBPF program using the Program Id
-  list    List all eBPF programs loaded via bpfman
-  get     Get an eBPF program using the Program Id
+  attach  Attach an eBPF program to a hook point using the Program Id
+  detach  Detach an eBPF program from a hook point using the Link Id
+  list    List all loaded eBPF programs or attached links
+  get     Get a loaded eBPF program or program attachment link
   image   eBPF Bytecode Image related commands
   help    Print this message or the help of the given subcommand(s)
 
@@ -53,39 +56,78 @@ Options:
           Print help (see a summary with '-h')
 ```
 
+The general flow for using the CLI is as follows:
+
+* **Load Program**: The first step is to load the eBPF Program (or Programs) using the
+  `bpfman load` command.
+  The programs can be from a locally built eBPF program (.o file) or an eBPF program
+  packaged in a OCI container image from a given registry.
+  Once the command completes successfully, the eBPF programs are loaded in kernel memory,
+  but have not been attached to any hook points yet.
+* **Attach Program**: The next step is to attach a loaded eBPF Program to a hook point
+  using the `bpfman attach` command.
+  Each program type (kprobe, tc, tracepoint, xdp, etc) has unique hook points and unique
+  configuration data which is provided with the attach command.
+  Once attached, the eBPF Program will be called if it's hook point is triggered.
+* **Display Programs**: At any time, the set of programs loaded and attach can be displayed.
+  To get a list of all the programs, use the `bpfman list programs` command.
+  If a program shows up in the list then the program has been loaded.
+  One of the attributes in the output is  the `Links` parameter.
+  If there is a values in the `Links` parameter, then the program has also been attached.
+  To retrieve all the parameters of a given program, use the `bpfman get program` command, which
+  displays a given program based its `Program ID`, which can be found in the list output.
+  To get a list of all the links, use the `bpfman list links` command.
+  To retrieve all the parameters of a given link, use the `bpfman get link` command, which
+  displays a given link based its `Link ID`, which can be found in the list output.
+* **Detach Program**: Optionally, an eBPF Program can be detached from a hook point if desired
+  using the `bpfman detach` command.
+* **Unload Program**: Once an eBPF Program is no longer needed, the program can be unloaded
+  using the `bpfman unload` command.
+  The program does not need to be detached before being unloaded.
+
 ## bpfman load
 
 The `bpfman load file` and `bpfman load image` commands are used to load eBPF programs.
+If the command is successful, the eBPF programs are loaded in kernel memory, but have
+not been attached to any hook points yet (see [bpfman attach](#bpfman-attach)).
+If the bytecode file contains multiple eBPF programs, they should be loaded in a single
+command by passing multiple <TYPE\>:<NAME\> pairs to the `--programs` parameters.
+They need to be loaded in one command so each those eBPF programs can share any global
+data and maps between the eBPF programs.
+
 The `bpfman load file` command is used to load a locally built eBPF program.
 The `bpfman load image` command is used to load an eBPF program packaged in a OCI container
 image from a given registry.
-Each program type (i.e. `<COMMAND>`) has it's own set of attributes specific to the program type,
-and those attributes MUST come after the program type is entered.
-There are a common set of attributes, and those MUST come before the program type is entered.
 
 ```console
 sudo bpfman load file --help
 Load an eBPF program from a local .o file
 
-Usage: bpfman load file [OPTIONS] --path <PATH> --name <NAME> <COMMAND>
-
-Commands:
-  xdp         Install an eBPF program on the XDP hook point for a given interface
-  tc          Install an eBPF program on the TC hook point for a given interface
-  tracepoint  Install an eBPF program on a Tracepoint
-  kprobe      Install a kprobe or kretprobe eBPF probe
-  uprobe      Install a uprobe or uretprobe eBPF probe
-  fentry      Install a fentry eBPF probe
-  fexit       Install a fexit eBPF probe
-  help        Print this message or the help of the given subcommand(s)
+Usage: bpfman load file [OPTIONS] --programs <PROGRAMS>... --path <PATH>
 
 Options:
+      --programs <PROGRAMS>...
+          Required: The program type and eBPF function name that is the entry point
+          for the eBPF program.
+          Format <TYPE>:<FUNC_NAME>
+
+          For fentry and fexit, the function that is being attached to is also
+          required at load time, so the format for fentry and fexit includes attach
+          function.
+          Format <TYPE>:<FUNC_NAME>:<ATTACH_FUNC>
+
+          If the bytecode file contains multiple eBPF programs that need to be
+          loaded, multiple eBPF programs can be entered by separating each
+          <TYPE>:<FUNC_NAME> pair with a space.
+          Example: --programs xdp:xdp_stats kprobe:kprobe_counter
+          Example: --programs fentry:test_fentry:do_unlinkat
+
+          [possible values for <TYPE>: fentry, fexit, kprobe, tc, tcx, tracepoint,
+                                       uprobe, xdp]
+
   -p, --path <PATH>
           Required: Location of local bytecode file
           Example: --path /run/bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o
-
-  -n, --name <NAME>
-          Required: The name of the function that is the entry point for the BPF program
 
   -g, --global <GLOBAL>...
           Optional: Global variables to be set when program is loaded.
@@ -93,7 +135,15 @@ Options:
 
           This is a very low level primitive. The caller is responsible for formatting
           the byte string appropriately considering such things as size, endianness,
-          alignment and packing of data structures.
+          alignment and packing of data structures. Multiple values can be enter by
+          separating each <NAME>=<Hex Value> pair with a space.
+          Example: -g GLOBAL_u8=01 GLOBAL_u32=0A0B0C0D
+
+  -a, --application <APPLICATION>
+          Optional: Application is used to group multiple programs that are loaded together
+          under the same load command. This actually creates a special <KEY>=<VALUE> in the
+          metadata parameter. It can be used to filer on list commands.
+          Example: --application TestEbpfApp
 
   -m, --metadata <METADATA>
           Optional: Specify Key/Value metadata to be attached to a program when it
@@ -119,19 +169,28 @@ and
 sudo bpfman load image --help
 Load an eBPF program packaged in a OCI container image from a given registry
 
-Usage: bpfman load image [OPTIONS] --image-url <IMAGE_URL> --name <NAME> <COMMAND>
-
-Commands:
-  xdp         Install an eBPF program on the XDP hook point for a given interface
-  tc          Install an eBPF program on the TC hook point for a given interface
-  tracepoint  Install an eBPF program on a Tracepoint
-  kprobe      Install a kprobe or kretprobe eBPF probe
-  uprobe      Install a uprobe or uretprobe eBPF probe
-  fentry      Install a fentry eBPF probe
-  fexit       Install a fexit eBPF probe
-  help        Print this message or the help of the given subcommand(s)
+Usage: bpfman load image [OPTIONS] --programs <PROGRAMS>... --image-url <IMAGE_URL>
 
 Options:
+      --programs <PROGRAMS>...
+          Required: The program type and eBPF function name that is the entry point
+          for the eBPF program.
+          Format <TYPE>:<FUNC_NAME>
+
+          For fentry and fexit, the function that is being attached to is also
+          required at load time, so the format for fentry and fexit includes attach
+          function.
+          Format <TYPE>:<FUNC_NAME>:<ATTACH_FUNC>
+
+          If the bytecode file contains multiple eBPF programs that need to be
+          loaded, multiple eBPF programs can be entered by separating each
+          <TYPE>:<FUNC_NAME> pair with a space.
+          Example: --programs xdp:xdp_stats kprobe:kprobe_counter
+          Example: --programs fentry:test_fentry:do_unlinkat
+
+          [possible values for <TYPE>: fentry, fexit, kprobe, tc, tcx, tracepoint,
+                                       uprobe, xdp]
+
   -i, --image-url <IMAGE_URL>
           Required: Container Image URL.
           Example: --image-url quay.io/bpfman-bytecode/xdp_pass:latest
@@ -149,16 +208,21 @@ Options:
 
           [default: IfNotPresent]
 
-  -n, --name <NAME>
-          Required: The name of the function that is the entry point for the eBPF program.
-
   -g, --global <GLOBAL>...
           Optional: Global variables to be set when program is loaded.
           Format: <NAME>=<Hex Value>
 
           This is a very low level primitive. The caller is responsible for formatting
           the byte string appropriately considering such things as size, endianness,
-          alignment and packing of data structures.
+          alignment and packing of data structures. Multiple values can be enter by
+          separating each <NAME>=<Hex Value> pair with a space.
+          Example: -g GLOBAL_u8=01 GLOBAL_u32=0A0B0C0D
+
+  -a, --application <APPLICATION>
+          Optional: Application is used to group multiple programs that are loaded together
+          under the same load command. This actually creates a special <KEY>=<VALUE> in the
+          metadata parameter. It can be used to filer on list commands.
+          Example: --application TestEbpfApp
 
   -m, --metadata <METADATA>
           Optional: Specify Key/Value metadata to be attached to a program when it
@@ -178,95 +242,23 @@ Options:
           Print help (see a summary with '-h')
 ```
 
-When using either load command, `--path`, `--image-url`, `--registry-auth`, `--pull-policy`, `--name`,
- `--global`, `--metadata` and `--map-owner-id` must be entered before the `<COMMAND>` (`xdp`, `tc`,
- `tracepoint`, etc) is entered.
-Then each `<COMMAND>` has its own custom parameters (same for both `bpfman load file` and
-`bpfman load image`):
+### Example Load Commands
 
-```console
-sudo bpfman load file xdp --help
-Install an eBPF program on the XDP hook point for a given interface
+Below are some different examples for using the `bpfmam load` command.
 
-Usage: bpfman load file --path <PATH> --name <NAME> xdp [OPTIONS] --iface <IFACE> --priority <PRIORITY>
+#### Loading From Local File
 
-Options:
-  -i, --iface <IFACE>
-          Required: Interface to load program on
-
-  -p, --priority <PRIORITY>
-          Required: Priority to run program in chain. Lower value runs first
-
-      --proceed-on <PROCEED_ON>...
-          Optional: Proceed to call other programs in chain on this exit code.
-          Multiple values supported by repeating the parameter.
-          Example: --proceed-on "pass" --proceed-on "drop"
-
-          [possible values: aborted, drop, pass, tx, redirect, dispatcher_return]
-
-          [default: pass, dispatcher_return]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-Example loading from local file (`--path` is the fully qualified path):
+The following is an example of the `tc` command from local file:
 
 ```console
 cd bpfman/
-sudo bpfman load file --path tests/integration-test/bpf/.output/xdp_pass.bpf.o --name "pass" xdp --iface eno3 --priority 100
+sudo bpfman load file -p tests/integration-test/bpf/.output/tc_pass.bpf/bpf_x86_bpfel.o \
+     --programs tc:pass --application TcPassProgram
 ```
 
-Example from image in remote repository:
-
-```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name "pass" xdp --iface eno3 --priority 100
-```
-
-The `tc` command is similar to `xdp`, but it also requires the `direction` option
-and the `proceed-on` values are different.
-
-```console
-sudo bpfman load file tc --help
-Install an eBPF program on the TC hook point for a given interface
-
-Usage: bpfman load file --path <PATH> --name <NAME> tc [OPTIONS] --direction <DIRECTION> --iface <IFACE> --priority <PRIORITY>
-
-Options:
-  -d, --direction <DIRECTION>
-          Required: Direction to apply program.
-
-          [possible values: ingress, egress]
-
-  -i, --iface <IFACE>
-          Required: Interface to load program on
-
-  -p, --priority <PRIORITY>
-          Required: Priority to run program in chain. Lower value runs first
-
-      --proceed-on <PROCEED_ON>...
-          Optional: Proceed to call other programs in chain on this exit code.
-          Multiple values supported by repeating the parameter.
-          Example: --proceed-on "ok" --proceed-on "pipe"
-
-          [possible values: unspec, ok, reclassify, shot, pipe, stolen, queued,
-                            repeat, redirect, trap, dispatcher_return]
-
-          [default: ok, pipe, dispatcher_return]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-The following is an example of the `tc` command using short option names:
-
-```console
-cd bpfman/
-sudo bpfman load file -p tests/integration-test/bpf/.output/tc_pass.bpf.o -n "pass" tc -d ingress -i mynet1 -p 40
-```
-
-For the `tc_pass.bpf.o` program loaded with the command above, the name
-would be set as shown in the following snippet, taken from the function name, not `SEC()`:
+For the `--programs tc:pass` program loaded with the command above, the `<FUNC_NAME>`
+would be set as shown in the following snippet, taken from the function name,
+not `SEC()`:
 
 ```c
 SEC("classifier/pass")
@@ -276,58 +268,86 @@ int pass(struct __sk_buff *skb) {
 }
 ```
 
-### Additional Load Examples
+#### Loading From Remote Repository
 
-Below are some additional examples of `bpfman load` commands:
-
-#### Fentry
+Below is an example loading an eBPF program packaged in a OCI container image
+from a given registry:
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/fentry:latest --name "test_fentry" fentry -f do_unlinkat
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest \
+     --programs xdp:pass --application XdpPassProgram
 ```
 
-#### Fexit
+#### Loading Multiple Programs
+
+An eBPF bytecode image can can contain multiple programs.
+Below is an example of how to load multiple eBPF programs in one load command.
+Commands that are loaded together can share global data and maps.
+Optionally, include an `application` name that can be used to group the load
+programs together when displaying.
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/fexit:latest --name "test_fexit" fexit -f do_unlinkat
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/go-app-counter:latest \
+   --programs kprobe:kprobe_counter tracepoint:tracepoint_kill_recorder tc:stats \
+              tcx:tcx_stats uprobe:uprobe_counter xdp:xdp_stats  --application go-app
 ```
 
-#### Kprobe
+#### Loading fentry/fexit Programs
+
+Below is an example loading an fentry program (fexit is similar).
+The fentry and fexit commands require the attach point at load time, which
+is the name of the function the eBPF will be attached too.
+The function name is included in the `--programs` parameter and uses the
+format: `<TYPE>:<FUNC_NAME>:<ATTACH_FUNC>`
+The fentry and fexit programs still require a `bpfman attach` command to be
+called before they will actually be triggered.
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/kprobe:latest --name "my_kprobe" kprobe -f try_to_wake_up
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/fentry:latest \
+     --programs fentry:test_fentry:do_unlinkat
+
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/fentry:latest \
+     --programs fexit:test_fexit:do_unlinkat
 ```
 
-#### Kretprobe
+#### Loading probe Versus retprobe Programs
 
-```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/kretprobe:latest --name "my_kretprobe" kprobe -f try_to_wake_up -r
+`kprobe` and `kretprobe` (as well as `uprobe` and `uretprobe`) are loaded and attached
+with the same set of attributes.
+From the kernel's perspective, probes and retprobes are both probes.
+What distinguishes a probe from a retprobe is the `SEC(..)` header in the code.
+For example, `kprobe` will look something like:
+
+```C
+SEC("kprobe/my_kprobe")
+int my_kprobe(struct pt_regs *ctx) {
+  bpf_printk(" KP: GLOBAL_u8: 0x%02X, GLOBAL_u32: 0x%08X", GLOBAL_u8,
+             GLOBAL_u32);
+  return 0;
+}
 ```
 
-#### TC
+Whereas `kretprobe` may look something like:
 
-```console
-cd bpfman/
-sudo bpfman load file --path examples/go-tc-counter/bpf_x86_bpfel.o --name "stats" tc --direction ingress --iface eno3 --priority 110
+```c
+SEC("kretprobe/my_kretprobe")
+int my_kretprobe(struct pt_regs *ctx) {
+  bpf_printk("KRP: GLOBAL_u8: 0x%02X, GLOBAL_u32: 0x%08X", GLOBAL_u8,
+             GLOBAL_u32);
+  return 0;
+}
 ```
 
-#### Uprobe
+But loading each type of program is similar:
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/uprobe:latest --name "my_uprobe" uprobe -f "malloc" -t "libc"
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/kprobe:latest \
+   --programs kprobe:my_kprobe
 ```
 
-#### Uretprobe
-
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/uretprobe:latest --name "my_uretprobe" uprobe -f "malloc" -t "libc" -r
-```
-
-#### XDP
-
-```console
-cd bpfman/
-sudo bpfman load file --path bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o --name "xdp_stats" xdp --iface eno3 --priority 35
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/kretprobe:latest \
+   --programs kprobe:my_kretprobe
 ```
 
 ### Setting Global Variables in eBPF Programs
@@ -336,7 +356,8 @@ Global variables can be set for any eBPF program type when loading as follows:
 
 ```console
 cd bpfman/
-sudo bpfman load file -p bpfman/tests/integration-test/bpf/.output/tc_pass.bpf.o -g GLOBAL_u8=01 GLOBAL_u32=0A0B0C0D -n "pass" tc -d ingress -i mynet1 -p 40
+sudo bpfman load file -p tests/integration-test/bpf/.output/tc_pass.bpf/bpf_x86_bpfel.o \
+     --programs tc:pass -g GLOBAL_u8=01 GLOBAL_u32=0A0B0C0D --application TcGlobal
 ```
 
 Note that when setting global variables, the eBPF program being loaded must
@@ -349,6 +370,218 @@ volatile const __u32 GLOBAL_u8 = 0;
 volatile const __u32 GLOBAL_u32 = 0;
 ```
 
+## bpfman attach
+
+The `bpfman attach` command is used to attach an eBPF program to a hook point.
+Each program type (i.e. `<COMMAND>`) has it's own set of attributes specific to the program type,
+and those program specific attributes MUST come after the `Program ID` (from the load command) and
+the program type are entered.
+
+```console
+sudo bpfman attach --help
+Attach an eBPF program to a hook point using the Program Id
+
+Usage: bpfman attach <PROGRAM_ID> <COMMAND>
+
+Commands:
+  xdp         Install an eBPF program on the XDP hook point for a given interface
+  tc          Install an eBPF program on the TC hook point for a given interface
+  tcx         Install an eBPF program on the TCX hook point for a given interface and direction
+  tracepoint  Install an eBPF program on a Tracepoint
+  kprobe      Install a kprobe or kretprobe eBPF probe
+  uprobe      Install a uprobe or uretprobe eBPF probe
+  fentry      Install a fentry eBPF probe
+  fexit       Install a fexit eBPF probe
+  help        Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <PROGRAM_ID>  Required: Program Id to be attached
+
+Options:
+  -h, --help  Print help
+```
+
+Each `<COMMAND>` has its own custom parameters:
+
+```console
+sudo bpfman attach xdp --help
+Install an eBPF program on the XDP hook point for a given interface
+
+Usage: bpfman attach <PROGRAM_ID> xdp [OPTIONS] --iface <IFACE> --priority <PRIORITY>
+
+Options:
+  -i, --iface <IFACE>
+          Required: Interface to load program on
+
+  -p, --priority <PRIORITY>
+          Required: Priority to run program in chain. Lower value runs first.
+          [possible values: 1-1000]
+
+      --proceed-on <PROCEED_ON>...
+          Optional: Proceed to call other programs in chain on this exit code.
+          Multiple values supported by repeating the parameter.
+          Example: --proceed-on pass --proceed-on drop
+
+          [possible values: aborted, drop, pass, tx, redirect, dispatcher_return]
+
+          [default: pass, dispatcher_return]
+
+  -n, --netns <NETNS>
+          Optional: The file path of the target network namespace.
+          Example: -n /var/run/netns/bpfman-test
+
+  -m, --metadata <METADATA>
+          Optional: Specify Key/Value metadata to be attached to a link when it
+          is loaded by bpfman.
+          Format: <KEY>=<VALUE>
+
+          This can later be used to list a certain subset of links which contain
+          the specified metadata.
+          Example: --metadata owner=acme
+
+  -h, --help
+          Print help (see a summary with '-h')```
+
+Example attaching an XDP Program:
+
+```console
+sudo bpfman attach 63674 xdp --iface eno3 --priority 100
+```
+
+The `tc` command is similar to `xdp`, but it also requires the `direction` option
+and the `proceed-on` values are different.
+
+```console
+sudo bpfman attach tc --help
+Install an eBPF program on the TC hook point for a given interface
+
+Usage: bpfman attach <PROGRAM_ID> tc [OPTIONS] --direction <DIRECTION> --iface <IFACE> --priority <PRIORITY>
+
+Options:
+  -d, --direction <DIRECTION>
+          Required: Direction to apply program.
+
+          [possible values: ingress, egress]
+
+  -i, --iface <IFACE>
+          Required: Interface to load program on
+
+  -p, --priority <PRIORITY>
+          Required: Priority to run program in chain. Lower value runs first.
+          [possible values: 1-1000]
+
+      --proceed-on <PROCEED_ON>...
+          Optional: Proceed to call other programs in chain on this exit code.
+          Multiple values supported by repeating the parameter.
+          Example: --proceed-on ok --proceed-on pipe
+
+          [possible values: unspec, ok, reclassify, shot, pipe, stolen, queued,
+                            repeat, redirect, trap, dispatcher_return]
+
+          [default: ok, pipe, dispatcher_return]
+
+  -n, --netns <NETNS>
+          Optional: The file path of the target network namespace.
+          Example: -n /var/run/netns/bpfman-test
+
+  -m, --metadata <METADATA>
+          Optional: Specify Key/Value metadata to be attached to a link when it
+          is loaded by bpfman.
+          Format: <KEY>=<VALUE>
+
+          This can later be used to list a certain subset of links which contain
+          the specified metadata.
+          Example: --metadata owner=acme
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+The following is an example of attaching the `tc` command using short option names:
+
+```console
+sudo bpfman attach 63671 tc -d ingress -i eno3 -p 40
+```
+
+### Additional Attach Examples
+
+Below are some additional examples of `bpfman attach` commands:
+
+#### Fentry
+
+```console
+sudo bpfman attach 63682 fentry
+```
+
+#### Fexit
+
+```console
+sudo bpfman attach 63744 fexit
+```
+
+#### Kprobe
+
+```console
+sudo bpfman attach 63690 kprobe -f try_to_wake_up
+```
+
+#### Kretprobe
+
+```console
+sudo bpfman attach 63698 kprobe -f try_to_wake_up
+```
+
+#### TC
+
+```console
+sudo bpfman attach 63706 tc --direction ingress --iface eno3 --priority 110
+```
+
+#### TCX
+
+```console
+sudo bpfman attach 63672 tcx --direction ingress --iface eno3 --priority 22
+```
+
+#### Tracepoint
+
+```console
+sudo bpfman attach 63670 tracepoint --tracepoint syscalls/sys_enter_openat
+```
+
+#### Uprobe
+
+```console
+sudo bpfman attach 63673 uprobe -t "libc" -f "malloc"
+```
+
+#### Uretprobe
+
+```console
+sudo bpfman attach 63809 uprobe -t "libc" -f "malloc"
+```
+
+#### XDP
+
+```console
+sudo bpfman attach 63674 xdp --iface eno3 --priority 35
+```
+
+### Attach to Multiple Hook Points
+
+Most programs can attach to multiple hook points.
+To attach a program to multiple hook points, simply call `bpfman attach`
+multiple times with the same `Program ID`:
+
+```console
+sudo bpfman attach 63661 xdp --iface eno3 --priority 35
+sudo bpfman attach 63661 xdp --iface eno4 --priority 35
+
+sudo bpfman list programs --application XdpPassProgram
+ Program ID  Application     Type  Function Name  Links
+ 63661       XdpPassProgram  xdp   pass           (2) 1301256968, 18827142
+```
+
 ### Modifying the Proceed-On Behavior
 
 The `proceed-on` setting applies to `xdp` and `tc` programs. For both of these
@@ -359,232 +592,323 @@ program's return value. For example, the default `proceed-on` configuration for
 an `xdp` program can be modified as follows:
 
 ```console
-cd bpfman/
-sudo bpfman load file -p tests/integration-test/bpf/.output/xdp_pass.bpf.o -n "pass" xdp -i mynet1 -p 30 --proceed-on drop pass dispatcher_return
+sudo bpfman attach 63661 xdp -i eno3 -p 30 --proceed-on drop pass dispatcher_return
 ```
 
-### Sharing Maps Between eBPF Programs
+## bpfman detach
 
-!!! Warning
-    Currently for the map sharing feature to work the LIBBPF_PIN_BY_NAME flag **MUST** be set in
-    the shared bpf map definitions.
-    Please see [this aya issue](https://github.com/aya-rs/aya/issues/837) for future work that will
-    change this requirement.
-
-To share maps between eBPF programs, first load the eBPF program that owns the
-maps.
-One eBPF program must own the maps.
+The `bpfman detach` command is used to detach an eBPF program from a hook point.
+When detached, the eBPF program is still loaded in kernel memory, but it is not
+attached to the hook point, so the eBPF program will not be triggered.
+The `bpfman detach` takes the `Link ID`, which can be obtained from the
+`bpfman list programs|links` or `bpfman get program|link` commands.
 
 ```console
-cd bpfman/
-sudo bpfman load file --path examples/go-xdp-counter/bpf_x86_bpfel.o -n "xdp_stats" xdp --iface eno3 --priority 100
-6371
+sudo bpfman detach --help
+Detach an eBPF program from a hook point using the Link Id
+
+Usage: bpfman detach <LINK_ID>
+
+Arguments:
+  <LINK_ID>  Required: Link Id to be detached
+
+Options:
+  -h, --help  Print help
 ```
 
-Next, load additional eBPF programs that will share the existing maps by passing
-the program id of the eBPF program that owns the maps using the `--map-owner-id`
-parameter:
+For example:
 
 ```console
-cd bpfman/
-sudo bpfman load file --path examples/go-xdp-counter/bpf_x86_bpfel.o -n "xdp_stats" --map-owner-id 6371 xdp --iface eno3 --priority 100
-6373
-```
-
-Use the `bpfman get <PROGRAM_ID>` command to display the configuration:
-
-```console
-sudo bpfman list
- Program ID  Name       Type  Load Time
- 6371        xdp_stats  xdp   2023-07-18T16:50:46-0400
- 6373        xdp_stats  xdp   2023-07-18T16:51:06-0400
-```
-
-```console
-sudo bpfman get 6371
- Bpfman State
----------------
- Name:          xdp_stats
- Path:          /home/<$USER>/src/bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6371
- Map Owner ID:  None
- Map Used By:   6371
-                6373
- Priority:      100
- Iface:         eno3
- Position:      1
- Proceed On:    pass, dispatcher_return
-:
+sudo bpfman list programs
+ Program ID  Application     Type        Function Name    Links
+ 63652       TcPassProgram   tc          pass
+ 63661       XdpPassProgram  xdp         pass             (3) 1301256968, 18827142, 3974774760
+ 63669       go-app          kprobe      kprobe_counter
+ 63670       go-app          tracepoint  tracepoint_kill  (1) 1462192047
+ 63671       go-app          tc          stats            (1) 3041462868
+ 63672       go-app          tcx         tcx_stats        (1) 3926782293
+ 63673       go-app          uprobe      uprobe_counter
+ 63674       go-app          xdp         xdp_stats        (2) 241636937, 4229414503
+ 63682                       fentry      test_fentry      (1) 294437142
+ 63690                       kprobe      my_kprobe        (1) 2131925936
+ 63698                       kprobe      my_kretprobe     (1) 1834679786
+ 63706       TcGlobal        tc          pass             (1) 2333059649
+ 63744                       fexit       test_fexit       (1) 2055942218
+ 63809                       uprobe      uretprobe_count  (1) 800266964
 ```
 
 ```console
-sudo bpfman get 6373
- Bpfman State
----------------
- Name:          xdp_stats
- Path:          /home/<$USER>/src/bpfman/examples/go-xdp-counter/bpf_x86_bpfel.o
- Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6371
- Map Owner ID:  6371
- Map Used By:   6371
-                6373
- Priority:      100
- Iface:         eno3
- Position:      0
- Proceed On:    pass, dispatcher_return
-:
-```
-
-As the output shows, the first program (`6371`) owns the map, with `Map Owner ID`
-of `None` and the `Map Pin Path` (`/run/bpfman/fs/maps/6371`) that includes its own ID.
-
-The second program (`6373`) references the first program via the `Map Owner ID` set
-to `6371` and the `Map Pin Path` (`/run/bpfman/fs/maps/6371`) set to same directory as
-the first program, which includes the first program's ID.
-The output for both commands shows the map is being used by both programs via
-the `Map Used By` with values of `6371` and `6373`.
-
-The eBPF programs can be unloaded any order, the `Map Pin Path` will not be deleted
-until all the programs referencing the maps are unloaded:
-
-```console
-sudo bpfman unload 6371
-sudo bpfman unload 6373
+sudo bpfman detach 3974774760
 ```
 
 ## bpfman list
 
-The `bpfman list` command lists all the bpfman loaded eBPF programs:
+The `bpfman list programs` command lists all the bpfman loaded eBPF programs and
+the `bpfman list links` command lists all the bpfman attached eBPF programs.
+
+### bpfman list programs
+
+Use the `bpfman list programs` command lists all the bpfman loaded eBPF programs.
+From the output of the command, if there is a value for the `Links` parameter,
+then the program has been loaded and attached.
+If no value exists, the program has only been loaded (or not managed by bpfman).
 
 ```console
-sudo bpfman list
- Program ID  Name              Type        Load Time
- 6201        pass              xdp         2023-07-17T17:17:53-0400
- 6202        sys_enter_openat  tracepoint  2023-07-17T17:19:09-0400
- 6204        stats             tc          2023-07-17T17:20:14-0400
+sudo bpfman list programs
+ Program ID  Application     Type        Function Name    Links
+ 63652       TcPassProgram   tc          pass
+ 63661       XdpPassProgram  xdp         pass             (2) 1301256968, 18827142
+ 63669       go-app          kprobe      kprobe_counter
+ 63670       go-app          tracepoint  tracepoint_kill  (1) 1462192047
+ 63671       go-app          tc          stats            (1) 3041462868
+ 63672       go-app          tcx         tcx_stats        (1) 3926782293
+ 63673       go-app          uprobe      uprobe_counter
+ 63674       go-app          xdp         xdp_stats        (2) 241636937, 4229414503
+ 63682                       fentry      test_fentry      (1) 294437142
+ 63690                       kprobe      my_kprobe        (1) 2131925936
+ 63698                       kprobe      my_kretprobe     (1) 1834679786
+ 63706       TcGlobal        tc          pass             (1) 2333059649
+ 63744                       fexit       test_fexit       (1) 2055942218
+ 63809                       uprobe      uretprobe_count  (1) 800266964
 ```
 
-To see all eBPF programs loaded on the system, include the `--all` option.
+If the `--application` parameter was used during the `bpfman load` command, that
+can be used to filter the programs displayed in the command.
 
 ```console
-sudo bpfman list --all
- Program ID  Name              Type           Load Time
- 52          restrict_filesy   lsm            2023-05-03T12:53:34-0400
- 166         dump_bpf_map      tracing        2023-05-03T12:53:52-0400
- 167         dump_bpf_prog     tracing        2023-05-03T12:53:52-0400
- 455                           cgroup_device  2023-05-03T12:58:26-0400
+sudo bpfman list programs --application go-app
+ Program ID  Application  Type        Function Name    Links
+ 63669       go-app       kprobe      kprobe_counter
+ 63670       go-app       tracepoint  tracepoint_kill  (1) 1462192047
+ 63671       go-app       tc          stats            (1) 3041462868
+ 63672       go-app       tcx         tcx_stats        (1) 3926782293
+ 63673       go-app       uprobe      uprobe_counter
+ 63674       go-app       xdp         xdp_stats        (2) 241636937, 422941450
+ ```
+
+To see all eBPF programs loaded on the system, not just bpfman loaded programs,
+include the `--all` option.
+
+```console
+sudo bpfman list programs --all
  :
- 6194                          cgroup_device  2023-07-17T17:15:23-0400
- 6201        pass              xdp            2023-07-17T17:17:53-0400
- 6202        sys_enter_openat  tracepoint     2023-07-17T17:19:09-0400
- 6203        dispatcher        tc             2023-07-17T17:20:14-0400
- 6204        stats             tc             2023-07-17T17:20:14-0400
- 6207        xdp               xdp            2023-07-17T17:27:13-0400
- 6210        test_fentry       tracing        2023-07-17T17:28:34-0400
- 6212        test_fexit        tracing        2023-07-17T17:29:02-0400
- 6223        my_uprobe         probe          2023-07-17T17:31:45-0400
- 6225        my_kretprobe      probe          2023-07-17T17:32:27-0400
- 6928        my_kprobe         probe          2023-07-17T17:33:49-0400
-```
+ 63638                       cgroup_device  sd_devices
+ 63639                       cgroup_skb     sd_fw_egress
+ 63640                       cgroup_skb     sd_fw_ingress
+ 63641                       cgroup_device  sd_devices
+ 63642                       cgroup_skb     sd_fw_egress
+ 63643                       cgroup_skb     sd_fw_ingress
+ 63651                       tc             tc_dispatcher
+ 63652       TcPassProgram   tc             pass
+ 63660                       xdp            xdp_dispatcher
+ 63661       XdpPassProgram  xdp            pass             (2) 1301256968, 18827142
+ 63669       go-app          kprobe         kprobe_counter
+ 63670       go-app          tracepoint     tracepoint_kill  (1) 1462192047
+ 63671       go-app          tc             stats            (1) 3041462868
+ 63672       go-app          tcx            tcx_stats        (1) 3926782293
+ 63673       go-app          uprobe         uprobe_counter
+ 63674       go-app          xdp            xdp_stats        (2) 241636937, 4229414503
+ 63682                       fentry         test_fentry      (1) 294437142
+ 63690                       kprobe         my_kprobe        (1) 2131925936
+ 63698                       kprobe         my_kretprobe     (1) 1834679786
+ 63706       TcGlobal        tc             pass             (1) 2333059649
+ 63744                       fexit          test_fexit       (1) 2055942218
+ 63787                       tc             tc_dispatcher
+ 63809                       uprobe         uretprobe_count  (1) 800266964
+ 63847                       xdp            xdp_dispatcher
+ 63884                       xdp            xdp_dispatcher
+ ```
 
 To filter on a given program type, include the `--program-type` parameter:
 
 ```console
-sudo bpfman list --all --program-type tc
- Program ID  Name        Type  Load Time
- 6203        dispatcher  tc    2023-07-17T17:20:14-0400
- 6204        stats       tc    2023-07-17T17:20:14-0400
+sudo bpfman list programs --all --program-type tc
+ Program ID  Application    Type  Function Name  Links
+ 63651                      tc    tc_dispatcher
+ 63652       TcPassProgram  tc    pass
+ 63671       go-app         tc    stats          (1) 3041462868
+ 63672       go-app         tcx   tcx_stats      (1) 3926782293
+ 63706       TcGlobal       tc    pass           (1) 2333059649
+ 63787                      tc    tc_dispatcher
 ```
 
-Note: The list filters by the Kernel Program Type.
-`kprobe`, `kretprobe`, `uprobe` and `uretprobe` all map to the `probe` Kernel Program Type.
-`fentry` and `fexit` both map to the `tracing` Kernel Program Type.
+**Note:** The list filters by the Kernel Program Type.
+
+* **probe**: `kprobe`, `kretprobe`, `uprobe` and `uretprobe` all map to the `probe` Kernel Program Type.
+* **tracing**: `fentry` and `fexit` both map to the `tracing` Kernel Program Type.
+* **tc**: `tc` and `tcx` both map to the `tc` Kernel Program Type.
+
+### bpfman list links
+
+Use the `bpfman list links` command lists all the bpfman attached eBPF programs.
+
+```console
+sudo bpfman list links
+ Program ID  Link ID     Application     Type        Function Name    Attachment
+ 63661       1301256968  XdpPassProgram  xdp         pass             eno4 pos-0
+ 63661       18827142    XdpPassProgram  xdp         pass             eno3 pos-0
+ 63670       1462192047  go-app          tracepoint  tracepoint_kill  syscalls/sys_enter_openat
+ 63671       3041462868  go-app          tc          stats            eno3 ingress pos-0
+ 63672       3926782293  go-app          tcx         tcx_stats        eno3 ingress pos-0
+ 63674       241636937   go-app          xdp         xdp_stats        eno3 pos-2
+ 63674       4229414503  go-app          xdp         xdp_stats        eno3 pos-1
+ 63682       294437142                   fentry      test_fentry      do_unlinkat
+ 63690       2131925936                  kprobe      my_kprobe        try_to_wake_up
+ 63698       1834679786                  kprobe      my_kretprobe     try_to_wake_up
+ 63706       2333059649  TcGlobal        tc          pass             eno3 ingress pos-1
+ 63744       2055942218                  fexit       test_fexit       do_unlinkat
+ 63809       800266964                   uprobe      uretprobe_count  libc malloc
+```
+
+If the `--application` parameter was used during the `bpfman load` command, that
+can be used to filter the programs displayed in the command.
+
+```console
+sudo bpfman list links --application go-app
+ Program ID  Link ID     Application  Type        Function Name    Attachment
+ 63670       1462192047  go-app       tracepoint  tracepoint_kill  syscalls/sys_enter_openat
+ 63671       3041462868  go-app       tc          stats            eno3 ingress pos-0
+ 63672       3926782293  go-app       tcx         tcx_stats        eno3 ingress pos-0
+ 63674       241636937   go-app       xdp         xdp_stats        eno3 pos-2
+ 63674       4229414503  go-app       xdp         xdp_stats        eno3 pos-1
+ ```
+
+To filter on a given program type, include the `--program-type` parameter:
+
+```console
+sudo bpfman list links -p tc
+ Program ID  Link ID     Application  Type  Function Name  Attachment
+ 63671       3041462868  go-app       tc    stats          eno3 ingress pos-0
+ 63672       3926782293  go-app       tcx   tcx_stats      eno3 ingress pos-0
+ 63706       2333059649  TcGlobal     tc    pass           eno3 ingress pos-1
+```
+
+**Note:** The list filters by the Kernel Program Type.
+
+* **probe**: `kprobe`, `kretprobe`, `uprobe` and `uretprobe` all map to the `probe` Kernel Program Type.
+* **tracing**: `fentry` and `fexit` both map to the `tracing` Kernel Program Type.
+* **tc**: `tc` and `tcx` both map to the `tc` Kernel Program Type.
 
 ## bpfman get
 
 To retrieve detailed information for a loaded eBPF program, use the
-`bpfman get <PROGRAM_ID>` command.
+`bpfman get program <PROGRAM_ID>` command.
+To retrieve detailed information for an attached eBPF program, use the
+`bpfman get link <LINK_ID>` command.
+
+### bpfman get program
+
+To retrieve detailed information for a loaded eBPF program, use the
+`bpfman get program <PROGRAM_ID>` command.
 If the eBPF program was loaded via bpfman, then there will be a `Bpfman State`
 section with bpfman related attributes and a `Kernel State` section with
 kernel information.
 If the eBPF program was loaded outside of bpfman, then the `Bpfman State`
 section will be empty and `Kernel State` section will be populated.
 
+bpfman managed eBPF Program:
+
 ```console
-sudo bpfman get 6204
+sudo bpfman get program 63661
  Bpfman State
 ---------------
- Name:          stats
- Image URL:     quay.io/bpfman-bytecode/go-tc-counter:latest
+ BPF Function:  pass
+ Program Type:  xdp
+ Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
  Pull Policy:   IfNotPresent
  Global:        None
- Metadata:      None
- Map Pin Path:  /run/bpfman/fs/maps/6204
+ Metadata:      bpfman_application=XdpPassProgram
+ Map Pin Path:  /run/bpfman/fs/maps/63661
  Map Owner ID:  None
- Map Used By:   6204
- Priority:      100
- Iface:         eno3
- Position:      0
- Direction:     eg
- Proceed On:    pipe, dispatcher_return
-
+ Maps Used By:  63661
+ Links:         1301256968 (eno4 pos-0)
+                18827142 (eno3 pos-0)
  Kernel State
 ----------------------------------
- Program ID:                       6204
- Name:                             stats
- Type:                             tc
- Loaded At:                        2023-07-17T17:20:14-0400
- Tag:                              ead94553702a3742
+ Program ID:                       63661
+ BPF Function:                     pass
+ Kernel Type:                      xdp
+ Loaded At:                        2025-04-01T10:26:22-0400
+ Tag:                              4b9d1b2c140e87ce
  GPL Compatible:                   true
- Map IDs:                          [2705]
- BTF ID:                           2821
- Size Translated (bytes):          176
- JITed:                            true
- Size JITed (bytes):               116
+ Map IDs:                          [21083]
+ BTF ID:                           31353
+ Size Translated (bytes):          96
+ JITted:                           true
+ Size JITted:                      75
  Kernel Allocated Memory (bytes):  4096
- Verified Instruction Count:       24
+ Verified Instruction Count:       9
 ```
 
-```console
-sudo bpfman get 6190
- Bpfman State
----------------
-NONE
+Non-bpfman managed eBPF Program:
 
+```console
+sudo bpfman get program 63643
  Kernel State
 ----------------------------------
-Program ID:                        6190
-Name:                              None
-Type:                              cgroup_skb
-Loaded At:                         2023-07-17T17:15:23-0400
-Tag:                               6deef7357e7b4530
-GPL Compatible:                    true
-Map IDs:                           []
-BTF ID:                            0
-Size Translated (bytes):           64
-JITed:                             true
-Size JITed (bytes):                55
-Kernel Allocated Memory (bytes):   4096
-Verified Instruction Count:        8
+ Program ID:                       63643
+ BPF Function:                     sd_fw_ingress
+ Kernel Type:                      cgroup_skb
+ Loaded At:                        2025-04-01T10:25:02-0400
+ Tag:                              6deef7357e7b4530
+ GPL Compatible:                   true
+ Map IDs:                          []
+ BTF ID:                           0
+ Size Translated (bytes):          64
+ JITted:                           true
+ Size JITted:                      63
+ Kernel Allocated Memory (bytes):  4096
+ Verified Instruction Count:       8
+```
+
+### bpfman get link
+
+To retrieve detailed information for an attached eBPF program, use the
+`bpfman get link <LINK_ID>` command.
+Only bpfman loaded and attached eBPF programs contain link data.
+
+```console
+sudo bpfman get link 18827142
+ Bpfman State
+---------------
+ BPF Function:       pass
+ Program Type:       xdp
+ Program ID:         63661
+ Link ID:            18827142
+ Interface:          eno3
+ Priority:           35
+ Position:           0
+ Proceed On:         pass, dispatcher_return
+ Network Namespace:  None
+ Metadata:           bpfman_application=XdpPassProgram
 ```
 
 ## bpfman unload
 
-The `bpfman unload` command takes the program id from the load or list command as a parameter,
-and unloads the requested eBPF program:
+The `bpfman unload` command takes the `Program ID` from the load or list command as a parameter,
+and unloads the requested eBPF program.
+The eBPF programs do not need to be detached before unloading.
 
 ```console
-sudo bpfman unload 6204
+sudo bpfman unload 63661
 ```
 
 ```console
-sudo bpfman list
- Program ID  Name              Type        Load Time
- 6201        pass              xdp         2023-07-17T17:17:53-0400
- 6202        sys_enter_openat  tracepoint  2023-07-17T17:19:09-0400
+sudo bpfman list programs
+ Program ID  Application    Type        Function Name    Links
+ 63652       TcPassProgram  tc          pass
+ 63669       go-app         kprobe      kprobe_counter
+ 63670       go-app         tracepoint  tracepoint_kill  (1) 1462192047
+ 63671       go-app         tc          stats            (1) 3041462868
+ 63672       go-app         tcx         tcx_stats        (1) 3926782293
+ 63673       go-app         uprobe      uprobe_counter
+ 63674       go-app         xdp         xdp_stats        (2) 241636937, 4229414503
+ 63682                      fentry      test_fentry      (1) 294437142
+ 63690                      kprobe      my_kprobe        (1) 2131925936
+ 63698                      kprobe      my_kretprobe     (1) 1834679786
+ 63706       TcGlobal       tc          pass             (1) 2333059649
+ 63744                      fexit       test_fexit       (1) 2055942218
+ 63809                      uprobe      uretprobe_count  (1) 800266964
 ```
 
 ## bpfman image
@@ -634,37 +958,36 @@ Successfully downloaded bytecode
 Then when loaded, the local image will be used:
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --pull-policy IfNotPresent xdp --iface eno3 --priority 100
- Bpfman State                                           
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest \
+     --programs xdp:pass
+ Bpfman State
  ---------------
- Name:          pass                                  
- Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest 
- Pull Policy:   IfNotPresent                          
- Global:        None                                  
- Metadata:      None                                  
- Map Pin Path:  /run/bpfman/fs/maps/406681              
- Map Owner ID:  None                                  
- Maps Used By:  None                                  
- Priority:      100                                   
- Iface:         eno3
- Position:      2                                     
- Proceed On:    pass, dispatcher_return               
+ BPF Function:  pass
+ Program Type:  xdp
+ Image URL:     quay.io/bpfman-bytecode/xdp_pass:latest
+ Pull Policy:   IfNotPresent
+ Global:        None
+ Metadata:      None
+ Map Pin Path:  /run/bpfman/fs/maps/64047
+ Map Owner ID:  None
+ Maps Used By:  64047
+ Links:         None
 
- Kernel State                                               
+ Kernel State
  ----------------------------------
- Program ID:                       406681                   
- Name:                             pass                     
- Type:                             xdp                      
- Loaded At:                        1917-01-27T01:37:06-0500 
- Tag:                              4b9d1b2c140e87ce         
- GPL Compatible:                   true                     
- Map IDs:                          [736646]                 
- BTF ID:                           555560                   
- Size Translated (bytes):          96                       
- JITted:                           true                     
- Size JITted:                      67                       
- Kernel Allocated Memory (bytes):  4096                     
- Verified Instruction Count:       9                        
+ Program ID:                       64047
+ BPF Function:                     pass
+ Kernel Type:                      xdp
+ Loaded At:                        2025-04-01T12:32:51-0400
+ Tag:                              4b9d1b2c140e87ce
+ GPL Compatible:                   true
+ Map IDs:                          [21259]
+ BTF ID:                           31787
+ Size Translated (bytes):          96
+ JITted:                           true
+ Size JITted:                      75
+ Kernel Allocated Memory (bytes):  4096
+ Verified Instruction Count:       9
 ```
 
 ### bpfman image build
@@ -698,7 +1021,7 @@ at least one bytecode file that can be passed in several ways. Use either:
 * --bytecode: for a single bytecode built for the host architecture.
 
 * --cilium-ebpf-project: for a cilium/ebpf project directory which contains
-    multiple object files for different architectures.
+  multiple object files for different architectures.
 
 * --bc-386-el .. --bc-s390x-eb: to add one or more architecture specific bytecode files.
 
@@ -804,7 +1127,7 @@ bpfman image build -f Containerfile.bytecode.multi.arch -t quay.io/$QUAY_USER/go
 
 !!! Note
     To build images for multiple architectures on a local system, docker (or podman) may need additional configuration
-    settings to allow for caching of non-native images. See 
+    settings to allow for caching of non-native images. See
     [https://docs.docker.com/build/building/multi-platform/](https://docs.docker.com/build/building/multi-platform/)
     for more details.
 
@@ -837,7 +1160,7 @@ at least one bytecode file that can be passed in several ways. Use either:
 * --bytecode: for a single bytecode built for the host architecture.
 
 * --cilium-ebpf-project: for a cilium/ebpf project directory which contains
-    multiple object files for different architectures.
+  multiple object files for different architectures.
 
 * --bc-386-el .. --bc-s390x-eb: to add one or more architecture specific bytecode files.
 

--- a/docs/getting-started/launching-bpfman.md
+++ b/docs/getting-started/launching-bpfman.md
@@ -28,16 +28,25 @@ cd bpfman/
 sudo ./scripts/setup.sh install
 ```
 
-`bpfman` CLI is now in $PATH and can be used to load, view and unload eBPF programs.
+`bpfman` CLI is now in $PATH and can be used to load, attach, view and unload eBPF programs.
 
 ```console
-sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest --name pass xdp --iface eno3 --priority 100
+sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest \
+     --programs xdp:pass --application XdpPassProgram
+```
 
-sudo bpfman list
- Program ID  Name  Type  Load Time                
- 53885       pass  xdp   2024-08-26T17:41:36-0400 
+```console
+sudo bpfman attach 63661 xdp --iface eno3 --priority 35
+```
 
-sudo bpfman unload 53885
+```console
+sudo bpfman list programs --application XdpPassProgram
+ Program ID  Application     Type  Function Name  Links
+ 63661       XdpPassProgram  xdp   pass           (1) 1301256968
+```
+
+```console
+sudo bpfman unload 63661
 ```
 
 `bpfman` CLI is a Rust program that calls the `bpfman` library directly.
@@ -45,10 +54,10 @@ To view logs while running `bpfman` CLI commands, prepend `RUST_LOG=info` to eac
 (see [Logging](../developer-guide/logging.md) for more details):
 
 ```console
-sudo RUST_LOG=info bpfman list
+sudo RUST_LOG=info bpfman list programs
 [INFO  bpfman::utils] Has CAP_BPF: true
 [INFO  bpfman::utils] Has CAP_SYS_ADMIN: true
- Program ID  Name  Type  Load Time 
+ Program ID  Application     Type        Function Name    Links
 ```
 
 The examples (see [Deploying Example eBPF Programs On Local Host](./example-bpf-local.md))

--- a/docs/getting-started/running-release.md
+++ b/docs/getting-started/running-release.md
@@ -7,7 +7,7 @@ releases.
 !!! Note
     Instructions for interacting with bpfman change from release to release, so reference
     release specific documentation. For example:
-    
+
     [https://bpfman.io/v0.5.6/getting-started/running-release/](https://bpfman.io/v0.5.6/getting-started/running-release/)
 
 Jump to the [Setup and Building bpfman](./building-bpfman.md) section
@@ -60,8 +60,8 @@ sudo RUST_LOG=info ./bpfman-rpc --timeout=0
 To use the CLI:
 
 ```console
-sudo ./bpfman list
- Program ID  Name  Type  Load Time
+sudo ./bpfman list programs
+ Program ID  Application    Type        Function Name    Links
 ```
 
 Continue in [Deploying Example eBPF Programs On Local Host](./example-bpf-local.md) if desired.

--- a/docs/getting-started/running-rpm.md
+++ b/docs/getting-started/running-rpm.md
@@ -40,7 +40,7 @@ sudo dnf copr enable @ebpf-sig/bpfman-next
     automatically pull from `bpfman-next`.
     Either repo can be disabled.
     For example, to disable `bpfman-next` run:
-    
+
     ```console
     sudo dnf copr disable @ebpf-sig/bpfman-next
     ```
@@ -87,9 +87,8 @@ $ sudo systemctl status bpfman.service
 TriggeredBy: ● bpfman.socket
 :
 
-$ sudo bpfman list
- Program ID  Name  Type  Load Time
-
+$ sudo bpfman list programs
+ Program ID  Application    Type        Function Name    Links
 ```
 
 ### Uninstall Given RPM
@@ -203,9 +202,8 @@ $ sudo systemctl status bpfman.service
 TriggeredBy: ● bpfman.socket
 :
 
-$ sudo bpfman list
- Program ID  Name  Type  Load Time
-
+$ sudo bpfman list programs
+ Program ID  Application    Type        Function Name    Links
 ```
 
 ### Uninstall Local Build

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -9,7 +9,7 @@ This section provides a list of common issues and solutions when working with `b
 When attempting to load an XDP program and the program fails to load:
 
 ```console
-$ sudo bpfman load image --image-url quay.io/bpfman-bytecode/xdp_pass:latest xdp --iface veth92cd99b --priority 100
+$ sudo bpfman attach 37568 xdp --iface veth92cd99b --priority 100
 Error: status: Aborted, message: "An error occurred. dispatcher attach failed on interface veth92cd99b: `bpf_link_create` failed", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Tue, 28 Nov 2023 13:37:02 GMT", "content-length": "0"} }
 ```
 


### PR DESCRIPTION
Update the CLI portion of the documents to match the changes that were made as part of the load/attach split and adding `program` and `link` to the `bpfman list` and `bpfman get` commands.