### PR TITLE
Added golangci-lint to the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.54.2
+    hooks:
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run
+        types: [go]
+        language: golang
+        pass_filenames: false


### PR DESCRIPTION
### Overview

Solves issue #1489 

This PR adds golangci-lint to our pre-commit hooks configuration, ensuring that Go code is linted locally before being committed.

### Details

- Added golangci-lint hook using the same version (v1.54.2) as our CI workflow
- Configured to run on all Go files in the project
- Set pass_filenames: false to ensure the linter examines the entire codebase

### Testing

To test these changes locally:

1. Install pre-commit: `pip install pre-commit`
2. Install golangci-lint
3. Run `pre-commit install` in your local repository
4. Test with `pre-commit run golangci-lint`