### PR TITLE
feat: Add version information to CLI tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "aya",
  "bpfman",
  "bpfman-api",
+ "buildinfo",
  "chrono",
  "clap",
  "opentelemetry",
@@ -509,6 +510,7 @@ dependencies = [
  "base16ct",
  "base64 0.22.1",
  "bpfman-csi",
+ "buildinfo",
  "caps",
  "chrono",
  "clap",
@@ -555,6 +557,7 @@ dependencies = [
  "base64 0.22.1",
  "bpfman",
  "bpfman-csi",
+ "buildinfo",
  "caps",
  "chrono",
  "clap",
@@ -602,6 +605,7 @@ version = "0.5.6"
 dependencies = [
  "anyhow",
  "aya",
+ "buildinfo",
  "caps",
  "clap",
  "env_logger",
@@ -618,6 +622,13 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "buildinfo"
+version = "0.5.6"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ default-members = [
     "bpfman",
     "bpfman-api",
     "bpfman-ns",
+    "buildinfo",
     "csi",
     # tests/integration-test is omitted from the default-members list since
     # integration tests MUST be run using cargo xtask
@@ -16,6 +17,7 @@ members = [
     "bpfman",
     "bpfman-api",
     "bpfman-ns",
+    "buildinfo",
     "csi",
     "tests/integration-test",
     "xtask",
@@ -43,6 +45,7 @@ base64 = { version = "0.22.0", default-features = false }
 bpfman = { version = "0.5.6", path = "./bpfman" }
 bpfman-api = { version = "0.5.6", path = "./bpfman-api" }
 bpfman-csi = { version = "1.8.0", path = "./csi" }
+buildinfo = { version = "0.5.6", path = "./buildinfo" }
 caps = { version = "0.5.4", default-features = false }
 cargo_metadata = { version = "0.19.2", default-features = false }
 chrono = { version = "0.4.41", default-features = false }

--- a/bpf-metrics-exporter/Cargo.toml
+++ b/bpf-metrics-exporter/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[build-dependencies]
+buildinfo = { workspace = true }
+
 [dependencies]
 anyhow = { workspace = true }
 aya = { workspace = true }

--- a/bpf-metrics-exporter/build.rs
+++ b/bpf-metrics-exporter/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+fn main() {
+    buildinfo::generate_version_info();
+}

--- a/bpf-metrics-exporter/src/main.rs
+++ b/bpf-metrics-exporter/src/main.rs
@@ -36,6 +36,7 @@ fn init_meter_provider(grpc_endpoint: &str) -> SdkMeterProvider {
 }
 
 #[derive(Parser)]
+#[command(version = env!("BPFMAN_BUILD_INFO"))]
 struct Cli {
     #[clap(long, default_value = "http://localhost:4317")]
     otel_grpc: String,

--- a/bpfman-api/Cargo.toml
+++ b/bpfman-api/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[build-dependencies]
+buildinfo = { workspace = true }
+
 [[bin]]
 name = "bpfman-rpc"
 path = "src/bin/rpc/main.rs"

--- a/bpfman-api/build.rs
+++ b/bpfman-api/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+fn main() {
+    buildinfo::generate_version_info();
+}

--- a/bpfman-api/src/bin/rpc/main.rs
+++ b/bpfman-api/src/bin/rpc/main.rs
@@ -32,6 +32,7 @@ const RTDIR_BPFMAN_CSI: &str = "/run/bpfman/csi";
 #[derive(Parser, Debug)]
 #[command(long_about = "A rpc server proxy for the bpfman library")]
 #[command(name = "bpfman-rpc")]
+#[command(version = env!("BPFMAN_BUILD_INFO"))]
 pub(crate) struct Rpc {
     /// Optional: Enable CSI support. Only supported when run in a Kubernetes
     /// environment with bpfman-agent.

--- a/bpfman-ns/Cargo.toml
+++ b/bpfman-ns/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[build-dependencies]
+buildinfo = { workspace = true }
+
 [[bin]]
 name = "bpfman-ns"
 path = "src/main.rs"

--- a/bpfman-ns/build.rs
+++ b/bpfman-ns/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+fn main() {
+    buildinfo::generate_version_info();
+}

--- a/bpfman-ns/src/main.rs
+++ b/bpfman-ns/src/main.rs
@@ -10,7 +10,7 @@ use log::debug;
 use nix::sched::{CloneFlags, setns};
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version = env!("BPFMAN_BUILD_INFO"), about, long_about = None)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/bpfman/Cargo.toml
+++ b/bpfman/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/lib.rs"
 name = "bpfman"
 path = "src/bin/cli/main.rs"
 
+[build-dependencies]
+buildinfo = { workspace = true }
+
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }

--- a/bpfman/build.rs
+++ b/bpfman/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+fn main() {
+    buildinfo::generate_version_info();
+}

--- a/bpfman/src/bin/cli/args.rs
+++ b/bpfman/src/bin/cli/args.rs
@@ -16,7 +16,7 @@ use hex::FromHex;
     long_about = "An eBPF manager focusing on simplifying the deployment and administration of eBPF programs."
 )]
 #[command(name = "bpfman")]
-#[command(disable_version_flag = true)]
+#[command(version = env!("BPFMAN_BUILD_INFO"))]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Commands,

--- a/buildinfo/Cargo.toml
+++ b/buildinfo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+description = "Shared build-time version generation"
+name = "buildinfo"
+publish = false
+
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+chrono = { workspace = true, features = ["now"] }

--- a/buildinfo/src/lib.rs
+++ b/buildinfo/src/lib.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Shared build-time version generation for bpfman binaries.
+//!
+//! This library provides a minimal public API for build.rs scripts
+//! across the bpfman project to generate consistent version
+//! information.
+
+use std::{env, fmt::Write, process::Command};
+
+use chrono::Utc;
+
+/// Generates version information and sets up rerun conditions.
+///
+/// This is the main entry point and only public function of this
+/// crate. It performs two actions:
+///
+/// 1. Sets the BPFMAN_BUILD_INFO environment variable for the build
+/// 2. Configures when Cargo should re-run the build script
+///
+/// The BPFMAN_BUILD_INFO format is: `<project-version> (<git-hash>
+/// <build-timestamp>) <rustc-version>`.
+pub fn generate_version_info() {
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-env-changed=BPFMAN_BUILD_TIMESTAMP");
+    println!("cargo:rustc-env=BPFMAN_BUILD_INFO={}", build_info_string());
+}
+
+/// Returns a human-readable Git version string for embedding in build
+/// metadata.
+///
+/// This function attempts to describe the current Git commit using:
+///
+/// ```sh
+/// git describe --tags --always --dirty
+/// ```
+///
+/// The output has the form:
+/// - `v0.5.6` (exact tag)
+/// - `v0.5.6-129-g77959d44` (129 commits after `v0.5.6`)
+/// - `v0.5.6-129-g77959d44-dirty` (same, with uncommitted changes)
+/// - `g77959d44` (no tag present, fallback to short commit hash)
+///
+/// If `git describe` fails (e.g., the repo has no tags), this
+/// function falls back to `git rev-parse --short=10 HEAD` combined
+/// with a manual check for uncommitted changes via `git status
+/// --porcelain`.
+///
+/// This fallback ensures version information is still available in
+/// untagged repositories.
+///
+/// Both code paths require a functioning Git repository (i.e., access
+/// to `.git`). If the build is performed from a source tarball or
+/// outside Git, this function returns `None`, and no Git version
+/// information is embedded.
+///
+/// Returns:
+/// - `Some(version_string)` if Git metadata is available
+/// - `None` if Git is not available or the repository is missing
+fn get_git_version() -> Option<String> {
+    // Try `git describe` first.
+    let describe = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            String::from_utf8(output.stdout)
+                .ok()
+                .map(|s| s.trim().to_string())
+        });
+
+    if describe.is_some() {
+        return describe;
+    }
+
+    // Fallback: short hash + dirty suffix.
+    let commit_hash = Command::new("git")
+        .args(["rev-parse", "--short=10", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            String::from_utf8(output.stdout)
+                .ok()
+                .map(|s| s.trim().to_string())
+        });
+
+    let is_dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|out| !out.stdout.is_empty())
+        .unwrap_or(false);
+
+    let dirty_suffix = if is_dirty { "-dirty" } else { "" };
+    commit_hash.map(|hash| format!("{hash}{dirty_suffix}"))
+}
+
+/// Gets the build timestamp from env or uses now.
+fn get_build_timestamp() -> String {
+    env::var("BPFMAN_BUILD_TIMESTAMP")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
+/// Gets the Rust toolchain version.
+fn get_rustc_version() -> Option<String> {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
+/// Gets the Git repository origin URL. Returns `None` if Git is
+/// unavailable or not a repo.
+fn get_git_origin() -> Option<String> {
+    use std::process::Command;
+    Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
+/// Computes the authoritative build info string.
+fn build_info_string() -> String {
+    let build_date = get_build_timestamp();
+    let git_version = get_git_version();
+    let git_origin = get_git_origin();
+    let rustc_version = get_rustc_version();
+    let version = env!("CARGO_PKG_VERSION");
+
+    let mut out = String::with_capacity(120);
+
+    write!(&mut out, "{version} (").unwrap();
+
+    if let Some(git) = git_version {
+        write!(&mut out, "{git} ").unwrap();
+    }
+
+    if let Some(origin) = git_origin {
+        write!(&mut out, "{origin} ").unwrap();
+    }
+
+    write!(&mut out, "{build_date})").unwrap();
+
+    if let Some(rustc) = rustc_version {
+        write!(&mut out, " {rustc}").unwrap();
+    }
+
+    out
+}


### PR DESCRIPTION
Fixes https://github.com/bpfman/bpfman/issues/1398.

This PR introduces standardised version information to all of bpfman’s CLI binaries (except bpf-log-exporter, which has no prior argument parsing), making the --version and -V flags available for all top-level commands. 

All CLI tools now embed standardised version metadata using a shared buildinfo crate and a single API (generate_version_info()) called from each binary’s build script. The version string includes the package version (from Cargo.toml), the Git commit hash (with a dirty-state indicator if the working tree is not clean), the build timestamp (overridable via environment variable for CI), the Rust compiler version, and the Git repository origin URL (from the origin remote). 

The version strings provide valuable context for debugging, support, and reproducibility.

### Examples

```sh
% cargo run -q -p bpfman -- -V
bpfman 0.5.6 (v0.5.6-127-gfa17c153 https://github.com/frobware/bpfman 2025-05-21T11:34:11Z) rustc 1.87.0 (17067e9ac 2025-05-09)
```

#### Changing the Rust toolchain is reflected in the version string:
```
rustup default nightly
cargo run -q -p bpfman -- --version
bpfman 0.5.6 (1611bec506-dirty https://github.com/frobware/bpfman 2025-05-16T14:52:21Z) rustc 1.88.0-nightly (b45dd71d1 2025-04-30)
```

#### Set a custom build timestamp (e.g., in CI):
```
% cargo run -q -p bpfman -- -V
bpfman 0.5.6 (v0.5.6-127-gfa17c153 https://github.com/frobware/bpfman 2025-05-21T11:34:11Z) rustc 1.87.0 (17067e9ac 2025-05-09)
% BPFMAN_BUILD_TIMESTAMP="now" cargo run -q -p bpfman -- --version

bpfman 0.5.6 (v0.5.6-127-gfa17c153 https://github.com/frobware/bpfman now) rustc 1.87.0 (17067e9ac 2025-05-09)
```

### Summary

- Each binary’s build info reflects the state at the last time its build.rs was triggered. Timestamps across binaries will vary unless you set a common env var (e.g., in CI).
- Modifying a build.rs, Cargo.toml, or any source file for a binary triggers an update to that binary’s embedded version string (timestamp, git commit, dirty status).
- If you build, then commit, then build again (with no other changes), Cargo won’t rebuild, so the version info (including git commit count) remains as it was for the last actual build—this is expected and correct due to incremental build caching.
- To guarantee version info reflects the latest commit, ensure something triggers a rebuild (e.g., run `cargo clean` before building).