### PR TITLE
docs: Add note on Security Profiles Operator

### DIFF
--- a/docs/developer-guide/develop-operator.md
+++ b/docs/developer-guide/develop-operator.md
@@ -396,6 +396,12 @@ The cluster needs to be up and running and specified in ~/.kube/config file.
 * **Manually with OLM Bundle:** The other option for installing the bpfman-operator is to install
   it using [OLM bundle](https://www.redhat.com/en/blog/deploying-operators-olm-bundles).
 
+!!! warning
+
+Regardless of which installation method you choose you must also install the Security Profiles
+Operator. This is required to be able to run the userspace side of your eBPF applications with
+reduced privileges since it requires a custom SELinux profile.
+
 ### OperatorHub
 
 When installing the latest release of bpfman/bpfman-operator, bpfman can be installed in a


### PR DESCRIPTION
This adds a note to the documentation that explains that SPO is required to be installed manually when installing via OLM on OpenShift.

<!--
    Thank you for your contribution to Bpfman! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

-->

# Pre-check

Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read the Bpfman Contributing Guide: https://github.com/bpfman/bpfman/blob/main/CONTRIBUTING.md
- 📖 Read the Bpfman Code of Conduct: https://github.com/bpfman/bpfman/blob/main/CODE_OF_CONDUCT.md
- ✅ Add tests according to our Test Policy: https://github.com/bpfman/bpfman/blob/main/CONTRIBUTING.md#test-policy
- 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
- 📗 Update any related documentation.


# Summary
<!---
      Summarize the changes you're making here.
      Detailed information belongs in the Git Commit messages.
      Feel free to flag anything you thing needs a reviewer's attention.
-->

# Related Issues
<!--
For example:

- Closes: #1234
- Relates To: #1234
-->

# Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

# Checklist

- [x] 📎 All clippy lints have been fixed:
```sh
cd bpfman/
cargo +nightly clippy --all -- --deny warnings
```
- [x] 🦀 Rust code has been formatted and linted:
```sh
cargo +nightly fmt --all -- --check
```
- [x] 📝 Yaml files have been formatted (see [Install Yaml Formatter](https://bpfman.io/main/getting-started/building-bpfman/#install-yaml-formatter)):
```sh
prettier -l "*.yaml"
```
- [x] 🐚 Bash scripts have been linted using `shellcheck`:
```sh
cargo xtask lint
```
- [x] ✅ Unit tests are passing locally (see [Unit Testing](https://bpfman.io/main/developer-guide/testing/#unit-testing)):
```sh
cargo xtask unit-test
```
- [x] ✅ Integration tests are passing locally (see [Basic Integration Tests](https://bpfman.io/main/developer-guide/testing/#basic-integration-tests)):
```sh
cargo xtask integration-test
```

# (Optional) What emojis best describe this PR or how it makes you feel?
