### PR TITLE
Fix go-xdp-counter-sharing-map example deployment error

### DIFF
--- a/examples/config/base/go-xdp-counter-sharing-map/bytecode.yaml
+++ b/examples/config/base/go-xdp-counter-sharing-map/bytecode.yaml
@@ -16,8 +16,8 @@ spec:
       bpfman.io/ownedByProgram: go-xdp-counter-example
   programs:
     - name: xdp_stats
-      type: xdp
-      xdpInfo:
+      type: XDP
+      xdp:
         links:
           - interfaceSelector:
               primaryNodeInterface: true


### PR DESCRIPTION
When running `make -C examples deploy`, the go-xdp-counter-sharing-map example was failing with an error due to incorrect field names in the ClusterBpfApplication resource definition.

The issue was that the program type was specified as "xdp" (lowercase) instead of "XDP" (uppercase), and the XDP configuration was incorrectly nested under "xdpInfo" instead of "xdp".

This change fixes the field names to match the expected ClusterBpfApplication schema, allowing the example to deploy successfully alongside the other examples.
