### PR TITLE
Fix clippy this pattern reimplements `Option::unwrap_or`

### DIFF
--- a/bpfman/src/oci_utils/image_manager.rs
+++ b/bpfman/src/oci_utils/image_manager.rs
@@ -319,21 +319,19 @@ fn serde_label(labels: &Value, label_type: String) -> Result<HashMap<String, Str
 }
 
 fn get_image_content_key(image: &Reference) -> String {
-    // Try to get the tag, if it doesn't exist, get the digest
-    // if neither exist, return "latest" as the tag
-    let tag = match image.tag() {
+    // Generate a unique key for storing image content by preferring
+    // tag over digest, falling back to "latest" if neither are
+    // present.
+    let identifier = match image.tag() {
         Some(t) => t,
-        _ => match image.digest() {
-            Some(d) => d,
-            _ => "latest",
-        },
+        _ => image.digest().unwrap_or("latest"),
     };
 
     format!(
         "{}_{}_{}",
         image.registry(),
         image.repository().replace('/', "_"),
-        tag
+        identifier
     )
 }
 


### PR DESCRIPTION
Make clippy happy. Found while working on https://github.com/bpfman/bpfman/pull/1577

Fixes:
```
]# cargo +nightly clippy --all -- --deny warnings --allow clippy::uninlined-format-args
   Compiling bpfman v0.5.6 (/home/akaris/development/bpfman/bpfman)
error: this pattern reimplements `Option::unwrap_or`
   --> bpfman/src/oci_utils/image_manager.rs:326:14
    |
326 |           _ => match image.digest() {
    |  ______________^
327 | |             Some(d) => d,
328 | |             _ => "latest",
329 | |         },
    | |_________^ help: replace with: `image.digest().unwrap_or("latest")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or
    = note: `-D clippy::manual-unwrap-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_unwrap_or)]`

error: could not compile `bpfman` (lib) due to 1 previous error
```

It's ignored by CI but when I run the tests locally, I hit -^

<!--
    Thank you for your contribution to Bpfman! 🎉

    For Work In Progress Pull Requests, please use the Draft PR feature.

-->

# Pre-check

Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read the Bpfman Contributing Guide: https://github.com/bpfman/bpfman/blob/main/CONTRIBUTING.md
- 📖 Read the Bpfman Code of Conduct: https://github.com/bpfman/bpfman/blob/main/CODE_OF_CONDUCT.md
- ✅ Add tests according to our Test Policy: https://github.com/bpfman/bpfman/blob/main/CONTRIBUTING.md#test-policy
- 📝 Use descriptive commit messages: https://cbea.ms/git-commit/
- 📗 Update any related documentation.


# Summary
<!---
      Summarize the changes you're making here.
      Detailed information belongs in the Git Commit messages.
      Feel free to flag anything you thing needs a reviewer's attention.
-->

# Related Issues
<!--
For example:

- Closes: #1234
- Relates To: #1234
-->

# Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

# Checklist

- [ ] 📎 All clippy lints have been fixed:
```sh
cd bpfman/
cargo +nightly clippy --all -- --deny warnings
```
- [ ] 🦀 Rust code has been formatted and linted:
```sh
cargo +nightly fmt --all -- --check
```
- [ ] 📝 Yaml files have been formatted (see [Install Yaml Formatter](https://bpfman.io/main/getting-started/building-bpfman/#install-yaml-formatter)):
```sh
prettier -l "*.yaml"
```
- [ ] 🐚 Bash scripts have been linted using `shellcheck`:
```sh
cargo xtask lint
```
- [x] ✅ Unit tests are passing locally (see [Unit Testing](https://bpfman.io/main/developer-guide/testing/#unit-testing)):
```sh
cargo xtask unit-test
```
- [ ] ✅ Integration tests are passing locally (see [Basic Integration Tests](https://bpfman.io/main/developer-guide/testing/#basic-integration-tests)):
```sh
cargo xtask integration-test
```

# (Optional) What emojis best describe this PR or how it makes you feel?
