### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here are some links to help in your bpfman journey (all links are from the bpfma
   on setting up your development environment and building bpfman.
 - [Example eBPF Programs](https://bpfman.io/main/getting-started/example-bpf/) for some
   examples of eBPF programs written in Go, interacting with `bpfman`.
-- [Deploying the bpfman-operator](https://bpfman.io/main/getting-started/develop-operator/) for details on launching
+- [Deploying the bpfman-operator](https://bpfman.io/main/getting-started/operator-quick-start/) for details on launching
   bpfman in a Kubernetes cluster.
 - [Meet the Community](https://bpfman.io/main/governance/meetings/) for details on community meeting details.
 


### PR DESCRIPTION
# Summary

Fix the bpfman-operator link to point to the correct `operator-quick-start` page instead of `develop-operator`.

# Related Issues

N/A

# Added/updated tests?

_We strongly encourage you to add a test for your changes._

- [ ] Yes
- [x] No, and this is why: link updates in the doc
- [ ] I need help with writing tests

