### PR TITLE
Deploy mike version aliases as HTML redirects

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Deploy Docs (Release Version)
         if: startsWith(github.ref_name, 'v')
         run: |
-          uv run mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          uv run mike deploy --push --update-aliases --alias-type=redirect ${{ github.ref_name }} latest
 
       - name: Deploy Docs (Development Version)
         if: github.ref_name == 'main'


### PR DESCRIPTION
## Summary

- `mike` 2.x materialises version aliases as symbolic links on the `gh-pages` branch by default.
- GitHub Pages does not follow those symlinks, so `/latest/` returns 404 once a release has been deployed under `mike` 2.x — the root redirect to `/latest/` then dead-ends.
- Pass `--alias-type=redirect` to the release `mike deploy` invocation so each aliased page is committed as a small HTML meta-refresh stub. These are ordinary static files that GitHub Pages serves without special handling, restoring `/latest/` and every deep link beneath it.

## Context

This regression dates to the `v0.6.0` release — the first `v*` tag deployed under `mike` 2.x. Earlier `v0.5.x` releases were deployed under `mike` 1.x, whose default alias type was HTML redirects (the same form this change restores); `mike` 2.x changed the default to symbolic links, which GitHub Pages does not follow.

Relates to #1655. PR #1656 works around the broken `/latest/` redirect by repointing README links at `/main/` (development-branch docs) and wrapping the root URL in backticks so it no longer auto-links. That hides the symptom but leaves the site broken for every other consumer of those URLs, and sends new users to unstable docs. This change targets the underlying deployment defect so `https://bpfman.io/` and `/latest/` work as intended.

## Effect

The workflow change takes effect on the next `v*` tag deploy. The existing `gh-pages` branch has been rewritten separately (commit bpfman/bpfman@032723b1) to replace the broken `v0.6.0`/`latest` symlink alias with redirect stubs, so the live site already resolves `/latest/` correctly.

<details>
<summary>How the live-site repair was done</summary>

The workflow change only affects future deploys. The live site was repaired separately by rewriting the existing `v0.6.0`/`latest` symlink alias on `gh-pages` to HTML redirects, without re-rendering any docs:

    # 1. Create a working branch off the live gh-pages tip.
    git fetch upstream gh-pages
    git branch fix-latest-alias upstream/gh-pages

    # 2. Drop the symlink alias and re-add it as HTML redirects.
    # Run from a worktree with a valid mkdocs.yml and the mike uv env
    # (e.g. a checkout of main). mike alias refuses to overwrite an
    # existing alias, so the delete+add is deliberate.
    uv run mike delete   --branch fix-latest-alias latest
    uv run mike alias    --branch fix-latest-alias --alias-type=redirect v0.6.0 latest

    # 3. Verify locally by serving the branch tree with python's HTTP server.
    git worktree add --detach /tmp/verify fix-latest-alias
    (cd /tmp/verify && python3 -m http.server 8766 &)
    curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8766/latest/
    curl -sS http://127.0.0.1:8766/latest/ | grep -i refresh
    curl -sS -o /dev/null -w "%{http_code}\n" \
         http://127.0.0.1:8766/latest/getting-started/operator-quick-start/
    pkill -f 'http.server 8766'
    git worktree remove /tmp/verify

    # 4. Squash the two mike commits into one signed commit.
    tree=$(git rev-parse fix-latest-alias^{tree})
    parent=$(git rev-parse upstream/gh-pages)
    commit=$(git commit-tree -S "$tree" -p "$parent" \
      -m "Rewrite latest alias as HTML redirects" \
      -m "<body paragraph>")
    git update-ref refs/heads/fix-latest-alias "$commit"

    # 5. Fast-forward push to bpfman/bpfman:gh-pages (maintainer-only).
    git push upstream fix-latest-alias:gh-pages
</details>

## Test plan

- [x] `https://bpfman.io/latest/` resolves to v0.6.0 content.
- [x] `https://bpfman.io/latest/getting-started/operator-quick-start/` resolves via redirect.
- [ ] After the next `v*` tag deploy, confirm `gh-pages` contains an HTML redirect tree under `latest/` rather than a symlink blob.