### PR TITLE
docs(index): fix 'Formerly know' -> 'Formerly known' typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ![bpfman logo](./img/horizontal/color/bpfman-horizontal-color.png) <!-- markdownlint-disable-line first-line-heading -->
 
-_Formerly know as `bpfd`_
+_Formerly known as `bpfd`_
 
 # bpfman: An eBPF Manager
 


### PR DESCRIPTION
## Summary
Single-word typo fix in `docs/index.md` line 3, addressing #1663 (filed by @nandedamana today).

```diff
- _Formerly know as `bpfd`_
+ _Formerly known as `bpfd`_
```

## Verification
- `grep -n "Formerly know" docs/index.md` → no matches after the change.

Commit is signed off (DCO).

Closes #1663

## Note
Co-developed with AI assistance; reviewed and tested by submitter.