### PR TITLE
docs: fix know -> known in index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ![bpfman logo](./img/horizontal/color/bpfman-horizontal-color.png) <!-- markdownlint-disable-line first-line-heading -->
 
-_Formerly know as `bpfd`_
+_Formerly known as `bpfd`_
 
 # bpfman: An eBPF Manager
 


### PR DESCRIPTION
# Pre-check

- [x] Read the Bpfman Contributing Guide.
- [x] Read the Bpfman Code of Conduct.
- [ ] Add tests according to the Test Policy. (Docs-only one-character fix; no test surface applies.)
- [x] Descriptive commit message.
- [x] Updated related documentation (this PR is the doc fix).

## Summary

Closes #1663. `docs/index.md:3` rendered the project's history note as `_Formerly know as bpfd_` - missing the trailing `n` on `known`. Add it.

## Why this matters

It's the third line of the docs landing page, the first place readers see the project's old name. One-character correction restores the intended English.

# Related Issues

- Closes: #1663

# Added/updated tests?

- [x] No, and this is why: docs-only one-character typo fix - no behavior surface to test.

# Checklist

- [x] All clippy lints have been fixed: not applicable (no Rust code touched).
- [x] Rust code formatted/linted: not applicable.
- [x] Commit is DCO-signed (`git commit -s`).

# (Optional) What emojis best describe this PR or how it makes you feel?

📝

Fixes #1663

AI-assisted.
