### PR TITLE
Add hidden dispatcher list and get commands to the CLI

### DIFF
--- a/bpfman/src/bin/cli/args.rs
+++ b/bpfman/src/bin/cli/args.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use bpfman::types::BpfProgType;
-use clap::{ArgGroup, Args, Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use hex::FromHex;
 
 #[derive(Parser, Debug)]
@@ -39,6 +39,10 @@ pub(crate) enum Commands {
     /// Get a loaded eBPF program or program attachment link.
     #[command(subcommand)]
     Get(GetSubcommand),
+    /// Inspect XDP/TC dispatcher state (debug).
+    #[command(subcommand)]
+    #[clap(hide = true)]
+    Dispatcher(DispatcherSubcommand),
     /// eBPF Bytecode Image related commands.
     #[command(subcommand)]
     Image(Box<ImageSubCommand>),
@@ -535,6 +539,47 @@ pub(crate) struct GetProgramArgs {
 pub(crate) struct GetLinkArgs {
     /// Required: Link Id to get.
     pub(crate) link_id: u32,
+}
+
+/// Output format for the dispatcher debug commands.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Subcommand, Debug)]
+#[command(disable_version_flag = true)]
+pub(crate) enum DispatcherSubcommand {
+    /// List all dispatchers.
+    List(DispatcherListArgs),
+    /// Get a single dispatcher by type, nsid and ifindex.
+    Get(DispatcherGetArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
+pub(crate) struct DispatcherListArgs {
+    /// Optional: Output format.
+    #[clap(short, long, value_enum, default_value = "text")]
+    pub(crate) output: OutputFormat,
+}
+
+#[derive(Args, Debug)]
+#[command(disable_version_flag = true)]
+pub(crate) struct DispatcherGetArgs {
+    /// Required: Dispatcher type (xdp, tc-ingress, tc-egress).
+    pub(crate) dispatcher_type: String,
+
+    /// Required: Network namespace id.
+    pub(crate) nsid: u64,
+
+    /// Required: Interface index.
+    pub(crate) ifindex: u32,
+
+    /// Optional: Output format.
+    #[clap(short, long, value_enum, default_value = "text")]
+    pub(crate) output: OutputFormat,
 }
 
 #[derive(Subcommand, Debug)]

--- a/bpfman/src/bin/cli/dispatcher.rs
+++ b/bpfman/src/bin/cli/dispatcher.rs
@@ -27,7 +27,11 @@ fn execute_dispatcher_list(args: &DispatcherListArgs) -> anyhow::Result<()> {
         list_dispatcher_snapshots(&root_db).map_err(|e| anyhow!("dispatcher list error: {e}"))?;
 
     match args.output {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&summaries)?),
+        // Wrap in a "dispatchers" object to match the Go CLI's list JSON.
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({ "dispatchers": summaries }))?
+        ),
         OutputFormat::Text => print_summary_table(&summaries),
     }
     Ok(())

--- a/bpfman/src/bin/cli/dispatcher.rs
+++ b/bpfman/src/bin/cli/dispatcher.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+use anyhow::anyhow;
+use bpfman::{
+    dispatcher_view::{
+        DispatcherSnapshot, DispatcherSummary, get_dispatcher_snapshot, list_dispatcher_snapshots,
+    },
+    setup,
+};
+use comfy_table::{Cell, Table, presets::NOTHING};
+
+use crate::args::{DispatcherGetArgs, DispatcherListArgs, DispatcherSubcommand, OutputFormat};
+
+impl DispatcherSubcommand {
+    pub(crate) fn execute(&self) -> anyhow::Result<()> {
+        match self {
+            DispatcherSubcommand::List(args) => execute_dispatcher_list(args),
+            DispatcherSubcommand::Get(args) => execute_dispatcher_get(args),
+        }
+    }
+}
+
+fn execute_dispatcher_list(args: &DispatcherListArgs) -> anyhow::Result<()> {
+    let (_, root_db) = setup()?;
+    let summaries =
+        list_dispatcher_snapshots(&root_db).map_err(|e| anyhow!("dispatcher list error: {e}"))?;
+
+    match args.output {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&summaries)?),
+        OutputFormat::Text => print_summary_table(&summaries),
+    }
+    Ok(())
+}
+
+fn execute_dispatcher_get(args: &DispatcherGetArgs) -> anyhow::Result<()> {
+    let (_, root_db) = setup()?;
+    let snapshot =
+        get_dispatcher_snapshot(&root_db, &args.dispatcher_type, args.nsid, args.ifindex)
+            .map_err(|e| anyhow!("dispatcher get error: {e}"))?;
+
+    let snapshot = match snapshot {
+        Some(s) => s,
+        None => {
+            return Err(anyhow!(
+                "dispatcher ({}, {}, {}) not found",
+                args.dispatcher_type,
+                args.nsid,
+                args.ifindex
+            ));
+        }
+    };
+
+    match args.output {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&snapshot)?),
+        OutputFormat::Text => print_snapshot_table(&snapshot),
+    }
+    Ok(())
+}
+
+fn print_summary_table(summaries: &[DispatcherSummary]) {
+    let mut table = Table::new();
+    table.load_preset(NOTHING);
+    table.set_header(vec![
+        "TYPE", "NSID", "IFINDEX", "REVISION", "PRIORITY", "HANDLE", "MEMBERS", "NETNS",
+    ]);
+
+    for s in summaries {
+        table.add_row(vec![
+            Cell::new(&s.key.dispatcher_type),
+            Cell::new(s.key.nsid),
+            Cell::new(s.key.ifindex),
+            Cell::new(s.revision),
+            Cell::new(opt_display(s.runtime.filter_priority)),
+            Cell::new(
+                s.runtime
+                    .filter_handle
+                    .map(|h| format!("{h:#x}"))
+                    .unwrap_or_else(|| "-".to_string()),
+            ),
+            Cell::new(s.member_count),
+            Cell::new(if s.runtime.netns_path.is_empty() {
+                "-"
+            } else {
+                &s.runtime.netns_path
+            }),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn print_snapshot_table(snapshot: &DispatcherSnapshot) {
+    println!(
+        "Dispatcher: {} nsid={} ifindex={}",
+        snapshot.key.dispatcher_type, snapshot.key.nsid, snapshot.key.ifindex
+    );
+    println!("  Revision:       {}", snapshot.revision);
+    println!(
+        "  Program ID:     {}",
+        opt_display(snapshot.runtime.program_id)
+    );
+    println!(
+        "  Kernel Link ID: {}",
+        opt_display(snapshot.runtime.kernel_link_id)
+    );
+
+    println!("\nMembers ({}):", snapshot.members.len());
+    if snapshot.members.is_empty() {
+        println!("  (none)");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.load_preset(NOTHING);
+    table.set_header(vec![
+        "POS",
+        "PRIORITY",
+        "PROGRAM ID",
+        "FUNCTION NAME",
+        "LINK ID",
+        "KERNEL LINK ID",
+        "PROCEED ON",
+    ]);
+
+    for m in &snapshot.members {
+        table.add_row(vec![
+            Cell::new(opt_display(m.position)),
+            Cell::new(m.priority),
+            Cell::new(m.program_id),
+            Cell::new(&m.program_name),
+            Cell::new(m.link_id),
+            Cell::new(opt_display(m.kernel_link_id)),
+            Cell::new(m.proceed_on),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn opt_display<T: std::fmt::Display>(v: Option<T>) -> String {
+    match v {
+        Some(v) => v.to_string(),
+        None => "-".to_string(),
+    }
+}

--- a/bpfman/src/bin/cli/main.rs
+++ b/bpfman/src/bin/cli/main.rs
@@ -12,6 +12,7 @@ mod args;
 mod attach;
 mod completions;
 mod detach;
+mod dispatcher;
 mod get;
 mod image;
 mod list;
@@ -38,6 +39,7 @@ impl Commands {
             Commands::Detach(args) => execute_detach(args),
             Commands::List(l) => l.execute(),
             Commands::Get(g) => g.execute(),
+            Commands::Dispatcher(d) => d.execute(),
             Commands::Image(i) => i.execute(),
             Commands::Man(args) => manpage::generate(args),
             Commands::Completions(args) => completions::generate(args),

--- a/bpfman/src/dispatcher_view.rs
+++ b/bpfman/src/dispatcher_view.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of bpfman
+
+//! Read-only dispatcher snapshots for the `bpfman dispatcher list|get`
+//! CLI, assembled from the sled store.
+//!
+//! The types are serde-serialisable so the output can be diffed against
+//! the Go implementation of bpfman. Field names mirror the Go JSON
+//! shape (`key`, `revision`, `runtime`, `members`, ...).
+//!
+//! Some fields Go reports are kernel-assigned identifiers that this
+//! implementation does not persist -- they live only on the loaded BPF
+//! objects, not in the store. Those are the dispatcher's own program id
+//! and link id, and each member's kernel link id. They are reported as
+//! null rather than loaded from the pins; the kernel hands them out at
+//! load time, so they differ between runs and carry no parity meaning.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use sled::Db;
+
+use crate::{
+    errors::BpfmanError,
+    get_dispatcher, get_multi_attach_links,
+    multiprog::{
+        Dispatcher, DispatcherId, DispatcherInfo, TC_DISPATCHER_PREFIX, XDP_DISPATCHER_PREFIX,
+    },
+    types::{BpfProgType, Direction, Link},
+    utils::bytes_to_string,
+};
+
+/// Attach-point key identifying a dispatcher.
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatcherKey {
+    #[serde(rename = "type")]
+    pub dispatcher_type: String,
+    pub nsid: u64,
+    pub ifindex: u32,
+}
+
+/// Kernel-assigned runtime identifiers for the dispatcher.
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatcherRuntime {
+    /// Kernel program id of the dispatcher. Not persisted; always null.
+    pub program_id: Option<u32>,
+    /// Kernel link id of the dispatcher. Not persisted; always null.
+    pub kernel_link_id: Option<u32>,
+    /// TC filter priority. Set for TC dispatchers, absent for XDP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_priority: Option<u16>,
+    /// TC filter handle. Set for TC dispatchers, absent for XDP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_handle: Option<u32>,
+    pub netns_path: String,
+}
+
+/// One extension program attached to a dispatcher.
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatcherMember {
+    /// Kernel program id of the extension program.
+    pub program_id: u32,
+    pub program_name: String,
+    /// bpfman link id.
+    pub link_id: u32,
+    /// Kernel link id of the extension. Not persisted; always null.
+    pub kernel_link_id: Option<u32>,
+    /// Slot the dispatcher runs the program in (0-based, ascending is
+    /// execution order).
+    pub position: Option<usize>,
+    pub priority: i32,
+    pub proceed_on: u32,
+}
+
+/// A full dispatcher view including its members.
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatcherSnapshot {
+    pub key: DispatcherKey,
+    pub revision: u32,
+    pub runtime: DispatcherRuntime,
+    pub members: Vec<DispatcherMember>,
+}
+
+/// A lightweight dispatcher view carrying the member count rather than
+/// the full member list.
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatcherSummary {
+    pub key: DispatcherKey,
+    pub revision: u32,
+    pub runtime: DispatcherRuntime,
+    pub member_count: usize,
+}
+
+/// Return every dispatcher present in the store, one summary each.
+pub fn list_dispatcher_snapshots(root_db: &Db) -> Result<Vec<DispatcherSummary>, BpfmanError> {
+    // A dispatcher may briefly have two revision trees during an atomic
+    // swap; keep the highest-revision one per attach point.
+    let mut by_key: BTreeMap<(String, u64, u32), DispatcherSummary> = BTreeMap::new();
+
+    for name in root_db.tree_names() {
+        let tree_name = bytes_to_string(&name);
+        if !tree_name.contains(XDP_DISPATCHER_PREFIX) && !tree_name.contains(TC_DISPATCHER_PREFIX) {
+            continue;
+        }
+
+        let tree = root_db.open_tree(&name).map_err(|e| {
+            BpfmanError::DatabaseError("unable to open dispatcher tree".to_string(), e.to_string())
+        })?;
+        let dispatcher = Dispatcher::new_from_db(tree);
+
+        let snapshot = snapshot_from_dispatcher(root_db, &dispatcher)?;
+        let dedup = (
+            snapshot.key.dispatcher_type.clone(),
+            snapshot.key.nsid,
+            snapshot.key.ifindex,
+        );
+        let summary = DispatcherSummary {
+            key: snapshot.key,
+            revision: snapshot.revision,
+            runtime: snapshot.runtime,
+            member_count: snapshot.members.len(),
+        };
+
+        match by_key.get(&dedup) {
+            Some(existing) if existing.revision >= summary.revision => {}
+            _ => {
+                by_key.insert(dedup, summary);
+            }
+        }
+    }
+
+    Ok(by_key.into_values().collect())
+}
+
+/// Return a single dispatcher by attach-point key, or None if no such
+/// dispatcher exists.
+pub fn get_dispatcher_snapshot(
+    root_db: &Db,
+    dispatcher_type: &str,
+    nsid: u64,
+    ifindex: u32,
+) -> Result<Option<DispatcherSnapshot>, BpfmanError> {
+    let id = dispatcher_id_from_type(dispatcher_type, nsid, ifindex)?;
+
+    match get_dispatcher(&id, root_db)? {
+        Some(dispatcher) => Ok(Some(snapshot_from_dispatcher(root_db, &dispatcher)?)),
+        None => Ok(None),
+    }
+}
+
+fn dispatcher_id_from_type(
+    dispatcher_type: &str,
+    nsid: u64,
+    ifindex: u32,
+) -> Result<DispatcherId, BpfmanError> {
+    match dispatcher_type {
+        "xdp" => Ok(DispatcherId::Xdp(DispatcherInfo(nsid, ifindex, None))),
+        "tc-ingress" => Ok(DispatcherId::Tc(DispatcherInfo(
+            nsid,
+            ifindex,
+            Some(Direction::Ingress),
+        ))),
+        "tc-egress" => Ok(DispatcherId::Tc(DispatcherInfo(
+            nsid,
+            ifindex,
+            Some(Direction::Egress),
+        ))),
+        other => Err(BpfmanError::Error(format!(
+            "unknown dispatcher type {other:?}; expected xdp, tc-ingress or tc-egress"
+        ))),
+    }
+}
+
+fn snapshot_from_dispatcher(
+    root_db: &Db,
+    dispatcher: &Dispatcher,
+) -> Result<DispatcherSnapshot, BpfmanError> {
+    let (key, revision, runtime, program_type, ifindex, direction, nsid) = match dispatcher {
+        Dispatcher::Xdp(d) => {
+            let nsid = d.get_nsid()?;
+            let ifindex = d.get_ifindex()?;
+            let key = DispatcherKey {
+                dispatcher_type: "xdp".to_string(),
+                nsid,
+                ifindex,
+            };
+            let runtime = DispatcherRuntime {
+                program_id: None,
+                kernel_link_id: None,
+                filter_priority: None,
+                filter_handle: None,
+                netns_path: String::new(),
+            };
+            (
+                key,
+                d.get_revision()?,
+                runtime,
+                BpfProgType::Xdp,
+                ifindex,
+                None,
+                nsid,
+            )
+        }
+        Dispatcher::Tc(d) => {
+            let nsid = d.get_nsid()?;
+            let ifindex = d.get_ifindex()?;
+            let direction = d.get_direction()?;
+            let dispatcher_type = match direction {
+                Direction::Ingress => "tc-ingress",
+                Direction::Egress => "tc-egress",
+            };
+            let key = DispatcherKey {
+                dispatcher_type: dispatcher_type.to_string(),
+                nsid,
+                ifindex,
+            };
+            let netns_path = d
+                .get_netns()?
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let runtime = DispatcherRuntime {
+                program_id: None,
+                kernel_link_id: None,
+                filter_priority: Some(d.get_priority()?),
+                filter_handle: d.get_handle()?,
+                netns_path,
+            };
+            (
+                key,
+                d.get_revision()?,
+                runtime,
+                BpfProgType::Tc,
+                ifindex,
+                Some(direction),
+                nsid,
+            )
+        }
+    };
+
+    let links = get_multi_attach_links(root_db, program_type, Some(ifindex), direction, nsid)?;
+
+    let mut members = Vec::with_capacity(links.len());
+    for link in &links {
+        let (priority, proceed_on) = match link {
+            Link::Xdp(l) => (l.get_priority()?, l.get_proceed_on()?.mask()),
+            Link::Tc(l) => (l.get_priority()?, l.get_proceed_on()?.mask()),
+            _ => continue,
+        };
+
+        members.push(DispatcherMember {
+            program_id: link.get_program_id()?,
+            program_name: link.get_program_name()?,
+            link_id: link.get_id()?,
+            kernel_link_id: None,
+            position: link.get_current_position()?,
+            priority,
+            proceed_on,
+        });
+    }
+
+    // Present members in execution order (ascending slot position), the
+    // order the kernel runs the chain.
+    members.sort_by_key(|m| m.position.unwrap_or(usize::MAX));
+
+    Ok(DispatcherSnapshot {
+        key,
+        revision,
+        runtime,
+        members,
+    })
+}

--- a/bpfman/src/dispatcher_view.rs
+++ b/bpfman/src/dispatcher_view.rs
@@ -70,6 +70,10 @@ pub struct DispatcherMember {
     pub position: Option<usize>,
     pub priority: i32,
     pub proceed_on: u32,
+    pub ifname: String,
+    /// User link labels applied at attach time. A BTreeMap so the
+    /// serialised order is deterministic for diffing.
+    pub metadata: BTreeMap<String, String>,
 }
 
 /// A full dispatcher view including its members.
@@ -175,7 +179,8 @@ fn snapshot_from_dispatcher(
     root_db: &Db,
     dispatcher: &Dispatcher,
 ) -> Result<DispatcherSnapshot, BpfmanError> {
-    let (key, revision, runtime, program_type, ifindex, direction, nsid) = match dispatcher {
+    let (key, revision, runtime, program_type, ifindex, direction, nsid, ifname) = match dispatcher
+    {
         Dispatcher::Xdp(d) => {
             let nsid = d.get_nsid()?;
             let ifindex = d.get_ifindex()?;
@@ -199,6 +204,7 @@ fn snapshot_from_dispatcher(
                 ifindex,
                 None,
                 nsid,
+                d.get_ifname()?,
             )
         }
         Dispatcher::Tc(d) => {
@@ -233,6 +239,7 @@ fn snapshot_from_dispatcher(
                 ifindex,
                 Some(direction),
                 nsid,
+                d.get_ifname()?,
             )
         }
     };
@@ -255,6 +262,8 @@ fn snapshot_from_dispatcher(
             position: link.get_current_position()?,
             priority,
             proceed_on,
+            ifname: ifname.clone(),
+            metadata: link.get_metadata()?.into_iter().collect(),
         });
     }
 

--- a/bpfman/src/lib.rs
+++ b/bpfman/src/lib.rs
@@ -49,6 +49,7 @@ use crate::{
 
 pub mod config;
 mod dispatcher_config;
+pub mod dispatcher_view;
 pub mod errors;
 mod multiprog;
 mod netlink;
@@ -901,7 +902,10 @@ pub(crate) fn init_image_manager() -> Result<ImageManager, BpfmanError> {
     //.expect("failed to initialize image manager")
 }
 
-fn get_dispatcher(id: &DispatcherId, root_db: &Db) -> Result<Option<Dispatcher>, BpfmanError> {
+pub(crate) fn get_dispatcher(
+    id: &DispatcherId,
+    root_db: &Db,
+) -> Result<Option<Dispatcher>, BpfmanError> {
     debug!("Getting dispatcher with id: {:?}", id);
     let dispatcher_id = match id {
         DispatcherId::Xdp(DispatcherInfo(nsid, if_index, _)) => {
@@ -950,7 +954,7 @@ fn get(root_db: &Db, id: &u32) -> Option<Program> {
     }
 }
 
-fn get_multi_attach_links(
+pub(crate) fn get_multi_attach_links(
     root_db: &'_ Db,
     program_type: BpfProgType,
     if_index: Option<u32>,


### PR DESCRIPTION
This adds a read-only `bpfman dispatcher list` and `bpfman dispatcher get <type> <nsid> <ifindex>`, hidden from help, for inspecting XDP and TC dispatcher state. It exists for debugging and for comparing dispatcher layout against another bpfman implementation, and both subcommands take `-o text|json`.

A new `dispatcher_view` library module assembles serde-serialisable snapshots from the store, reusing the existing `get_dispatcher` and `get_multi_attach_links` grouping rather than re-deriving membership. Each snapshot carries the attach-point key, revision, the TC filter priority/handle and netns where applicable, and the members with their slot position, priority, function name, bpfman link id, kernel program id, proceed-on mask, interface name and metadata. Members are ordered by slot position, the order the dispatcher runs the chain.

The kernel-assigned identifiers this implementation does not persist -- the dispatcher's own program id and link id, and each member's kernel link id -- serialise as null rather than being loaded from the pins; they are per-load values with no cross-implementation meaning. The JSON field names mirror the Go implementation so the two can be diffed directly.

## Test plan

`cargo build`, `cargo clippy` and `cargo fmt --check` are clean. Exercised against a live store: loaded XDP and TC programs, then confirmed `dispatcher list -o json` and `dispatcher get ... -o json` render the expected members in position order. The JSON output was diffed step-by-step against the Go implementation across proceed-on encoding, priority ordering, name tie-break, slot reuse, the 10-slot cap, multi-interface independence, TC ingress/egress independence, teardown, unload-cascade and netns scenarios; all matched on the semantic core.