### PR TITLE
Resolve container uprobe library names in the correct namespaces

### DIFF
--- a/cmd/bpfman-shell/fixturemode/doc.go
+++ b/cmd/bpfman-shell/fixturemode/doc.go
@@ -3,5 +3,33 @@
 // These modes bypass the normal script runner and turn
 // bpfman-shell into small helper processes used by tests and
 // fixtures. They are command-private support code for the binary,
-// not part of the shell language itself.
+// not part of the shell language itself. A mode is selected by the
+// BPFMAN_SHELL_MODE environment variable; the remaining argv is the
+// mode's own, dispatched by Run in mode.go.
+//
+// The modes:
+//
+//   - uprobe-fire-worker: a stable-PID worker that fires the cgo'd
+//     bpfman_shell_uprobe_call_malloc symbol N times per wave, gated
+//     by numbered sentinel/ack files. Scripts attach uprobes to the
+//     bpfman-shell binary (or, via libc malloc, to the worker's
+//     libc) and drive deterministic traffic through the wave
+//     protocol. See uprobe.go.
+//
+//   - unlinkat-fire-worker: the same wave-protocol worker shape
+//     firing unlinkat(2), for sys_enter/sys_exit_unlinkat
+//     tracepoint fixtures. See unlinkat.go.
+//
+//   - kill-fire-worker: the wave-protocol worker shape firing
+//     kill(2). See kill.go.
+//
+//   - ldso-cache-writer: not a worker; a one-shot generator that
+//     writes a minimal new-format glibc ld.so.cache from
+//     soname=path pairs (`bpfman-shell <outfile> <soname>=<path>...`
+//     under the mode). Scripts install the result as a synthetic
+//     /etc/ld.so.cache inside a target mount namespace to test
+//     container uprobe library-name resolution: an entry that
+//     exists in no host's cache proves resolution happened inside
+//     the namespace. ldconfig cannot build such a cache because it
+//     takes keys from ELF sonames, not file names. See ldsocache.go.
 package fixturemode

--- a/cmd/bpfman-shell/fixturemode/ldsocache.go
+++ b/cmd/bpfman-shell/fixturemode/ldsocache.go
@@ -1,0 +1,91 @@
+// Test-fixture mode that fabricates a dynamic-linker cache. When
+// BPFMAN_SHELL_MODE=ldso-cache-writer, bpfman-shell writes a minimal
+// new-format (glibc-ld.so.cache1.1) cache file from soname=path
+// pairs given on the command line:
+//
+//	bpfman-shell <outfile> <soname>=<path> [<soname>=<path>...]
+//
+// The e2e scripts use this to place a synthetic /etc/ld.so.cache
+// inside a target mount namespace whose entries diverge from the
+// host -- the discriminating fixture for container uprobe
+// library-name resolution (BPFMAN-42,
+// https://redhat.atlassian.net/browse/BPFMAN-42): a name
+// that resolves through this cache can only have been resolved inside the namespace.
+// ldconfig cannot build such a cache because it takes each key from
+// the library's ELF soname, not from the file name.
+//
+// The byte layout mirrors what glibc writes and what the resolver's
+// parseLdSoCache expects: the 20-byte header, a native-endian u32
+// entry count, six unused u32s, 24-byte entries of (flags, key
+// offset, value offset, 12 unused bytes), then the string pool,
+// with offsets absolute from the start of the file.
+package fixturemode
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runLdSoCacheWriter parses <outfile> <soname>=<path>... and writes
+// the cache image.
+func runLdSoCacheWriter(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: ldso-cache-writer <outfile> <soname>=<path>...")
+	}
+
+	outfile := args[0]
+
+	type pair struct{ key, value string }
+	pairs := make([]pair, 0, len(args)-1)
+
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok || key == "" || value == "" {
+			return fmt.Errorf("malformed entry %q (want soname=path)", arg)
+		}
+		pairs = append(pairs, pair{key: key, value: value})
+	}
+
+	const header = "glibc-ld.so.cache1.1"
+	tableOff := len(header) + 4 + 6*4
+	poolOff := tableOff + len(pairs)*24
+
+	var pool []byte
+	type entry struct{ key, value uint32 }
+	entries := make([]entry, 0, len(pairs))
+
+	for _, p := range pairs {
+		key := uint32(poolOff + len(pool))
+		pool = append(pool, p.key...)
+		pool = append(pool, 0)
+		value := uint32(poolOff + len(pool))
+		pool = append(pool, p.value...)
+		pool = append(pool, 0)
+		entries = append(entries, entry{key: key, value: value})
+	}
+
+	buf := make([]byte, 0, poolOff+len(pool))
+	buf = append(buf, header...)
+	buf = binary.NativeEndian.AppendUint32(buf, uint32(len(pairs)))
+
+	for range 6 {
+		buf = binary.NativeEndian.AppendUint32(buf, 0)
+	}
+
+	for _, e := range entries {
+		buf = binary.NativeEndian.AppendUint32(buf, 1) // flags: ELF
+		buf = binary.NativeEndian.AppendUint32(buf, e.key)
+		buf = binary.NativeEndian.AppendUint32(buf, e.value)
+		buf = append(buf, make([]byte, 12)...)
+	}
+
+	buf = append(buf, pool...)
+
+	if err := os.WriteFile(outfile, buf, 0o644); err != nil {
+		return fmt.Errorf("write cache %s: %w", outfile, err)
+	}
+
+	return nil
+}

--- a/cmd/bpfman-shell/fixturemode/mode.go
+++ b/cmd/bpfman-shell/fixturemode/mode.go
@@ -15,6 +15,8 @@ func Run(mode string, args []string) error {
 		return runUnlinkatFireWorker(args)
 	case "kill-fire-worker":
 		return runKillFireWorker(args)
+	case "ldso-cache-writer":
+		return runLdSoCacheWriter(args)
 	default:
 		return fmt.Errorf("unknown BPFMAN_SHELL_MODE %q", mode)
 	}

--- a/cmd/bpfman/attach.go
+++ b/cmd/bpfman/attach.go
@@ -323,12 +323,14 @@ type AttachUprobeCmd struct {
 	Offset uint64 `name:"offset" help:"Offset within the function." default:"0"`
 
 	// Pid restricts tracing to a single process ID; 0 traces all
-	// processes.
-	Pid int32 `name:"pid" help:"Only trace this process ID (0 traces all processes)."`
+	// processes. The number is a host PID -- the same pid namespace
+	// ContainerPid uses -- for both the process-maps tier of
+	// library-name resolution and the perf-event filter.
+	Pid int32 `name:"pid" help:"Only trace this host PID (0 traces all processes; same pid namespace as --container-pid)."`
 
 	// ContainerPid identifies the container whose mount namespace
-	// resolves Target, enabling namespace-aware attachment.
-	ContainerPid int32 `name:"container-pid" help:"Container PID for namespace-aware uprobe attachment."`
+	// resolves and opens Target, enabling namespace-aware attachment.
+	ContainerPid int32 `name:"container-pid" help:"Host PID of the container whose mount namespace resolves the target."`
 }
 
 // Run builds a uprobe attach spec from the flags, attaches the

--- a/e2e/scripts/TestContainerUprobe_AppTestImage.bpfman
+++ b/e2e/scripts/TestContainerUprobe_AppTestImage.bpfman
@@ -1,0 +1,90 @@
+# -*- mode: bpfman -*-
+#pragma labels={"external":"true","image":"true"}
+#
+# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
+#
+# The reporter's reproducer with its real bytecode: the operator's
+# sample BpfApplication loads quay.io/bpfman-bytecode/app-test and
+# attaches its uprobe_test/uretprobe_test pair to `target: libc,
+# function: malloc` in selected containers. This script loads that
+# exact image by reference -- bpfman's native OCI support, no
+# container runtime involved -- and attaches both programs, by
+# their real names, into a mount namespace whose synthetic
+# /etc/ld.so.cache resolves the bare name.
+#
+# The app-test programs only bpf_printk and return, so there is no
+# counter to assert; traffic proof for bare-name container attaches
+# lives in the sibling LibraryNameTarget and SyntheticLdSoCache
+# scripts. What this script pins is the reproducer's own artefacts:
+# the published image loads, and both probe directions attach with
+# the bare name.
+#
+# Given: the published app-test bytecode image, and a target
+# process in a mount namespace with a synthetic cache mapping
+# libc to a namespace-private bind of the real libc
+#
+# When: uprobe_test and uretprobe_test are attached to malloc with
+# target "libc" via --container-pid (no --pid: the cache tier must
+# answer, from inside the namespace)
+#
+# Then: both attaches succeed, recording the raw target and the
+# correct probe directions
+
+import ../lib.bpfman
+
+let image = "quay.io/bpfman-bytecode/app-test"
+
+guard wd <- tempdir container-uprobe-apptest
+defer exec rm -rf $wd.path
+let cachefile = "${wd.path}/ld.so.cache"
+let bindtgt = "${wd.path}/libc.so.6"
+
+guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
+assert path-exists $shell_path.stdout
+
+guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
+assert path-exists $libc.stdout
+
+# The synthetic cache maps the reproducer's bare name, libc, to a
+# namespace-private bind of the real libc.
+exec touch $bindtgt
+exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libc.so.6=${bindtgt}"
+
+let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${libc.stdout}' '${bindtgt}' && exec sleep 300"
+guard target <- start unshare -m -- sh -c $nssetup
+defer kill $target
+
+guard self_ns <- exec readlink /proc/self/ns/mnt
+poll timeout 5s every 100ms {
+    let target_ns <- exec readlink "/proc/${target.pid}/ns/mnt"
+    retry "waiting for target mount namespace switch" unless $target_ns.stdout != $self_ns.stdout
+}
+
+guard loaded <- bpfman program load image $image --pull-policy Always --programs uprobe:uprobe_test,uretprobe:uretprobe_test
+let progU = $loaded.programs[0]
+let progR = $loaded.programs[1]
+assert $progU.record.meta.name == "uprobe_test"
+assert $progR.record.meta.name == "uretprobe_test"
+let pidU = $progU.record.program_id
+let pidR = $progR.record.program_id
+defer bpfman program unload $pidU
+defer bpfman program unload $pidR
+
+guard linkU <- bpfman link attach uprobe $progU libc --fn-name malloc --container-pid $target.pid
+defer bpfman link detach $linkU
+assert $linkU.record.id > 0
+assert not null $linkU.record.kernel_link_id
+assert $linkU.record.kind == uprobe
+assert $linkU.record.details.target == "libc"
+assert $linkU.status.kernel_seen
+
+guard linkR <- bpfman link attach uprobe $progR libc --fn-name malloc --container-pid $target.pid
+defer bpfman link detach $linkR
+assert $linkR.record.id > 0
+assert not null $linkR.record.kernel_link_id
+assert $linkR.record.kind == uretprobe
+assert $linkR.record.details.target == "libc"
+assert $linkR.record.details.retprobe
+assert $linkR.status.kernel_seen
+
+print "app-test image attach: uprobe link=${linkU.record.id} uretprobe link=${linkR.record.id}"

--- a/e2e/scripts/TestContainerUprobe_AppTestImage.bpfman
+++ b/e2e/scripts/TestContainerUprobe_AppTestImage.bpfman
@@ -46,7 +46,11 @@ guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc
 assert path-exists $libc.stdout
 
 # The synthetic cache maps the reproducer's bare name, libc, to a
-# namespace-private bind of the real libc.
+# namespace-private bind of the real libc. The bound file must
+# define the malloc symbol the reproducer's links name, so this
+# script needs a dynamically linked bpfman-shell to discover libc
+# from -- true for local builds; CI's static bundle does not run
+# external scripts.
 exec touch $bindtgt
 exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libc.so.6=${bindtgt}"
 

--- a/e2e/scripts/TestContainerUprobe_HostProcDaemonView.bpfman
+++ b/e2e/scripts/TestContainerUprobe_HostProcDaemonView.bpfman
@@ -1,0 +1,107 @@
+# -*- mode: bpfman -*-
+#pragma labels={"serial":"true"}
+#
+# BPFMAN-42 companion -- https://redhat.atlassian.net/browse/BPFMAN-42
+#
+# The DAEMON side of the kube deployment
+# shape. In the operator's daemonset the bpfman pod has no hostPID:
+# its /proc shows only its own processes, and the host's procfs is
+# volume-mounted at /host/proc. A container uprobe attach must
+# therefore reach the target's namespace file through the
+# /proc -> /host/proc fallback -- dead code in every other test,
+# load-bearing in every real cluster.
+#
+# The rig: the attach runs through the external bpfman CLI wrapped
+# in its own mount+pid namespaces, with the real procfs bound at
+# /host/proc BEFORE a pod-scoped procfs overmounts /proc (order
+# matters: bind first or you hide what you meant to expose). The
+# target is a fire worker in its own mount namespace with a
+# synthetic /etc/ld.so.cache (tmpfs over /etc) mapping
+# libbpfmantest.so.1 to a namespace-private bind of the real libc.
+#
+# The attach succeeding IS the fallback assertion: inside the
+# daemon pod, /proc/<target-pid> does not exist, so the namespace
+# file is only reachable via /host/proc.
+#
+# Serial: the script creates and removes the /host/proc mountpoint
+# on the host filesystem.
+
+import ../lib.bpfman
+
+let events = 5
+let weight = 13
+
+guard wd <- tempdir container-uprobe-hostproc
+defer exec rm -rf $wd.path
+let sentinel = "${wd.path}/sentinel"
+let ack = "${wd.path}/ack"
+let cachefile = "${wd.path}/ld.so.cache"
+let bindtgt = "${wd.path}/libbpfmantest.so.1"
+
+guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
+assert path-exists $shell_path.stdout
+
+guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
+assert path-exists $libc.stdout
+
+exec touch $bindtgt
+exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libbpfmantest.so.1=${bindtgt}"
+
+# The daemonset mounts host /proc at /host/proc; here that needs a
+# mountpoint on the host root. Ownership is tracked per directory
+# with marker files in the script's tempdir: only a directory this
+# run created is removed afterwards, so a pre-existing /host or
+# /host/proc on the machine is never touched. (The tempdir's own
+# cleanup defer was registered first, so it runs last and the
+# markers are still present here.)
+exec sh -c "[ -d /host ] || touch '${wd.path}/created-host'; [ -d /host/proc ] || touch '${wd.path}/created-hostproc'; mkdir -p /host/proc"
+defer exec sh -c "[ ! -e '${wd.path}/created-hostproc' ] || rmdir /host/proc 2>/dev/null; [ ! -e '${wd.path}/created-host' ] || rmdir /host 2>/dev/null; true"
+
+# Target: mount namespace with a divergent /etc (tmpfs), synthetic
+# cache installed, real libc bound at the advertised path, then
+# exec into the fire worker (pid preserved).
+let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${libc.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
+guard target <- start unshare -m -- sh -c $nssetup
+defer kill $target
+
+guard self_ns <- exec readlink /proc/self/ns/mnt
+poll timeout 5s every 100ms {
+    let target_ns <- exec readlink "/proc/${target.pid}/ns/mnt"
+    retry "waiting for target mount namespace switch" unless $target_ns.stdout != $self_ns.stdout
+}
+
+guard loaded <- bpfman program load file testdata/bpf/uprobe_exact.bpf.o --programs uprobe:uprobe_counter -g "expected_pid=0x${u32le $target.pid}" -g "weight=0x${u64le $weight}"
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+defer bpfman program unload $pid
+
+# The attach, issued from inside the synthesised daemon pod: pod
+# pid namespace, pod-scoped /proc (the target's pid is invisible
+# there), host procfs at /host/proc. Bare-name target: only the
+# target namespace's cache can resolve it.
+let podattach = "mount --make-rprivate / && mount --bind /proc /host/proc && mount -t proc proc /proc && exec bpfman link attach uprobe ${pid} libbpfmantest --fn-name malloc --container-pid ${target.pid} -o json"
+guard att <- exec unshare --mount --pid --fork -- sh -c $podattach
+let lid = $att.stdout |> jq "fromjson | .record.id"
+defer exec bpfman link detach $lid
+let klid = $att.stdout |> jq "fromjson | .record.kernel_link_id"
+
+assert $lid > 0
+assert not null $klid
+
+let mapID = $prog |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
+let counter_filter = "fromjson | .[0].formatted.value | tonumber"
+
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $counter_filter
+
+exec touch "${sentinel}.1"
+poll timeout 5s every 100ms {
+    await_wave_completion $ack 1
+}
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $counter_filter
+let delta = $after - $before
+let want = $events * $weight
+print "container-uprobe host-proc daemon view count: got=${delta} want>=${want}"
+assert $delta >= $want

--- a/e2e/scripts/TestContainerUprobe_HostProcDaemonView.bpfman
+++ b/e2e/scripts/TestContainerUprobe_HostProcDaemonView.bpfman
@@ -17,7 +17,9 @@
 # matters: bind first or you hide what you meant to expose). The
 # target is a fire worker in its own mount namespace with a
 # synthetic /etc/ld.so.cache (tmpfs over /etc) mapping
-# libbpfmantest.so.1 to a namespace-private bind of the real libc.
+# libbpfmantest.so.1 to a namespace-private bind of the worker's
+# own binary, probed at its cgo fixture symbol (static-proof; a
+# libc probe would never fire on CI's statically linked worker).
 #
 # The attach succeeding IS the fallback assertion: inside the
 # daemon pod, /proc/<target-pid> does not exist, so the namespace
@@ -40,9 +42,7 @@ let bindtgt = "${wd.path}/libbpfmantest.so.1"
 
 guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
 assert path-exists $shell_path.stdout
-
-guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
-assert path-exists $libc.stdout
+guard tinfo <- uprobe-target
 
 exec touch $bindtgt
 exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libbpfmantest.so.1=${bindtgt}"
@@ -60,7 +60,7 @@ defer exec sh -c "[ ! -e '${wd.path}/created-hostproc' ] || rmdir /host/proc 2>/
 # Target: mount namespace with a divergent /etc (tmpfs), synthetic
 # cache installed, real libc bound at the advertised path, then
 # exec into the fire worker (pid preserved).
-let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${libc.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
+let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${shell_path.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
 guard target <- start unshare -m -- sh -c $nssetup
 defer kill $target
 
@@ -79,7 +79,7 @@ defer bpfman program unload $pid
 # pid namespace, pod-scoped /proc (the target's pid is invisible
 # there), host procfs at /host/proc. Bare-name target: only the
 # target namespace's cache can resolve it.
-let podattach = "mount --make-rprivate / && mount --bind /proc /host/proc && mount -t proc proc /proc && exec bpfman link attach uprobe ${pid} libbpfmantest --fn-name malloc --container-pid ${target.pid} -o json"
+let podattach = "mount --make-rprivate / && mount --bind /proc /host/proc && mount -t proc proc /proc && exec bpfman link attach uprobe ${pid} libbpfmantest --fn-name ${tinfo.symbol} --container-pid ${target.pid} -o json"
 guard att <- exec unshare --mount --pid --fork -- sh -c $podattach
 let lid = $att.stdout |> jq "fromjson | .record.id"
 defer exec bpfman link detach $lid

--- a/e2e/scripts/TestContainerUprobe_LibraryNameTarget.bpfman
+++ b/e2e/scripts/TestContainerUprobe_LibraryNameTarget.bpfman
@@ -1,0 +1,111 @@
+# -*- mode: bpfman -*-
+#
+# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
+#
+# A container uprobe whose target is a bare library name
+# (libc) must resolve inside the container's mount namespace, as the
+# Rust implementation does (aya resolves via the container's
+# /proc/<pid>/maps and /etc/ld.so.cache after setns).
+#
+# Given: a cgo-linked target process running in its own mount
+# namespace, whose fire helper calls libc malloc once per event
+#
+# When: a uprobe and a uretprobe (the BPFMAN-42 reproducer is the
+# uprobe_test/uretprobe_test pair) are attached to function malloc
+# with target "libc" -- a bare library name, not an absolute path --
+# via --container-pid
+#
+# Then: both attaches succeed and firing the target advances both
+# pid-filtered counter maps by at least events * weight (the fire
+# helper calls malloc exactly once per event, and every entry has a
+# matching return; the process may malloc elsewhere, so the counts
+# are lower bounds, not equalities)
+
+import ../lib.bpfman
+
+let events = 5
+let weight = 13
+let retweight = 7
+
+guard wd <- tempdir container-uprobe-libname
+defer exec rm -rf $wd.path
+let sentinel = "${wd.path}/sentinel"
+let ack = "${wd.path}/ack"
+
+guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
+assert path-exists $shell_path.stdout
+
+guard target <- start unshare -m -- env BPFMAN_SHELL_MODE=uprobe-fire-worker \
+    $shell_path.stdout \
+    $sentinel \
+    $ack \
+    $events \
+    1
+defer kill $target
+
+guard self_ns <- exec readlink /proc/self/ns/mnt
+# unshare switches mount namespace a moment after start forks the
+# child; poll until the target's namespace actually differs instead
+# of racing the readlink against the switch.
+poll timeout 5s every 100ms {
+    let target_ns <- exec readlink "/proc/${target.pid}/ns/mnt"
+    retry "waiting for target mount namespace switch" unless $target_ns.stdout != $self_ns.stdout
+}
+
+guard loaded <- bpfman program load file testdata/bpf/uprobe_exact.bpf.o --programs uprobe:uprobe_counter -g "expected_pid=0x${u32le $target.pid}" -g "weight=0x${u64le $weight}"
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+defer bpfman program unload $pid
+
+guard loadedRet <- bpfman program load file testdata/bpf/uprobe_exact.bpf.o --programs uretprobe:uprobe_counter -g "expected_pid=0x${u32le $target.pid}" -g "weight=0x${u64le $retweight}"
+let progRet = $loadedRet.programs[0]
+let pidRet = $progRet.record.program_id
+defer bpfman program unload $pidRet
+
+# The essence of BPFMAN-42: the target is the bare name "libc", not
+# an absolute path. The name must be resolved against the container's
+# mount namespace, not bpfman's. --pid lets resolution use the
+# /proc/<pid>/maps tier so the script also passes on hosts without
+# /etc/ld.so.cache (e.g. NixOS); the gate under test rejects any
+# non-absolute target before resolution runs.
+guard link <- bpfman link attach uprobe $prog libc --fn-name malloc --pid $target.pid --container-pid $target.pid
+defer bpfman link detach $link
+let linkID = $link.record.id
+
+assert $link.record.id > 0
+assert not null $link.record.kernel_link_id
+assert $link.status.kernel_seen
+assert $link.status.pin_present
+
+guard linkRet <- bpfman link attach uprobe $progRet libc --fn-name malloc --pid $target.pid --container-pid $target.pid
+defer bpfman link detach $linkRet
+assert $linkRet.record.id > 0
+assert not null $linkRet.record.kernel_link_id
+
+let mapID = $prog |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
+let mapIDRet = $progRet |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
+let counter_filter = "fromjson | .[0].formatted.value | tonumber"
+
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $counter_filter
+guard dumpBeforeRet <- bpftool map dump id $mapIDRet -j
+let beforeRet = $dumpBeforeRet.stdout |> jq $counter_filter
+
+exec touch "${sentinel}.1"
+poll timeout 5s every 100ms {
+    await_wave_completion $ack 1
+}
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $counter_filter
+let delta = $after - $before
+let want = $events * $weight
+print "container-uprobe libc-malloc count: got=${delta} want>=${want}"
+assert $delta >= $want
+
+guard dumpAfterRet <- bpftool map dump id $mapIDRet -j
+let afterRet = $dumpAfterRet.stdout |> jq $counter_filter
+let deltaRet = $afterRet - $beforeRet
+let wantRet = $events * $retweight
+print "container-uretprobe libc-malloc count: got=${deltaRet} want>=${wantRet}"
+assert $deltaRet >= $wantRet

--- a/e2e/scripts/TestContainerUprobe_LibraryNameTarget.bpfman
+++ b/e2e/scripts/TestContainerUprobe_LibraryNameTarget.bpfman
@@ -2,24 +2,32 @@
 #
 # BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
 #
-# A container uprobe whose target is a bare library name
-# (libc) must resolve inside the container's mount namespace, as the
-# Rust implementation does (aya resolves via the container's
+# A container uprobe whose target is a bare library name must
+# resolve inside the container's mount namespace, as the Rust
+# implementation does (aya resolves via the container's
 # /proc/<pid>/maps and /etc/ld.so.cache after setns).
 #
-# Given: a cgo-linked target process running in its own mount
-# namespace, whose fire helper calls libc malloc once per event
+# The probed "library" is the fire worker's own binary, executed
+# through a namespace-private bind named libbpfmantest.so.1, and
+# the probed function is the worker's cgo fixture symbol. That
+# keeps the test independent of how bpfman-shell is linked: CI
+# builds it statically, so a probe on libc would never fire (the
+# worker executes no libc inode) and ldd-based libc discovery
+# returns nothing. Resolution semantics are identical -- the maps
+# tier matches the library-shaped basename among the pid's mapped
+# files exactly as it would match libc.so.6.
+#
+# Given: a target process in its own mount namespace, executing a
+# library-named bind of the fire worker whose fixture symbol fires
+# once per event
 #
 # When: a uprobe and a uretprobe (the BPFMAN-42 reproducer is the
-# uprobe_test/uretprobe_test pair) are attached to function malloc
-# with target "libc" -- a bare library name, not an absolute path --
-# via --container-pid
+# uprobe_test/uretprobe_test pair) are attached to that symbol with
+# target "libbpfmantest" -- a bare library name, not an absolute
+# path -- via --pid and --container-pid
 #
 # Then: both attaches succeed and firing the target advances both
-# pid-filtered counter maps by at least events * weight (the fire
-# helper calls malloc exactly once per event, and every entry has a
-# matching return; the process may malloc elsewhere, so the counts
-# are lower bounds, not equalities)
+# pid-filtered counter maps by at least events * weight
 
 import ../lib.bpfman
 
@@ -31,16 +39,18 @@ guard wd <- tempdir container-uprobe-libname
 defer exec rm -rf $wd.path
 let sentinel = "${wd.path}/sentinel"
 let ack = "${wd.path}/ack"
+let bindtgt = "${wd.path}/libbpfmantest.so.1"
 
 guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
 assert path-exists $shell_path.stdout
+guard tinfo <- uprobe-target
 
-guard target <- start unshare -m -- env BPFMAN_SHELL_MODE=uprobe-fire-worker \
-    $shell_path.stdout \
-    $sentinel \
-    $ack \
-    $events \
-    1
+# The worker execs the library-named bind, so its maps carry a
+# basename the maps tier can match, exactly as a process's mapped
+# libc.so.6 would be matched for a "libc" query.
+exec touch $bindtgt
+let nssetup = "mount --bind '${shell_path.stdout}' '${bindtgt}' && BPFMAN_SHELL_MODE=uprobe-fire-worker exec '${bindtgt}' '${sentinel}' '${ack}' ${events} 1"
+guard target <- start unshare -m -- sh -c $nssetup
 defer kill $target
 
 guard self_ns <- exec readlink /proc/self/ns/mnt
@@ -62,13 +72,12 @@ let progRet = $loadedRet.programs[0]
 let pidRet = $progRet.record.program_id
 defer bpfman program unload $pidRet
 
-# The essence of BPFMAN-42: the target is the bare name "libc", not
-# an absolute path. The name must be resolved against the container's
-# mount namespace, not bpfman's. --pid lets resolution use the
-# /proc/<pid>/maps tier so the script also passes on hosts without
-# /etc/ld.so.cache (e.g. NixOS); the gate under test rejects any
-# non-absolute target before resolution runs.
-guard link <- bpfman link attach uprobe $prog libc --fn-name malloc --pid $target.pid --container-pid $target.pid
+# The essence of BPFMAN-42: the target is a bare library name, not
+# an absolute path. The name must be resolved against the
+# container's mount namespace, not bpfman's. --pid engages the
+# /proc/<pid>/maps tier, so the script passes on hosts without
+# /etc/ld.so.cache (e.g. NixOS).
+guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name $tinfo.symbol --pid $target.pid --container-pid $target.pid
 defer bpfman link detach $link
 let linkID = $link.record.id
 
@@ -77,7 +86,7 @@ assert not null $link.record.kernel_link_id
 assert $link.status.kernel_seen
 assert $link.status.pin_present
 
-guard linkRet <- bpfman link attach uprobe $progRet libc --fn-name malloc --pid $target.pid --container-pid $target.pid
+guard linkRet <- bpfman link attach uprobe $progRet libbpfmantest --fn-name $tinfo.symbol --pid $target.pid --container-pid $target.pid
 defer bpfman link detach $linkRet
 assert $linkRet.record.id > 0
 assert not null $linkRet.record.kernel_link_id
@@ -100,12 +109,12 @@ guard dumpAfter <- bpftool map dump id $mapID -j
 let after = $dumpAfter.stdout |> jq $counter_filter
 let delta = $after - $before
 let want = $events * $weight
-print "container-uprobe libc-malloc count: got=${delta} want>=${want}"
+print "container-uprobe library-name count: got=${delta} want>=${want}"
 assert $delta >= $want
 
 guard dumpAfterRet <- bpftool map dump id $mapIDRet -j
 let afterRet = $dumpAfterRet.stdout |> jq $counter_filter
 let deltaRet = $afterRet - $beforeRet
 let wantRet = $events * $retweight
-print "container-uretprobe libc-malloc count: got=${deltaRet} want>=${wantRet}"
+print "container-uretprobe library-name count: got=${deltaRet} want>=${wantRet}"
 assert $deltaRet >= $wantRet

--- a/e2e/scripts/TestContainerUprobe_PodStyleNamespaces.bpfman
+++ b/e2e/scripts/TestContainerUprobe_PodStyleNamespaces.bpfman
@@ -1,0 +1,125 @@
+# -*- mode: bpfman -*-
+#
+# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
+#
+# Container uprobe library-name resolution against a
+# kube-faithful target: its own mount AND pid namespaces, a
+# pivot_root'd rootfs (what real runtimes do -- setns into a merely
+# chroot'd namespace lands at the host root, so chroot would lie),
+# a container-scoped /proc, and a synthetic /etc/ld.so.cache whose
+# entry names a path that exists nowhere on the host.
+#
+# The rootfs carries: the worker's loader closure (top-level
+# directories derived from ldd, so /nix on NixOS, /lib and /usr on
+# conventional distros -- no distro paths are encoded here),
+# /worker (bind of bpfman-shell), /data (bind shared with the host
+# for the wave protocol), /testlib/libbpfmantest.so.1 (bind of the
+# real libc, preserving the inode the worker's mallocs run from),
+# /etc/ld.so.cache (synthetic, sole entry libbpfmantest.so.1 ->
+# /testlib/libbpfmantest.so.1), and /proc scoped to the new pid
+# namespace (mounted before the pivot -- the pid namespace is
+# already ours -- so nothing external runs after pivot_root and no
+# binary needs a rootfs-internal path). The old root stays mounted
+# at /old: hiding it is cosmetic, and what the test discriminates
+# -- which cache resolves the bare name -- does not depend on it.
+#
+# Given: a fire worker running as pid 1 of its own pid namespace
+# inside that rootfs
+#
+# When: a uprobe is attached to malloc with the bare name target
+# "libbpfmantest" via --container-pid (no --pid: only the
+# namespace's cache can resolve it, and the cache's value path is
+# meaningless outside the namespace)
+#
+# Then: the attach succeeds and firing the worker advances the
+# pid-filtered counter map by at least events * weight
+
+import ../lib.bpfman
+
+let events = 5
+let weight = 13
+
+guard wd <- tempdir container-uprobe-podstyle
+defer exec rm -rf $wd.path
+let cachefile = "${wd.path}/ld.so.cache"
+let rootfs = "${wd.path}/rootfs"
+let data = "${wd.path}/data"
+
+guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
+assert path-exists $shell_path.stdout
+
+guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
+assert path-exists $libc.stdout
+
+exec mkdir -p "${rootfs}/proc" "${rootfs}/etc" "${rootfs}/testlib" "${rootfs}/data" "${rootfs}/old" $data
+
+# The worker's loader closure as bind commands: every top-level
+# directory ldd names gets a mountpoint in the rootfs and a bind
+# fragment for the namespace assembly below. Derived, not encoded,
+# so the same script works on any distro layout.
+guard libbinds <- exec sh -c 'r=$1; bin=$2; out=""; for d in $(ldd "$bin" 2>/dev/null | grep -o "/[^ ]*" | xargs -rn1 dirname | cut -d/ -f2 | sort -u); do mkdir -p "$r/$d" && out="$out mount --bind /$d $r/$d && "; done; printf %s "$out"' sh $rootfs $shell_path.stdout
+exec touch "${rootfs}/worker" "${rootfs}/testlib/libbpfmantest.so.1"
+exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libbpfmantest.so.1=/testlib/libbpfmantest.so.1"
+exec cp $cachefile "${rootfs}/etc/ld.so.cache"
+
+# Assemble the container: private propagation, binds (closure,
+# data, libc, worker), pid-ns-scoped /proc mounted pre-pivot,
+# pivot_root, then straight into the worker -- sh builtins only
+# after the pivot, so no binary needs a rootfs-internal path (the
+# assignment-prefix exec likewise avoids needing env(1)).
+let nssetup = "mount --make-rprivate / && mount --bind '${rootfs}' '${rootfs}' && ${libbinds.stdout}mount --bind '${data}' '${rootfs}/data' && mount --bind '${libc.stdout}' '${rootfs}/testlib/libbpfmantest.so.1' && mount --bind '${shell_path.stdout}' '${rootfs}/worker' && mount -t proc proc '${rootfs}/proc' && cd '${rootfs}' && pivot_root . old && BPFMAN_SHELL_MODE=uprobe-fire-worker exec /worker /data/sentinel /data/ack ${events} 1"
+guard target <- start unshare --mount --pid --fork -- sh -c $nssetup
+defer kill $target
+
+# --pid forces --fork, so $target.pid is unshare; the worker is its
+# child. Wait for the fork, then for the exec (comm flips to
+# "worker") which marks the namespace assembly complete.
+poll timeout 5s every 100ms {
+    let c <- exec sh -c "pgrep -P ${target.pid} | head -n1 | tr -d '[:space:]'"
+    retry "waiting for pod child" unless $c.stdout != ""
+}
+guard cpid <- exec sh -c "pgrep -P ${target.pid} | head -n1 | tr -d '[:space:]'"
+defer exec sh -c "kill ${cpid.stdout} 2>/dev/null || true"
+poll timeout 5s every 100ms {
+    let comm <- exec sh -c "cat /proc/${cpid.stdout}/comm 2>/dev/null | tr -d '[:space:]'"
+    retry "waiting for worker exec" unless $comm.stdout == "worker"
+}
+
+# The worker is pid 1 in its own namespace; its host pid is what
+# both the BPF-side filter (root-namespace tgid) and container-pid
+# want.
+let cpidn = $cpid.stdout |> jq "tonumber"
+
+guard loaded <- bpfman program load file testdata/bpf/uprobe_exact.bpf.o --programs uprobe:uprobe_counter -g "expected_pid=0x${u32le $cpidn}" -g "weight=0x${u64le $weight}"
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+defer bpfman program unload $pid
+
+# The essence: a bare name only the container's cache knows, whose
+# resolved path only the container's rootfs contains.
+guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name malloc --container-pid $cpidn
+defer bpfman link detach $link
+let linkID = $link.record.id
+
+assert $link.record.id > 0
+assert not null $link.record.kernel_link_id
+assert $link.status.kernel_seen
+assert $link.status.pin_present
+
+let mapID = $prog |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
+let counter_filter = "fromjson | .[0].formatted.value | tonumber"
+
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $counter_filter
+
+exec touch "${data}/sentinel.1"
+poll timeout 5s every 100ms {
+    await_wave_completion "${data}/ack" 1
+}
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $counter_filter
+let delta = $after - $before
+let want = $events * $weight
+print "container-uprobe pod-style count: got=${delta} want>=${want}"
+assert $delta >= $want

--- a/e2e/scripts/TestContainerUprobe_PodStyleNamespaces.bpfman
+++ b/e2e/scripts/TestContainerUprobe_PodStyleNamespaces.bpfman
@@ -13,8 +13,10 @@
 # directories derived from ldd, so /nix on NixOS, /lib and /usr on
 # conventional distros -- no distro paths are encoded here),
 # /worker (bind of bpfman-shell), /data (bind shared with the host
-# for the wave protocol), /testlib/libbpfmantest.so.1 (bind of the
-# real libc, preserving the inode the worker's mallocs run from),
+# for the wave protocol), /testlib/libbpfmantest.so.1 (a second
+# bind of the worker's own binary, preserving the inode its cgo
+# fixture symbol executes from -- static-linking-proof, where a
+# libc bind would not be),
 # /etc/ld.so.cache (synthetic, sole entry libbpfmantest.so.1 ->
 # /testlib/libbpfmantest.so.1), and /proc scoped to the new pid
 # namespace (mounted before the pivot -- the pid namespace is
@@ -48,8 +50,7 @@ let data = "${wd.path}/data"
 guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
 assert path-exists $shell_path.stdout
 
-guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
-assert path-exists $libc.stdout
+guard tinfo <- uprobe-target
 
 exec mkdir -p "${rootfs}/proc" "${rootfs}/etc" "${rootfs}/testlib" "${rootfs}/data" "${rootfs}/old" $data
 
@@ -67,7 +68,7 @@ exec cp $cachefile "${rootfs}/etc/ld.so.cache"
 # pivot_root, then straight into the worker -- sh builtins only
 # after the pivot, so no binary needs a rootfs-internal path (the
 # assignment-prefix exec likewise avoids needing env(1)).
-let nssetup = "mount --make-rprivate / && mount --bind '${rootfs}' '${rootfs}' && ${libbinds.stdout}mount --bind '${data}' '${rootfs}/data' && mount --bind '${libc.stdout}' '${rootfs}/testlib/libbpfmantest.so.1' && mount --bind '${shell_path.stdout}' '${rootfs}/worker' && mount -t proc proc '${rootfs}/proc' && cd '${rootfs}' && pivot_root . old && BPFMAN_SHELL_MODE=uprobe-fire-worker exec /worker /data/sentinel /data/ack ${events} 1"
+let nssetup = "mount --make-rprivate / && mount --bind '${rootfs}' '${rootfs}' && ${libbinds.stdout}mount --bind '${data}' '${rootfs}/data' && mount --bind '${shell_path.stdout}' '${rootfs}/testlib/libbpfmantest.so.1' && mount --bind '${shell_path.stdout}' '${rootfs}/worker' && mount -t proc proc '${rootfs}/proc' && cd '${rootfs}' && pivot_root . old && BPFMAN_SHELL_MODE=uprobe-fire-worker exec /worker /data/sentinel /data/ack ${events} 1"
 guard target <- start unshare --mount --pid --fork -- sh -c $nssetup
 defer kill $target
 
@@ -97,7 +98,7 @@ defer bpfman program unload $pid
 
 # The essence: a bare name only the container's cache knows, whose
 # resolved path only the container's rootfs contains.
-guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name malloc --container-pid $cpidn
+guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name $tinfo.symbol --container-pid $cpidn
 defer bpfman link detach $link
 let linkID = $link.record.id
 

--- a/e2e/scripts/TestContainerUprobe_SyntheticLdSoCache.bpfman
+++ b/e2e/scripts/TestContainerUprobe_SyntheticLdSoCache.bpfman
@@ -8,19 +8,21 @@
 # This is the discriminating test for where resolution runs. The
 # target namespace gets a synthetic ld.so.cache (tmpfs over /etc)
 # whose only entry maps a library name no host cache has --
-# libbpfmantest -- to a namespace-private bind mount of the real
-# libc. Resolution done inside the namespace finds it; resolution
-# done in the host's namespace cannot, on any distro. The bind
-# mount preserves the libc inode the fire worker executes, so the
-# malloc uprobe still counts real traffic.
+# libbpfmantest -- to a namespace-private bind mount of the fire
+# worker's own binary. Resolution done inside the namespace finds
+# it; resolution done in the host's namespace cannot, on any
+# distro. The bind preserves the worker's executable inode, so a
+# probe on its cgo fixture symbol counts real traffic -- and does
+# so whether bpfman-shell is linked dynamically or statically (CI
+# builds it static, so a libc probe would never fire).
 #
-# Given: a cgo-linked target process in its own mount namespace,
-# with a synthetic /etc/ld.so.cache mapping libbpfmantest.so.1 to
-# a namespace-private bind of the worker's real libc
+# Given: a target process in its own mount namespace, with a
+# synthetic /etc/ld.so.cache mapping libbpfmantest.so.1 to a
+# namespace-private bind of the worker's own binary
 #
-# When: a uprobe is attached to function malloc with the bare name
-# target "libbpfmantest" via --container-pid (no --pid, so the
-# maps tier cannot answer; only the namespace's cache can)
+# When: a uprobe is attached to the fixture symbol with the bare
+# name target "libbpfmantest" via --container-pid (no --pid, so
+# the maps tier cannot answer; only the namespace's cache can)
 #
 # Then: the attach succeeds and firing the target advances the
 # pid-filtered counter map by at least events * weight
@@ -39,12 +41,7 @@ let bindtgt = "${wd.path}/libbpfmantest.so.1"
 
 guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
 assert path-exists $shell_path.stdout
-
-# The worker's real libc: the bind-mount source, so the synthetic
-# cache entry resolves to the same inode the worker's mallocs run
-# from.
-guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
-assert path-exists $libc.stdout
+guard tinfo <- uprobe-target
 
 # Fabricate the cache and the bind mountpoint on the shared
 # filesystem; the mounts below are what make them namespace-private.
@@ -55,7 +52,7 @@ exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libb
 # host /etc behind a tmpfs, install the synthetic cache, bind the
 # real libc at the path the cache advertises, then become the fire
 # worker (exec keeps the pid).
-let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${libc.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
+let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${shell_path.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
 guard target <- start unshare -m -- sh -c $nssetup
 defer kill $target
 
@@ -73,7 +70,7 @@ defer bpfman program unload $pid
 # No --pid: the maps tier is unavailable, so only the namespace's
 # synthetic cache can resolve the name. This line is where a
 # host-side resolver fails on every distro.
-guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name malloc --container-pid $target.pid
+guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name $tinfo.symbol --container-pid $target.pid
 defer bpfman link detach $link
 let linkID = $link.record.id
 

--- a/e2e/scripts/TestContainerUprobe_SyntheticLdSoCache.bpfman
+++ b/e2e/scripts/TestContainerUprobe_SyntheticLdSoCache.bpfman
@@ -1,0 +1,101 @@
+# -*- mode: bpfman -*-
+#
+# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
+#
+# Bare library-name resolution for a container uprobe
+# must consult the CONTAINER's /etc/ld.so.cache, not the host's.
+#
+# This is the discriminating test for where resolution runs. The
+# target namespace gets a synthetic ld.so.cache (tmpfs over /etc)
+# whose only entry maps a library name no host cache has --
+# libbpfmantest -- to a namespace-private bind mount of the real
+# libc. Resolution done inside the namespace finds it; resolution
+# done in the host's namespace cannot, on any distro. The bind
+# mount preserves the libc inode the fire worker executes, so the
+# malloc uprobe still counts real traffic.
+#
+# Given: a cgo-linked target process in its own mount namespace,
+# with a synthetic /etc/ld.so.cache mapping libbpfmantest.so.1 to
+# a namespace-private bind of the worker's real libc
+#
+# When: a uprobe is attached to function malloc with the bare name
+# target "libbpfmantest" via --container-pid (no --pid, so the
+# maps tier cannot answer; only the namespace's cache can)
+#
+# Then: the attach succeeds and firing the target advances the
+# pid-filtered counter map by at least events * weight
+
+import ../lib.bpfman
+
+let events = 5
+let weight = 13
+
+guard wd <- tempdir container-uprobe-synthetic-cache
+defer exec rm -rf $wd.path
+let sentinel = "${wd.path}/sentinel"
+let ack = "${wd.path}/ack"
+let cachefile = "${wd.path}/ld.so.cache"
+let bindtgt = "${wd.path}/libbpfmantest.so.1"
+
+guard shell_path <- exec sh -c 'p=$(command -v bpfman-shell); printf %s "$p"'
+assert path-exists $shell_path.stdout
+
+# The worker's real libc: the bind-mount source, so the synthetic
+# cache entry resolves to the same inode the worker's mallocs run
+# from.
+guard libc <- exec sh -c 'ldd "$(command -v bpfman-shell)" | grep -o "/[^ ]*libc.so[^ ]*" | head -n1 | tr -d "[:space:]"'
+assert path-exists $libc.stdout
+
+# Fabricate the cache and the bind mountpoint on the shared
+# filesystem; the mounts below are what make them namespace-private.
+exec touch $bindtgt
+exec env BPFMAN_SHELL_MODE=ldso-cache-writer $shell_path.stdout $cachefile "libbpfmantest.so.1=${bindtgt}"
+
+# Inside the new mount namespace (private propagation): hide the
+# host /etc behind a tmpfs, install the synthetic cache, bind the
+# real libc at the path the cache advertises, then become the fire
+# worker (exec keeps the pid).
+let nssetup = "mount -t tmpfs tmpfs /etc && cp '${cachefile}' /etc/ld.so.cache && mount --bind '${libc.stdout}' '${bindtgt}' && exec env BPFMAN_SHELL_MODE=uprobe-fire-worker '${shell_path.stdout}' '${sentinel}' '${ack}' ${events} 1"
+guard target <- start unshare -m -- sh -c $nssetup
+defer kill $target
+
+guard self_ns <- exec readlink /proc/self/ns/mnt
+poll timeout 5s every 100ms {
+    let target_ns <- exec readlink "/proc/${target.pid}/ns/mnt"
+    retry "waiting for target mount namespace switch" unless $target_ns.stdout != $self_ns.stdout
+}
+
+guard loaded <- bpfman program load file testdata/bpf/uprobe_exact.bpf.o --programs uprobe:uprobe_counter -g "expected_pid=0x${u32le $target.pid}" -g "weight=0x${u64le $weight}"
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+defer bpfman program unload $pid
+
+# No --pid: the maps tier is unavailable, so only the namespace's
+# synthetic cache can resolve the name. This line is where a
+# host-side resolver fails on every distro.
+guard link <- bpfman link attach uprobe $prog libbpfmantest --fn-name malloc --container-pid $target.pid
+defer bpfman link detach $link
+let linkID = $link.record.id
+
+assert $link.record.id > 0
+assert not null $link.record.kernel_link_id
+assert $link.status.kernel_seen
+assert $link.status.pin_present
+
+let mapID = $prog |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
+let counter_filter = "fromjson | .[0].formatted.value | tonumber"
+
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $counter_filter
+
+exec touch "${sentinel}.1"
+poll timeout 5s every 100ms {
+    await_wave_completion $ack 1
+}
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $counter_filter
+let delta = $after - $before
+let want = $events * $weight
+print "container-uprobe synthetic-cache count: got=${delta} want>=${want}"
+assert $delta >= $want

--- a/internal/bpfman/ns/runner/runner.go
+++ b/internal/bpfman/ns/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/bpfman/bpfman/internal/bpfman/ns"
+	"github.com/bpfman/bpfman/internal/libresolve"
 	"github.com/bpfman/bpfman/lock"
 )
 
@@ -27,11 +28,12 @@ type NSCmd struct {
 	Uprobe NSUprobeCmd `cmd:"" help:"Attach a uprobe program in the given container."`
 }
 
-// NSUprobeCmd opens the target binary in the container's mount namespace
-// and returns its fd to the parent. When this code runs, the process is
-// already in the target namespace (switched by the CGO constructor before
-// Go started), so the binary path resolves against the container's
-// filesystem.
+// NSUprobeCmd resolves and opens the target binary in the container's
+// mount namespace and returns its fd to the parent. When this code
+// runs, the process is already in the target namespace (switched by
+// the CGO constructor before Go started), so both the dynamic-linker
+// cache consulted for a bare library name and the final path resolve
+// against the container's filesystem.
 //
 // The parent passes a Unix socket via fd 3 (ExtraFiles[0]); the child sends
 // the opened target-binary fd back over it. The parent, in bpfman's own
@@ -39,12 +41,14 @@ type NSCmd struct {
 // link create and pin there, where the kernel reliably exposes a pinnable
 // perf-event bpf_link. The function name, offset, and retprobe flag are not
 // needed here -- the parent owns the attach -- so the child takes only the
-// target path.
+// target.
 type NSUprobeCmd struct {
-	// Target is the path of the binary to open. It resolves against the
-	// container's filesystem because the C constructor already switched
-	// the process into the target mount namespace before parsing.
-	Target string `arg:"" help:"Target binary path (resolved in container namespace)."`
+	// Target is the binary to open: an absolute path, or a bare
+	// library name (e.g. libc) resolved through the container's
+	// /etc/ld.so.cache. Both resolve against the container's
+	// filesystem because the C constructor already switched the
+	// process into the target mount namespace before parsing.
+	Target string `arg:"" help:"Absolute target path, or a library name resolved in the container namespace."`
 }
 
 // getMntNsInode returns the inode of a mount namespace file.
@@ -129,14 +133,33 @@ func (cmd *NSUprobeCmd) Run() error {
 	}
 	defer socket.Close()
 
-	// Open the target binary in the container's mount namespace. Only this
-	// path resolution needs the target namespace; the parent performs the
-	// uprobe attach and pin in bpfman's own namespace, reaching this same
-	// inode through /proc/self/fd of the fd sent below.
-	target, err := os.Open(cmd.Target)
+	// Resolve a bare library-name target through the dynamic
+	// linker's cache. The setns into the container's mount namespace
+	// has already happened (CGO constructor), so /etc/ld.so.cache
+	// here is the container's -- the same view aya resolved against
+	// in the Rust implementation. Absolute paths pass through, and
+	// the maps tier is not run here: its pid would be a host pid,
+	// which this namespace's procfs cannot interpret, so the parent
+	// runs that tier before spawning us.
+	resolved, err := libresolve.Default.Resolve(cmd.Target, 0)
 	if err != nil {
-		logger.Error("failed to open target binary in container namespace", "target", cmd.Target, "error", err, "current_mnt_ns_inode", currentMntNs, "hint", "ensure the target path exists in the container's filesystem")
-		return fmt.Errorf("open target binary %q in container (mnt ns inode %d): %w", cmd.Target, currentMntNs, err)
+		logger.Error("failed to resolve target in container namespace", "target", cmd.Target, "error", err, "current_mnt_ns_inode", currentMntNs, "hint", "ensure the container has an /etc/ld.so.cache naming the library, or pass an absolute path")
+		return fmt.Errorf("resolve target %q in container (mnt ns inode %d): %w", cmd.Target, currentMntNs, err)
+	}
+
+	if resolved.Source != libresolve.SourceAbsolutePath {
+		logger.Info("resolved target in container namespace", "target", cmd.Target, "path", resolved.Path, "source", resolved.Source.String())
+	}
+
+	// Open the target binary in the container's mount namespace. Only
+	// resolution and this open need the target namespace; the parent
+	// performs the uprobe attach and pin in bpfman's own namespace,
+	// reaching this same inode through /proc/self/fd of the fd sent
+	// below.
+	target, err := os.Open(resolved.Path)
+	if err != nil {
+		logger.Error("failed to open target binary in container namespace", "target", resolved.Path, "error", err, "current_mnt_ns_inode", currentMntNs, "hint", "ensure the target path exists in the container's filesystem")
+		return fmt.Errorf("open target binary %q in container (mnt ns inode %d): %w", resolved.Path, currentMntNs, err)
 	}
 
 	defer target.Close()

--- a/internal/libresolve/resolve.go
+++ b/internal/libresolve/resolve.go
@@ -17,7 +17,7 @@
 // running an attacker-supplied library's constructors inside the
 // daemon would be code execution. aya parses the cache for the
 // same reason.
-package ebpf
+package libresolve
 
 import (
 	"bytes"
@@ -32,44 +32,50 @@ import (
 // resolutionSource says which tier resolved a target. Carried on
 // targetResolution so logs and errors can name the decision, not
 // just its outcome.
-type resolutionSource int
+type Source int
 
 const (
-	sourceProcMaps resolutionSource = iota
-	sourceAbsolutePath
-	sourceLdSoCache
+	SourceProcMaps Source = iota
+	SourceAbsolutePath
+	SourceLdSoCache
 )
 
 // String returns a human-readable name for the resolution tier.
-func (s resolutionSource) String() string {
+func (s Source) String() string {
 	switch s {
-	case sourceProcMaps:
+	case SourceProcMaps:
 		return "process maps"
-	case sourceAbsolutePath:
+	case SourceAbsolutePath:
 		return "absolute path"
-	case sourceLdSoCache:
+	case SourceLdSoCache:
 		return "ld.so.cache"
 	default:
-		return fmt.Sprintf("resolutionSource(%d)", int(s))
+		return fmt.Sprintf("Source(%d)", int(s))
 	}
 }
 
-// targetResolution is the resolver's decision as a value: the path
-// to open and the tier that chose it. The caller performs the open.
-type targetResolution struct {
+// Resolution is the resolver's decision as a value: the path to
+// open and the tier that chose it. The caller performs the open.
+type Resolution struct {
 	Path   string
-	Source resolutionSource
+	Source Source
 }
 
-// targetResolver is the imperative shell: it owns the two file
-// reads and the tier order, nothing else. The zero-value paths are
-// only for tests; production uses defaultTargetResolver.
-type targetResolver struct {
-	procRoot  string
-	cachePath string
+// Resolver is the imperative shell: it owns the two file reads and
+// the tier order, nothing else. The zero-value paths are only for
+// tests; production uses Default or derives ProcRoot from the same
+// /proc-vs-/host/proc decision as the container namespace lookup.
+type Resolver struct {
+	ProcRoot  string
+	CachePath string
 }
 
-var defaultTargetResolver = targetResolver{procRoot: "/proc", cachePath: "/etc/ld.so.cache"}
+// Default resolves against the calling process's own view of the
+// world. For a local uprobe that is bpfman's namespace; inside the
+// bpfman-ns helper, which has already setns'd into the container's
+// mount namespace, the same paths dereference against the
+// container's filesystem.
+var Default = Resolver{ProcRoot: "/proc", CachePath: "/etc/ld.so.cache"}
 
 // resolve maps target to a probeable path using aya's tier order:
 // a pid's mapped libraries first (a library name names the copy
@@ -78,36 +84,60 @@ var defaultTargetResolver = targetResolver{procRoot: "/proc", cachePath: "/etc/l
 // pid is an error rather than a fallthrough -- the caller asked
 // about that process, and resolving the name some other way could
 // silently probe a different library than the one mapped.
-func (r targetResolver) resolve(target string, pid int32) (targetResolution, error) {
+func (r Resolver) Resolve(target string, pid int32) (Resolution, error) {
 	if pid > 0 {
-		mapsPath := filepath.Join(r.procRoot, strconv.Itoa(int(pid)), "maps")
-		data, err := os.ReadFile(mapsPath)
+		path, ok, err := r.FromMaps(target, pid)
 		if err != nil {
-			return targetResolution{}, fmt.Errorf("resolve target %q: read %s: %w", target, mapsPath, err)
+			return Resolution{}, err
 		}
-
-		if path, ok := libFromMaps(data, target); ok {
-			return targetResolution{Path: path, Source: sourceProcMaps}, nil
+		if ok {
+			return Resolution{Path: path, Source: SourceProcMaps}, nil
 		}
 	}
 	if filepath.IsAbs(target) {
-		return targetResolution{Path: target, Source: sourceAbsolutePath}, nil
+		return Resolution{Path: target, Source: SourceAbsolutePath}, nil
 	}
-	data, err := os.ReadFile(r.cachePath)
+
+	data, err := os.ReadFile(r.CachePath)
 	if err != nil {
-		return targetResolution{}, fmt.Errorf("resolve target %q: read %s: %w", target, r.cachePath, err)
+		return Resolution{}, fmt.Errorf("resolve target %q: read %s: %w", target, r.CachePath, err)
 	}
 
 	entries, err := parseLdSoCache(data)
 	if err != nil {
-		return targetResolution{}, fmt.Errorf("resolve target %q: parse %s: %w", target, r.cachePath, err)
+		return Resolution{}, fmt.Errorf("resolve target %q: parse %s: %w", target, r.CachePath, err)
 	}
 
 	path, ok := resolveLibName(entries, target)
 	if !ok {
-		return targetResolution{}, fmt.Errorf("resolve target %q: not found in %s (pass an absolute path)", target, r.cachePath)
+		return Resolution{}, fmt.Errorf("resolve target %q: not found in %s (pass an absolute path)", target, r.CachePath)
 	}
-	return targetResolution{Path: path, Source: sourceLdSoCache}, nil
+
+	return Resolution{Path: path, Source: SourceLdSoCache}, nil
+}
+
+// FromMaps runs only the maps tier: the queried library among the
+// files pid has mapped. It exists separately from Resolve for the
+// container attach path, where the tiers run on opposite sides of
+// the namespace boundary -- the maps tier in the parent, whose
+// procfs can interpret a host pid, and the cache tier in the
+// helper, whose /etc/ld.so.cache is the container's. A maps read
+// failure for a requested pid is an error rather than a
+// fallthrough, as in Resolve. pid <= 0 reports no match.
+func (r Resolver) FromMaps(target string, pid int32) (string, bool, error) {
+	if pid <= 0 {
+		return "", false, nil
+	}
+
+	mapsPath := filepath.Join(r.ProcRoot, strconv.Itoa(int(pid)), "maps")
+
+	data, err := os.ReadFile(mapsPath)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve target %q: read %s: %w", target, mapsPath, err)
+	}
+
+	path, ok := libFromMaps(data, target)
+	return path, ok, nil
 }
 
 // libFromMaps finds the first mapped file in /proc/<pid>/maps text

--- a/internal/libresolve/resolve_test.go
+++ b/internal/libresolve/resolve_test.go
@@ -1,4 +1,4 @@
-package ebpf
+package libresolve
 
 import (
 	"encoding/binary"
@@ -206,7 +206,7 @@ func TestLibFromMaps(t *testing.T) {
 
 // writeResolverFixture lays out a fake procRoot and cache file for
 // shell-level tier tests.
-func writeResolverFixture(t *testing.T, pid string, maps string, cache []byte) targetResolver {
+func writeResolverFixture(t *testing.T, pid string, maps string, cache []byte) Resolver {
 	t.Helper()
 	dir := t.TempDir()
 	procRoot := filepath.Join(dir, "proc")
@@ -225,7 +225,7 @@ func writeResolverFixture(t *testing.T, pid string, maps string, cache []byte) t
 			t.Fatal(err)
 		}
 	}
-	return targetResolver{procRoot: procRoot, cachePath: cachePath}
+	return Resolver{ProcRoot: procRoot, CachePath: cachePath}
 }
 
 func TestResolveUprobeTarget_TierOrder(t *testing.T) {
@@ -236,25 +236,25 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("pid present and lib mapped wins over cache", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "1234", fixtureMaps, cache)
-		res, err := r.resolve("libc", 1234)
+		res, err := r.Resolve("libc", 1234)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res.Path != "/usr/lib64/libc.so.6" || res.Source != sourceProcMaps {
+		if res.Path != "/usr/lib64/libc.so.6" || res.Source != SourceProcMaps {
 			t.Fatalf("got %+v", res)
 		}
 	})
 
 	t.Run("absolute path used as-is without reads", func(t *testing.T) {
 		t.Parallel()
-		r := targetResolver{procRoot: "/nonexistent", cachePath: "/nonexistent"}
-		res, err := r.resolve("/usr/bin/thing", 0)
+		r := Resolver{ProcRoot: "/nonexistent", CachePath: "/nonexistent"}
+		res, err := r.Resolve("/usr/bin/thing", 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res.Path != "/usr/bin/thing" || res.Source != sourceAbsolutePath {
+		if res.Path != "/usr/bin/thing" || res.Source != SourceAbsolutePath {
 			t.Fatalf("got %+v", res)
 		}
 	})
@@ -262,12 +262,12 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("bare name with no pid resolves via cache", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "0", "", cache)
-		res, err := r.resolve("libc", 0)
+		res, err := r.Resolve("libc", 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res.Path != "/from/cache/libc.so.6" || res.Source != sourceLdSoCache {
+		if res.Path != "/from/cache/libc.so.6" || res.Source != SourceLdSoCache {
 			t.Fatalf("got %+v", res)
 		}
 	})
@@ -275,12 +275,12 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("pid present but lib unmapped falls through to cache", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "1234", "7f00-7f01 r-xp 00000000 00:21 1 /usr/lib64/libssl.so.3\n", cache)
-		res, err := r.resolve("libc", 1234)
+		res, err := r.Resolve("libc", 1234)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if res.Path != "/from/cache/libc.so.6" || res.Source != sourceLdSoCache {
+		if res.Path != "/from/cache/libc.so.6" || res.Source != SourceLdSoCache {
 			t.Fatalf("got %+v", res)
 		}
 	})
@@ -288,7 +288,7 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("pid present but maps unreadable is an error", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "9999", "", cache) // no maps file for 1234
-		_, err := r.resolve("libc", 1234)
+		_, err := r.Resolve("libc", 1234)
 		if err == nil {
 			t.Fatal("an unreadable maps file for a requested pid must not silently fall through")
 		}
@@ -297,7 +297,7 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("name missing from cache is a designed error naming the target", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "0", "", cache)
-		_, err := r.resolve("libnope", 0)
+		_, err := r.Resolve("libnope", 0)
 		if err == nil {
 			t.Fatal("want error")
 		}
@@ -309,7 +309,41 @@ func TestResolveUprobeTarget_TierOrder(t *testing.T) {
 	t.Run("unreadable cache surfaces as an error", func(t *testing.T) {
 		t.Parallel()
 		r := writeResolverFixture(t, "0", "", nil) // no cache file
-		_, err := r.resolve("libc", 0)
+		_, err := r.Resolve("libc", 0)
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+}
+
+func TestFromMaps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pid zero reports no match without touching procfs", func(t *testing.T) {
+		t.Parallel()
+		r := Resolver{ProcRoot: "/nonexistent"}
+		path, ok, err := r.FromMaps("libc", 0)
+		if err != nil || ok || path != "" {
+			t.Fatalf("got (%q, %v, %v), want no match and no error", path, ok, err)
+		}
+	})
+
+	t.Run("mapped library resolves", func(t *testing.T) {
+		t.Parallel()
+		r := writeResolverFixture(t, "1234", fixtureMaps, nil)
+		path, ok, err := r.FromMaps("libc", 1234)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok || path != "/usr/lib64/libc.so.6" {
+			t.Fatalf("got (%q, %v)", path, ok)
+		}
+	})
+
+	t.Run("unreadable maps is an error, not a fallthrough", func(t *testing.T) {
+		t.Parallel()
+		r := writeResolverFixture(t, "9999", "", nil)
+		_, _, err := r.FromMaps("libc", 1234)
 		if err == nil {
 			t.Fatal("want error")
 		}

--- a/manager/attach_test.go
+++ b/manager/attach_test.go
@@ -3187,14 +3187,13 @@ func TestUprobe_NeitherFnNameNorOffset_Fails(t *testing.T) {
 	assert.Equal(t, 0, fix.Kernel.LinkCount(), "rejection must happen before any kernel attach")
 }
 
-// TestUprobe_ContainerLibraryNameRejected pins the deferred scope
-// boundary: library-name resolution happens in bpfman's own
-// namespace, but a container uprobe's target is opened inside the
-// container's mount namespace, where no resolution is implemented.
-// A bare name with --container-pid must be a designed error before
-// any helper spawns, not a literal-path open failure inside the
-// child.
-func TestUprobe_ContainerLibraryNameRejected(t *testing.T) {
+// TestUprobe_ContainerLibraryNameDelegated pins the manager-level
+// contract for bare library names with --container-pid: the manager
+// neither resolves nor rejects them. Resolution is the platform's
+// attach-time concern (the maps tier in the parent, the container's
+// ld.so.cache in the bpfman-ns helper), and the link record keeps
+// the user's spelling of the target.
+func TestUprobe_ContainerLibraryNameDelegated(t *testing.T) {
 	t.Parallel()
 
 	fix := newTestFixture(t)
@@ -3209,8 +3208,14 @@ func TestUprobe_ContainerLibraryNameRejected(t *testing.T) {
 	require.NoError(t, err)
 	attachSpec = attachSpec.WithFnName("malloc")
 
-	_, err = fix.Attach(ctx, attachSpec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "container uprobe target must be an absolute path")
-	assert.Equal(t, 0, fix.Kernel.LinkCount())
+	link, err := fix.Attach(ctx, attachSpec)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fix.Kernel.LinkCount())
+
+	record, err := fix.Store.GetLink(ctx, link.Record.ID)
+	require.NoError(t, err)
+	details, ok := record.Details.(bpfman.UprobeDetails)
+	require.True(t, ok, "expected UprobeDetails")
+	assert.Equal(t, "libc", details.Target, "the raw target spelling persists; resolution is attach-time only")
+	assert.Equal(t, int32(4242), details.ContainerPid)
 }

--- a/manager/attach_tracing.go
+++ b/manager/attach_tracing.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"slices"
 
 	"github.com/bpfman/bpfman"
@@ -113,13 +112,6 @@ func (m *Manager) attachUprobe(ctx context.Context, scope lock.WriterScope, spec
 			retprobe := prog.Load.ProgramType() == bpfman.ProgramTypeUretprobe
 			if fnName == "" && offset == 0 {
 				return attachPlan{}, fmt.Errorf("uprobe attach requires a function name or a non-zero offset")
-			}
-			// Library-name resolution runs in bpfman's own
-			// namespace, but a container uprobe's target is
-			// opened inside the container's mount namespace,
-			// where no resolution is implemented.
-			if containerPid > 0 && !filepath.IsAbs(binaryTarget) {
-				return attachPlan{}, fmt.Errorf("container uprobe target must be an absolute path (got %q; library-name resolution is not supported inside containers)", binaryTarget)
 			}
 			if containerPid > 0 && scope == nil {
 				return attachPlan{}, fmt.Errorf("container uprobe requires lock scope (containerPid=%d)", containerPid)

--- a/platform/ebpf/attach_uprobe.go
+++ b/platform/ebpf/attach_uprobe.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/bpfman/bpfman"
 	"github.com/bpfman/bpfman/internal/bpfman/ns"
+	"github.com/bpfman/bpfman/internal/libresolve"
 	"github.com/bpfman/bpfman/kernel"
 	"github.com/bpfman/bpfman/lock"
 )
@@ -97,12 +98,12 @@ func (k *kernelAdapter) doAttachUprobeLocal(progPinPath, target, fnName string, 
 	}
 	defer prog.Close()
 
-	resolved, err := defaultTargetResolver.resolve(target, pid)
+	resolved, err := libresolve.Default.Resolve(target, pid)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	if resolved.Source != sourceAbsolutePath {
+	if resolved.Source != libresolve.SourceAbsolutePath {
 		k.logger.Debug("resolved uprobe target", "target", target, "path", resolved.Path, "source", resolved.Source.String())
 	}
 

--- a/platform/ebpf/attach_uprobe.go
+++ b/platform/ebpf/attach_uprobe.go
@@ -88,16 +88,11 @@ func uprobeOptions(fnName string, offset uint64, pid int32) (string, *link.Uprob
 	return fnName, &link.UprobeOptions{Offset: offset, PID: int(pid)}
 }
 
-// doAttachUprobeLocal attaches a uprobe directly (no namespace switching).
-// pid > 0 scopes the perf event to that process; cilium maps 0 to
-// "all threads", so the unfiltered default needs no special-casing.
+// doAttachUprobeLocal resolves the target in bpfman's own namespace
+// and attaches (no namespace switching). pid > 0 scopes the perf
+// event to that process; cilium maps 0 to "all threads", so the
+// unfiltered default needs no special-casing.
 func (k *kernelAdapter) doAttachUprobeLocal(progPinPath, target, fnName string, offset uint64, pid int32, retprobe bool, linkPinPath string) (kernel.LinkID, *kernel.Link, error) {
-	prog, err := ebpf.LoadPinnedProgram(progPinPath, nil)
-	if err != nil {
-		return 0, nil, fmt.Errorf("load pinned program %s: %w", progPinPath, err)
-	}
-	defer prog.Close()
-
 	resolved, err := libresolve.Default.Resolve(target, pid)
 	if err != nil {
 		return 0, nil, err
@@ -107,9 +102,26 @@ func (k *kernelAdapter) doAttachUprobeLocal(progPinPath, target, fnName string, 
 		k.logger.Debug("resolved uprobe target", "target", target, "path", resolved.Path, "source", resolved.Source.String())
 	}
 
-	ex, err := link.OpenExecutable(resolved.Path)
+	return k.doAttachUprobeResolved(progPinPath, resolved.Path, fnName, offset, pid, retprobe, linkPinPath)
+}
+
+// doAttachUprobeResolved attaches a uprobe to an already-resolved
+// path, keeping pid for the perf-event filter only. The container
+// path lands here with /proc/self/fd of the helper-opened target:
+// resolution has already happened on the correct side of the
+// namespace boundary, and re-running it would read the pid's maps
+// through bpfman's own procfs -- unreadable in a daemonset pod, and
+// answering a question the open fd has already settled.
+func (k *kernelAdapter) doAttachUprobeResolved(progPinPath, path, fnName string, offset uint64, pid int32, retprobe bool, linkPinPath string) (kernel.LinkID, *kernel.Link, error) {
+	prog, err := ebpf.LoadPinnedProgram(progPinPath, nil)
 	if err != nil {
-		return 0, nil, fmt.Errorf("open executable %s: %w", resolved.Path, err)
+		return 0, nil, fmt.Errorf("load pinned program %s: %w", progPinPath, err)
+	}
+	defer prog.Close()
+
+	ex, err := link.OpenExecutable(path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("open executable %s: %w", path, err)
 	}
 
 	symbol, opts := uprobeOptions(fnName, offset, pid)
@@ -121,9 +133,9 @@ func (k *kernelAdapter) doAttachUprobeLocal(progPinPath, target, fnName string, 
 	}
 	if err != nil {
 		if fnName == "" {
-			return 0, nil, fmt.Errorf("attach uprobe at offset %#x in %s: %w", offset, target, err)
+			return 0, nil, fmt.Errorf("attach uprobe at offset %#x in %s: %w", offset, path, err)
 		}
-		return 0, nil, fmt.Errorf("attach uprobe to %s in %s: %w", fnName, target, err)
+		return 0, nil, fmt.Errorf("attach uprobe to %s in %s: %w", fnName, path, err)
 	}
 
 	// Get link info
@@ -165,17 +177,21 @@ func (k *kernelAdapter) doAttachUprobeLocal(progPinPath, target, fnName string, 
 // Go's runtime is multi-threaded and setns(CLONE_NEWNS) requires a
 // single-threaded process. We solve this using a CGO constructor in the
 // bpfman-ns transport that runs before Go's runtime starts. The child does no
-// BPF work; it only opens the target binary, whose path resolves only in the
-// container namespace:
+// BPF work; it only resolves and opens the target, whose path resolves only
+// in the container namespace:
 //
-//  1. Parent creates socketpair for fd passing
-//  2. Parent passes socket via ExtraFiles (fd 3) and the writer lock fd
-//  3. Parent sets _BPFMAN_MNT_NS env var and re-execs itself in bpfman-ns mode
-//  4. Child's C constructor calls setns() before Go runtime starts
-//  5. Child verifies it holds the writer lock
-//  6. Child opens the target binary (visible only in the target namespace)
-//  7. Child sends the target-binary fd back to parent via socket (SCM_RIGHTS)
-//  8. Parent, in its own namespace, attaches and pins the uprobe via
+//  1. Parent resolves a library name via the pid's maps when a pid
+//     filter is given (a host pid only the host's procfs can interpret)
+//  2. Parent creates socketpair for fd passing
+//  3. Parent passes socket via ExtraFiles (fd 3) and the writer lock fd
+//  4. Parent sets _BPFMAN_MNT_NS env var and re-execs itself in bpfman-ns mode
+//  5. Child's C constructor calls setns() before Go runtime starts
+//  6. Child verifies it holds the writer lock
+//  7. Child resolves a still-bare library name via the container's
+//     /etc/ld.so.cache and opens the target (visible only in the
+//     target namespace)
+//  8. Child sends the target-binary fd back to parent via socket (SCM_RIGHTS)
+//  9. Parent, in its own namespace, attaches and pins the uprobe via
 //     /proc/self/fd of the received fd -- the same path as a local uprobe,
 //     where the kernel exposes a pinnable perf-event bpf_link
 func (k *kernelAdapter) attachUprobeViaHelper(scope lock.WriterScope, progPinPath, target, fnName string, offset uint64, pid int32, retprobe bool, linkPinPath string, containerPid int32) (kernel.LinkID, *kernel.Link, error) {
@@ -184,6 +200,41 @@ func (k *kernelAdapter) attachUprobeViaHelper(scope lock.WriterScope, progPinPat
 	if err != nil {
 		k.logger.Error("failed to get executable path", "error", err)
 		return 0, nil, fmt.Errorf("get executable path: %w", err)
+	}
+
+	// Determine target namespace path - try /proc first, then /host/proc
+	// for k8s, where the daemonset has no hostPID and the host's procfs
+	// is volume-mounted at /host/proc. The procfs that can see the
+	// container pid is also the one that can interpret the uprobe's pid
+	// filter for the maps tier below.
+	procRoot := "/proc"
+	nsPath := fmt.Sprintf("/proc/%d/ns/mnt", containerPid)
+	if _, err := os.Stat(nsPath); err != nil {
+		altRoot := "/host/proc"
+		altPath := fmt.Sprintf("%s/%d/ns/mnt", altRoot, containerPid)
+		if _, err := os.Stat(altPath); err != nil {
+			k.logger.Error("container namespace not accessible", "container_pid", containerPid, "tried_paths", []string{nsPath, altPath}, "error", err, "hint", "ensure container PID is valid and /proc or /host/proc is accessible")
+			return 0, nil, fmt.Errorf("container namespace for PID %d not accessible (tried %s and %s): %w", containerPid, nsPath, altPath, err)
+		}
+		nsPath, procRoot = altPath, altRoot
+	}
+
+	// The maps tier of library-name resolution runs here, in the
+	// parent: the pid filter is a host-namespace pid, and inside the
+	// container's mount namespace /proc is numbered in container
+	// pids. The paths in a process's maps are valid in its own mount
+	// namespace, which is where the helper opens them. Absolute
+	// targets pass through; a still-bare name is the helper's to
+	// resolve against the container's /etc/ld.so.cache after setns.
+	if pid > 0 {
+		path, ok, err := (libresolve.Resolver{ProcRoot: procRoot}).FromMaps(target, pid)
+		if err != nil {
+			return 0, nil, err
+		}
+		if ok {
+			k.logger.Debug("resolved container uprobe target from process maps", "target", target, "path", path, "pid", pid, "proc_root", procRoot)
+			target = path
+		}
 	}
 
 	// Create socketpair for receiving the target-binary fd from the child.
@@ -198,20 +249,9 @@ func (k *kernelAdapter) attachUprobeViaHelper(scope lock.WriterScope, progPinPat
 	// Get current mount namespace inode for logging
 	currentMntNs, _ := ns.GetCurrentMntNsInode()
 
-	// Determine target namespace path - try /proc first, then /host/proc for k8s
-	nsPath := fmt.Sprintf("/proc/%d/ns/mnt", containerPid)
-	if _, err := os.Stat(nsPath); err != nil {
-		altPath := fmt.Sprintf("/host/proc/%d/ns/mnt", containerPid)
-		if _, err := os.Stat(altPath); err != nil {
-			k.logger.Error("container namespace not accessible", "container_pid", containerPid, "tried_paths", []string{nsPath, altPath}, "error", err, "hint", "ensure container PID is valid and /proc or /host/proc is accessible")
-			return 0, nil, fmt.Errorf("container namespace for PID %d not accessible (tried %s and %s): %w", containerPid, nsPath, altPath, err)
-		}
-		nsPath = altPath
-	}
-
 	k.logger.Info("preparing container uprobe attachment", "container_pid", containerPid, "current_mnt_ns_inode", currentMntNs, "target_ns_path", nsPath, "target_binary", target, "fn_name", fnName, "offset", offset, "retprobe", retprobe, "prog_pin_path", progPinPath, "link_pin_path", linkPinPath)
 
-	// The child needs only the target path; the parent owns the attach.
+	// The child needs only the target; the parent owns the attach.
 	// bpfman-ns mode is set via the BPFMAN_MODE env var, not argv.
 	args := []string{"uprobe", target}
 
@@ -280,11 +320,12 @@ func (k *kernelAdapter) attachUprobeViaHelper(scope lock.WriterScope, progPinPat
 
 	// Attach and pin in bpfman's own namespace. The kernel resolves
 	// /proc/self/fd of the inherited fd back to the target binary's inode,
-	// so this is the same code path as a local uprobe -- and the perf-event
+	// so this joins the local uprobe's attach path below resolution --
+	// the target is already resolved and open, and the perf-event
 	// bpf_link is created here, where Cilium's feature probe behaves.
 	procTarget := fmt.Sprintf("/proc/self/fd/%d", binaryFd)
 	k.logger.Info("attaching container uprobe in host namespace", "container_pid", containerPid, "proc_target", procTarget, "fn_name", fnName, "pid", pid, "link_pin_path", linkPinPath)
-	return k.doAttachUprobeLocal(progPinPath, procTarget, fnName, offset, pid, retprobe, linkPinPath)
+	return k.doAttachUprobeResolved(progPinPath, procTarget, fnName, offset, pid, retprobe, linkPinPath)
 }
 
 func helperExitError(fnName, target string, containerPid int32, exitCode int, stderr string) error {


### PR DESCRIPTION
Container uprobes rejected bare library names: `target: libc` with `--container-pid` failed, although the CRD, the docs, and our own CLI help all advertise it. Tracked as [BPFMAN-42](https://redhat.atlassian.net/browse/BPFMAN-42).

`libc` is a nickname, not a file, and "which file?" depends on whose filesystem you ask -- a container's libc can live somewhere the host has never heard of. Rust got this right by construction: its bpfman-ns helper setns'd into the container's mount namespace and handed the raw name to aya, which resolved it there. The Go port has the same resolver (a faithful port of aya's matching rules) but wired it only into the local attach path; the container helper stayed a courier for exact paths, and a manager gate rejected bare names instead.

The fix runs each resolution tier where it can answer. The cache tier moves into the helper, after its setns, so `/etc/ld.so.cache` is the container's -- exact aya parity. The maps tier runs in the parent, because a pid filter is a host pid that only host procfs can interpret (via the same `/proc` -> `/host/proc` fallback the daemonset deployment uses); Rust read that same pid in two different namespaces within one attach, which never worked coherently in a pod, so here we are deliberately better than bug-for-bug parity. The attach below resolution never re-resolves the fd it already holds. And the manager-level check that produced the error above -- an explicit rejection of any non-absolute container target, added because the helper could not resolve names -- is removed entirely: bare names now flow through to resolution, and when resolution genuinely cannot answer (say, a container image with no `ld.so.cache`), the failure is a designed error naming the target and the absolute-path workaround, raised from the layer that actually tried, rather than a blanket refusal in front of it.

## Show and tell

Before, Rust and Go side by side on the same namespaced target:

```
=== Rust bpfman: attach uprobe target=libc fn=malloc container-pid=<ns pid> ===
RUST ATTACH: OK

=== Go bpfman: attach uprobe target=libc fn=malloc container-pid=<ns pid> ===
bpfman: error: container uprobe target must be an absolute path (got "libc"; library-name resolution is not supported inside containers)
GO ATTACH: FAILED (exit 1)
```

After, same script:

```
RUST ATTACH: OK
GO ATTACH: OK
```

Each tier is individually visible from the shell: a namespace with no cache gets a designed error *from inside the namespace*, `--pid` resolves through the process's own maps, and a namespace carrying its own cache resolves with no pid at all -- the helper logs the resolution from inside the container.

<details>
<summary>bpfman-42-explore.sh on the fixed build: the three tiers</summary>

```
target A (no cache) pid: 1338157; target B (cache in ns) pid: 1338170
program id: 397867

=== 1. bare libc, no pid, no cache in the namespace -> helper's designed error
bpfman-ns: error: resolve target "libc" in container (mnt ns inode 4026534202): read /etc/ld.so.cache: open /etc/ld.so.cache: no such file or directory
bpfman: error: attach uprobe via helper: bpfman-ns failed attaching malloc to "libc" in container 1338157 (exit 1): resolve target "libc" in container ...

=== 2. maps tier: --pid resolves in the parent via /proc/<pid>/maps -> attach OK
{"link_id":386,"kernel_link_id":534253,"target":"libc"}

=== 3. cache tier: the CONTAINER's /etc/ld.so.cache resolves libc -> attach OK
cache: /tmp/nix-ld.so.cache (built from /nix/store/...-glibc-2.42-51/lib, installed in target B's namespace)
msg="resolved target in container namespace" target=libc path=/nix/store/...-glibc-2.42-51/lib/libc.so.6 source=ld.so.cache
{"link_id":387,"kernel_link_id":534254,"target":"libc"}
```

</details>

The same works against kube-shaped namespaces built with nothing but `unshare` -- a pivot_root'd rootfs whose synthetic cache maps a library name that exists in **no** host's cache, and a daemon running behind a pod-scoped `/proc` that can only reach the target through `/host/proc`, exactly the operator daemonset's topology:

<details>
<summary>bpfman-42-podstyle.sh: a bare name resolved inside a rootfs the host cannot see; the /host/proc fallback firing</summary>

```
=== A. pod-style TARGET: mount+pid ns, pivot_root rootfs, synthetic cache
unshare pid=1319920; target host pid=1319922 (pid 1 inside its own pid ns)
worker's rootfs, via /proc/1319922/root:
etc  nix  old  proc  sleep  testlib

--- A: bare name resolved by the helper inside the container namespace.
--- On the host, the resolved path's directory does not even exist:
ls: cannot access '/testlib': No such file or directory
msg="resolved target in container namespace" target=libbpfmantest path=/testlib/libbpfmantest.so.1 source=ld.so.cache
{"link_id":388,"kernel_link_id":534255,"target":"libbpfmantest"}

=== B. pod-style DAEMON: pod /proc, host procfs at /host/proc
--- B1: pod ns WITHOUT the /host/proc bind -> ns file unreachable
bpfman: error: attach uprobe via helper: container namespace for PID 1339189 not accessible (tried /proc/1339189/ns/mnt and /host/proc/1339189/ns/mnt)

--- B2: WITH the /host/proc bind (daemonset shape) -> fallback fires
{"link_id":390,"kernel_link_id":534256}
```

</details>

And the real thing: the actual `go-target` image under podman. The helper resolves `libc` to Fedora's `/lib64/libc.so.6` -- a path the (NixOS) host does not even have -- and the probe counts the container's mallocs:

```
msg="resolved target in container namespace" target=libc path=/lib64/libc.so.6 source=ld.so.cache
count before: 0
count after container exec: 37
```

In the corpus, red first: every new `.bpfman` script was watched failing at the attach line before the fix --

```
[guard] FAIL at scripts/TestContainerUprobe_LibraryNameTarget.bpfman:60:1
command:
  bpfman link attach uprobe $prog libc --fn-name malloc --pid 1234081 --container-pid 1234081
stderr:
  bpfman: error: container uprobe target must be an absolute path (got "libc"; library-name resolution is not supported inside containers)
```

-- then green, all five, with exact counts where the rig controls the traffic. (CI's first run caught the scripts assuming a dynamically linked worker -- the bundle builds bpfman-shell static, so a libc probe counts nothing there; the scripts now probe a library-named bind of the worker's own binary at its cgo fixture symbol, same resolution semantics, linkage-independent.)

```
container-uprobe library-name count: got=65 want>=65
container-uretprobe library-name count: got=35 want>=35
container-uprobe synthetic-cache count: got=65 want>=65
container-uprobe pod-style count: got=65 want>=65
container-uprobe host-proc daemon view count: got=65 want>=65
app-test image attach: uprobe link=24 uretprobe link=25
```

<details>
<summary>Bonus red/green from review: the fd must not be re-resolved</summary>

Review caught the container path re-running resolution on the fd it already held, which breaks in a daemonset pod. Red, with the fix toggled off:

```
bpfman: error: attach uprobe via helper: resolve target "/proc/self/fd/12": read /proc/1413418/maps: open /proc/1413418/maps: no such file or directory
```

Green, same command: the bogus resolution error is gone and the failure moves to the correct, pre-existing layer (perf pid filters from a non-hostPID pod are an older limitation shared with the Rust implementation):

```
bpfman: error: attach uprobe via helper: attach uprobe to malloc in /proc/self/fd/12: creating perf_uprobe PMU: ... opening perf event: no such process
```

Without the pid filter, the same daemonset-topology attach fully succeeds.

</details>

## Test plan

- `make lint-go` (0 issues), `make bpfman-gofix` (no changes), `make test`, `make test-e2e`, `make test-e2e-scripts`, `make test-e2e-grpc` -- all green.
- The five new scripts cover: maps tier (both probe directions), cache tier (synthetic in-namespace cache), pivot_root pod-style target, the `/host/proc` daemon view, and the `app-test` bytecode image loaded by reference through bpfman's native OCI support -- no container runtime anywhere in the corpus.

## The scripts

Not part of the change set; included for reviewers who want to reproduce the show-and-tell:

<details>
<summary>bpfman-42-explore.sh -- each resolution tier from the shell</summary>

```sh
#!/usr/bin/env bash
# BPFMAN-42 exploration -- https://redhat.atlassian.net/browse/BPFMAN-42
#
# Exercise each resolution tier for a
# container uprobe whose target is the bare library name "libc",
# against the fixed Go build (Option A: the maps tier resolves in
# the parent against host procfs; bare names otherwise resolve in
# the bpfman-ns helper against the CONTAINER's /etc/ld.so.cache
# after setns).
#
# Run as root from the repo root:
#   sudo ./bpfman-42-explore.sh
#
# Scenario 1: no pid, and the target namespace has no
#   /etc/ld.so.cache (this NixOS host has none to inherit) -- the
#   HELPER's resolution fails inside the namespace with a designed
#   error naming the escape hatch.
# Scenario 2: --pid engages the /proc/<pid>/maps tier in the
#   parent -- no cache needed anywhere, attach succeeds.
# Scenario 3: a second target whose namespace carries an
#   ldconfig-generated cache (tmpfs over /etc) -- the helper
#   resolves libc through the CONTAINER's cache and the attach
#   succeeds without a pid. Watch the helper log the resolution
#   from inside the namespace.

set -u

BPFMAN=${BPFMAN:-./bin/bpfman}
OBJ=${OBJ:-e2e/testdata/bpf/uprobe_counter.bpf.o}
CACHE=${CACHE:-/tmp/nix-ld.so.cache}

if [ "$(id -u)" -ne 0 ]; then
    echo "must run as root" >&2
    exit 1
fi
for f in "$BPFMAN" "$OBJ"; do
    if [ ! -e "$f" ]; then
        echo "missing: $f (run from the repo root; build with make bpfman-build)" >&2
        exit 1
    fi
done

wait_ns_switch() {
    local pid=$1 self_ns target_ns
    self_ns=$(readlink /proc/self/ns/mnt)
    for _ in $(seq 50); do
        target_ns=$(readlink "/proc/$pid/ns/mnt" 2>/dev/null || true)
        [ -n "$target_ns" ] && [ "$target_ns" != "$self_ns" ] && return 0
        sleep 0.1
    done
    return 1
}

# Target A: a bare mount namespace, no cache anywhere (scenarios 1-2).
unshare -m -- sleep 300 &
TPID=$!

# Target B: a mount namespace whose /etc carries a generated cache
# (scenario 3). ldconfig builds it from the libc directory; tmpfs
# over /etc keeps it namespace-private.
libc_dir=$(dirname "$(ldd "$BPFMAN" | awk '/libc\.so/ {print $3}')")
ldconfig -C "$CACHE" "$libc_dir"
unshare -m -- sh -c "mount -t tmpfs tmpfs /etc && cp '$CACHE' /etc/ld.so.cache && exec sleep 300" &
TPID2=$!

wait_ns_switch "$TPID" || { echo "target A never switched namespace" >&2; exit 1; }
wait_ns_switch "$TPID2" || { echo "target B never switched namespace" >&2; exit 1; }

ID=$("$BPFMAN" program load file "$OBJ" --programs uprobe:uprobe_counter -o json |
    jq -r '.programs[0].record.program_id')

cleanup() {
    "$BPFMAN" program unload "$ID" >/dev/null 2>&1 || true
    kill "$TPID" "$TPID2" 2>/dev/null || true
}
trap cleanup EXIT

echo "target A (no cache) pid: $TPID; target B (cache in ns) pid: $TPID2"
echo "program id: $ID"

echo
echo "=== 1. bare libc, no pid, no cache in the namespace -> helper's designed error"
if "$BPFMAN" link attach uprobe "$ID" libc --fn-name malloc \
    --container-pid "$TPID"; then
    echo "UNEXPECTED: attach succeeded"
fi

echo
echo "=== 2. maps tier: --pid resolves in the parent via /proc/<pid>/maps -> attach OK"
"$BPFMAN" link attach uprobe "$ID" libc --fn-name malloc \
    --pid "$TPID" --container-pid "$TPID" -o json |
    jq -c '{link_id: .record.id, kernel_link_id: .record.kernel_link_id, target: .record.details.target}'

echo
echo "=== 3. cache tier: the CONTAINER's /etc/ld.so.cache resolves libc -> attach OK"
echo "cache: $CACHE (built from $libc_dir, installed in target B's namespace)"
"$BPFMAN" link attach uprobe "$ID" libc --fn-name malloc \
    --container-pid "$TPID2" -o json |
    jq -c '{link_id: .record.id, kernel_link_id: .record.kernel_link_id, target: .record.details.target}'

echo
echo "=== links (program unload cascades these on exit)"
"$BPFMAN" link list
```

</details>
<details>
<summary>bpfman-42-compare.sh -- side-by-side Go vs Rust attach of target=libc</summary>

```sh
#!/usr/bin/env bash
# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
#
# Compare Go and Rust bpfman behaviour when a container
# uprobe names its target as a bare library name (libc) rather than
# an absolute path.
#
# With the BPFMAN-42 fix in place both CLIs attach successfully:
# Rust via aya's in-namespace resolution, Go via the maps tier in
# the parent (host procfs interprets the host pid) with cache-tier
# fallback in the bpfman-ns helper. Historically the Go CLI
# rejected this at a manager gate with "container uprobe target
# must be an absolute path".
#
# Both attaches pass --pid so resolution can use the
# /proc/<pid>/maps tier, keeping the script working on hosts
# without /etc/ld.so.cache (e.g. NixOS).
#
# Run as root. The Rust CLI locates bpfman-ns relative to its cwd
# (./target/debug/bpfman-ns), so the Rust phase runs from the Rust
# worktree.

set -u

GO_WT=${GO_WT:-/home/aim/src/github.com/bpfman/bpfman/worktrees/go-bpfman}
RUST_WT=${RUST_WT:-/home/aim/src/github.com/bpfman/bpfman/worktrees/general}
GO_BPFMAN=$GO_WT/bin/bpfman
RUST_BPFMAN=$RUST_WT/target/debug/bpfman
OBJ=$GO_WT/e2e/testdata/bpf/uprobe_counter.bpf.o

if [ "$(id -u)" -ne 0 ]; then
    echo "must run as root" >&2
    exit 1
fi
for f in "$GO_BPFMAN" "$RUST_BPFMAN" "$RUST_WT/target/debug/bpfman-ns" "$OBJ"; do
    if [ ! -e "$f" ]; then
        echo "missing: $f" >&2
        exit 1
    fi
done

# Start a long-lived process in its own mount namespace and wait for
# the namespace switch to be observable.
start_target() {
    unshare -m -- sleep 300 &
    TARGET_PID=$!
    local self_ns target_ns
    self_ns=$(readlink /proc/self/ns/mnt)
    for _ in $(seq 50); do
        target_ns=$(readlink "/proc/$TARGET_PID/ns/mnt" 2>/dev/null || true)
        if [ -n "$target_ns" ] && [ "$target_ns" != "$self_ns" ]; then
            return 0
        fi
        sleep 0.1
    done
    echo "target never switched mount namespace" >&2
    return 1
}

stop_target() {
    kill "$TARGET_PID" 2>/dev/null || true
    wait "$TARGET_PID" 2>/dev/null || true
}

rust_result=
go_result=

echo "=== Rust bpfman: attach uprobe target=libc fn=malloc container-pid=<ns pid> ==="
start_target
(
    cd "$RUST_WT" || exit 1
    out=$("$RUST_BPFMAN" load file --path "$OBJ" --programs uprobe:uprobe_counter 2>&1) || {
        echo "rust load failed:"
        echo "$out"
        exit 1
    }
    id=$(echo "$out" | awk '/Program ID:/ {print $NF; exit}')
    echo "rust loaded program id=$id"
    if "$RUST_BPFMAN" attach "$id" uprobe --fn-name malloc --target libc --pid "$TARGET_PID" --container-pid "$TARGET_PID"; then
        echo "RUST ATTACH: OK"
    else
        echo "RUST ATTACH: FAILED (exit $?)"
    fi
    "$RUST_BPFMAN" unload "$id" >/dev/null 2>&1 || true
)
rust_result=$?
stop_target

echo
echo "=== Go bpfman: attach uprobe target=libc fn=malloc container-pid=<ns pid> ==="
start_target
(
    out=$("$GO_BPFMAN" program load file "$OBJ" --programs uprobe:uprobe_counter -o json 2>&1) || {
        echo "go load failed:"
        echo "$out"
        exit 1
    }
    id=$(echo "$out" | jq -r '.programs[0].record.program_id')
    echo "go loaded program id=$id"
    if "$GO_BPFMAN" link attach uprobe "$id" libc --fn-name malloc --pid "$TARGET_PID" --container-pid "$TARGET_PID"; then
        echo "GO ATTACH: OK"
    else
        echo "GO ATTACH: FAILED (exit $?)"
    fi
    "$GO_BPFMAN" program unload "$id" >/dev/null 2>&1 || true
)
go_result=$?
stop_target

echo
echo "=== summary ==="
echo "rust phase exit: $rust_result"
echo "go phase exit: $go_result"
```

</details>
<details>
<summary>bpfman-42-podstyle.sh -- kube-style pods synthesised with unshare</summary>

```sh
#!/usr/bin/env bash
# BPFMAN-42 -- https://redhat.atlassian.net/browse/BPFMAN-42
#
# Synthesise kube-style pods with unshare and walk the
# container uprobe attach through them.
#
# Scenario A -- the TARGET as a pod-style container: own mount and
# pid namespaces, pivot_root'd rootfs (setns into a chroot lands at
# the host root, so chroot would lie), pid-namespace-scoped /proc,
# and a synthetic /etc/ld.so.cache whose entry (libbpfmantest.so.1
# -> /testlib/libbpfmantest.so.1) names a path that exists nowhere
# on the host.
#   A: the bare-name attach succeeds -- the bpfman-ns helper
#      resolves libbpfmantest through the CONTAINER's synthetic
#      cache after setns and opens /testlib/... inside the rootfs
#      (watch its log lines), even though no host cache knows the
#      name and the host has no /testlib at all.
#
# Scenario B -- the DAEMON as a pod: own mount+pid namespaces,
# pod-scoped /proc (the target's host pid is invisible there), host
# procfs bound at /host/proc -- the operator daemonset shape (no
# hostPID; hostPath /proc -> /host/proc).
#   B1: without the /host/proc bind the target's namespace file is
#       unreachable and the attach fails.
#   B2: with it, the /proc -> /host/proc fallback fires and the
#       attach succeeds. An absolute target path is used so
#       namespace-file reachability is isolated from resolution.
#
# Run as root from the repo root: sudo ./bpfman-42-podstyle.sh

set -u

GO_WT=${GO_WT:-/home/aim/src/github.com/bpfman/bpfman/worktrees/go-bpfman}
BPFMAN=$GO_WT/bin/bpfman
SHELL_BIN=$GO_WT/bin/bpfman-shell
OBJ=$GO_WT/e2e/testdata/bpf/uprobe_counter.bpf.o

if [ "$(id -u)" -ne 0 ]; then
    echo "must run as root" >&2
    exit 1
fi
for f in "$BPFMAN" "$SHELL_BIN" "$OBJ"; do
    [ -e "$f" ] || { echo "missing: $f" >&2; exit 1; }
done

WD=$(mktemp -d /tmp/bpfman-42-podstyle.XXXXXX)
PIDS=()
IDS=()
# Ownership tracking for the /host/proc mountpoint: only remove a
# directory this run created; a pre-existing /host or /host/proc is
# never touched.
CREATED_HOST=""
CREATED_HOSTPROC=""
cleanup() {
    for id in "${IDS[@]:-}"; do
        [ -n "$id" ] && "$BPFMAN" program unload "$id" >/dev/null 2>&1
    done
    for p in "${PIDS[@]:-}"; do
        [ -n "$p" ] && kill "$p" 2>/dev/null
    done
    [ -n "$CREATED_HOSTPROC" ] && rmdir /host/proc 2>/dev/null
    [ -n "$CREATED_HOST" ] && rmdir /host 2>/dev/null
    rm -rf "$WD"
}
trap cleanup EXIT

SLEEPBIN=$(readlink -f "$(command -v sleep)")
LIBC=$(ldd "$SLEEPBIN" | grep -o '/[^ ]*libc.so[^ ]*' | head -n1)

echo "=== A. pod-style TARGET: mount+pid ns, pivot_root rootfs, synthetic cache"
R=$WD/rootfs
mkdir -p "$R"/{proc,etc,testlib,old}
touch "$R/sleep" "$R/testlib/libbpfmantest.so.1"
env BPFMAN_SHELL_MODE=ldso-cache-writer "$SHELL_BIN" "$WD/ld.so.cache" "libbpfmantest.so.1=/testlib/libbpfmantest.so.1"
cp "$WD/ld.so.cache" "$R/etc/ld.so.cache"

# The payload's loader closure, derived (not encoded): top-level
# directories from ldd -- /nix on NixOS, /lib and /usr elsewhere.
# Everything external runs before pivot_root (proc is mounted
# pre-pivot; the pid namespace is already ours), so no binary ever
# needs a rootfs-internal path. The old root stays at /old: hiding
# it is cosmetic and needs nothing the rootfs would have to carry.
BINDS=""
for d in $(ldd "$SLEEPBIN" 2>/dev/null | grep -o '/[^ ]*' | xargs -rn1 dirname | cut -d/ -f2 | sort -u); do
    mkdir -p "$R/$d"
    BINDS="$BINDS mount --bind /$d '$R/$d' &&"
done

unshare --mount --pid --fork -- sh -c "
    mount --make-rprivate / &&
    mount --bind '$R' '$R' &&
    $BINDS
    mount --bind '$LIBC' '$R/testlib/libbpfmantest.so.1' &&
    mount --bind '$SLEEPBIN' '$R/sleep' &&
    mount -t proc proc '$R/proc' &&
    cd '$R' && pivot_root . old &&
    exec /sleep 300" &
UPID=$!
PIDS+=("$UPID")
CPID=
for _ in $(seq 50); do
    CPID=$(pgrep -P "$UPID" | head -n1)
    [ -n "$CPID" ] && [ "$(cat /proc/$CPID/comm 2>/dev/null)" = sleep ] && break
    sleep 0.1
done
[ -n "$CPID" ] || { echo "pod target never came up" >&2; exit 1; }
PIDS+=("$CPID")
echo "unshare pid=$UPID; target host pid=$CPID (pid 1 inside its own pid ns)"
echo "worker's rootfs, via /proc/$CPID/root:"
ls "/proc/$CPID/root/"

ID=$("$BPFMAN" program load file "$OBJ" --programs uprobe:uprobe_counter -o json | jq -r '.programs[0].record.program_id')
IDS+=("$ID")

echo
echo "--- A: bare name resolved by the helper inside the container namespace."
echo "--- On the host, the resolved path's directory does not even exist:"
ls /testlib 2>&1 | head -n1
"$BPFMAN" link attach uprobe "$ID" libbpfmantest --fn-name malloc --container-pid "$CPID" -o json |
    jq -c '{link_id: .record.id, kernel_link_id: .record.kernel_link_id, target: .record.details.target}'

echo
echo "=== B. pod-style DAEMON: pod /proc, host procfs at /host/proc"
unshare -m -- sleep 300 &
TPID=$!
PIDS+=("$TPID")
sleep 0.3
ID2=$("$BPFMAN" program load file "$OBJ" --programs uprobe:uprobe_counter -o json | jq -r '.programs[0].record.program_id')
IDS+=("$ID2")
[ -d /host ] || CREATED_HOST=1
[ -d /host/proc ] || CREATED_HOSTPROC=1
mkdir -p /host/proc

echo "--- B1: pod ns WITHOUT the /host/proc bind -> ns file unreachable"
unshare --mount --pid --fork -- sh -c "
    mount --make-rprivate / &&
    mount -t proc proc /proc &&
    exec '$BPFMAN' link attach uprobe $ID2 '$LIBC' --fn-name malloc --container-pid $TPID" || true

echo
echo "--- B2: WITH the /host/proc bind (daemonset shape) -> fallback fires"
unshare --mount --pid --fork -- sh -c "
    mount --make-rprivate / &&
    mount --bind /proc /host/proc &&
    mount -t proc proc /proc &&
    exec '$BPFMAN' link attach uprobe $ID2 '$LIBC' --fn-name malloc --container-pid $TPID -o json" |
    jq -c '{link_id: .record.id, kernel_link_id: .record.kernel_link_id}'

echo
echo "=== links before cleanup"
"$BPFMAN" link list
```

</details>


