### PR TITLE
Fall back to generic XDP mode when native attach hits the veth MTU limit

### DIFF
--- a/e2e/scripts/TestXDP_JumboMTUGenericFallback.bpfman
+++ b/e2e/scripts/TestXDP_JumboMTUGenericFallback.bpfman
@@ -1,0 +1,68 @@
+# -*- mode: bpfman -*-
+#
+# BPFMAN-43: XDP attach to a jumbo-MTU veth must succeed by falling
+# back to generic/SKB mode.
+#
+# Given: a netns veth pair raised to the OpenShift overlay MTU
+# (8901), which exceeds the per-page XDP buffer limit (~3506 bytes on
+# a 4K-page system), so native/driver-mode XDP attach is rejected by
+# the veth driver with ERANGE ("numerical result out of range")
+#
+# When: an XDP program is attached through bpfman
+#
+# Then: the attach succeeds, the kernel reports the link in generic
+# mode (ip xdp.mode == 2 == XDP_FLAGS_SKB_MODE), and traffic drives
+# the XDP counter -- proving the SKB fallback fired and is on the
+# packet path. Without the fix the attach fails with ERANGE.
+
+import ../lib.bpfman
+
+guard pair <- net netns-veth-pair
+defer net release $pair
+
+let netns = "/var/run/netns/${pair.a.ns}"
+
+# Raise both ends to the overlay MTU so native-mode XDP attach hits
+# the veth driver's peer-MTU rejection.
+guard _ <- net exec $pair.a ip link set dev $pair.a.link mtu 8901
+guard _ <- net exec $pair.b ip link set dev $pair.b.link mtu 8901
+
+guard loaded <- bpfman program load file testdata/bpf/xdp_pass.bpf.o --programs xdp:pass
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+defer bpfman program unload $pid
+
+# Native mode fails with ERANGE here before the fix; with the fix the
+# attach retries in generic/SKB mode and succeeds.
+guard link <- bpfman link attach xdp $prog $pair.a.link --priority 50 --netns $netns -m owner=xdp
+let linkID = $link.record.id
+assert $link.record.kind == xdp
+assert $link.record.program_id == $pid
+assert $link.status.kernel_seen
+
+# Direct kernel proof that the fallback fired: the interface carries
+# an XDP program in generic mode (mode 2 = XDP_FLAGS_SKB_MODE; native
+# would be 1).
+guard xdpShow <- net exec $pair.a ip -j -d link show dev $pair.a.link
+let xdpMode = $xdpShow.stdout |> jq "fromjson | .[0].xdp.mode"
+print "xdp mode on ${pair.a.link}: ${xdpMode} (1=native, 2=generic/SKB)"
+assert $xdpMode == 2
+
+# Traffic round-trip: ping from b to a and prove the XDP counter
+# moved, so the generic-mode dispatcher is genuinely on the path.
+# ARP/control traffic may add packets, so this is a lower bound.
+let mapID = $prog.status.maps[0].id
+let sumFilter = "fromjson | [.[0].formatted.values[].value | tonumber] | add"
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $sumFilter
+
+guard _ <- net exec $pair.b ping -c 5 -i 0.05 -W 1 $pair.a.addr
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $sumFilter
+let delta = $after - $before
+print "xdp count: before=${before} after=${after} delta=${delta}"
+assert $delta >= 5
+
+bpfman link detach $link
+assert fail bpfman link get $linkID

--- a/platform/ebpf/attach_xdp.go
+++ b/platform/ebpf/attach_xdp.go
@@ -18,6 +18,30 @@ import (
 	"github.com/bpfman/bpfman/platform"
 )
 
+// attachXDP attaches an XDP program, falling back from native/driver
+// mode to generic (SKB) mode when the driver rejects the attach with
+// ERANGE. A veth pair rejects native XDP when the peer MTU exceeds the
+// per-page XDP buffer limit (~3506 bytes on 4K-page systems); this is
+// the common case on OpenShift, where OVN-Kubernetes sets the pod veth
+// MTU to the overlay size (e.g. 8901). Generic mode runs XDP in the
+// stack's software path and does not invoke the driver's MTU check.
+func attachXDP(opts link.XDPOptions) (link.Link, error) {
+	lnk, err := attachXDPWithRetry(opts)
+	if shouldFallbackToGeneric(err, opts.Flags) {
+		opts.Flags = link.XDPGenericMode
+		lnk, err = attachXDPWithRetry(opts)
+	}
+	return lnk, err
+}
+
+// shouldFallbackToGeneric reports whether a failed native-mode XDP
+// attach should be retried in generic/SKB mode. ERANGE is the veth
+// driver's rejection of a peer MTU too large for native XDP; the flag
+// guard stops a generic-mode attach that itself fails from looping.
+func shouldFallbackToGeneric(err error, flags link.XDPAttachFlags) bool {
+	return errors.Is(err, syscall.ERANGE) && flags != link.XDPGenericMode
+}
+
 // attachXDPWithRetry retries link.AttachXDP on EBUSY. Removing a
 // pinned XDP link drops the last kernel reference, but the kernel
 // releases the XDP hook asynchronously. A brief retry avoids
@@ -48,7 +72,7 @@ func (k *kernelAdapter) AttachXDP(ctx context.Context, progPinPath bpfman.ProgPi
 	}
 	defer prog.Close()
 
-	lnk, err := attachXDPWithRetry(link.XDPOptions{
+	lnk, err := attachXDP(link.XDPOptions{
 		Program:   prog,
 		Interface: ifindex,
 	})
@@ -198,7 +222,7 @@ func (k *kernelAdapter) CreateXDPLink(ctx context.Context, progPinPath bpfman.Pr
 	var result *platform.XDPDispatcherResult
 	err = netns.Run(netnsPath, func() error {
 		k.logger.Debug("creating XDP link", "ifindex", ifindex, "prog_pin_path", progPinPath, "link_pin_path", linkPinPath, "netns", netnsPath)
-		lnk, err := attachXDPWithRetry(link.XDPOptions{
+		lnk, err := attachXDP(link.XDPOptions{
 			Program:   prog,
 			Interface: ifindex,
 		})

--- a/platform/ebpf/attach_xdp_test.go
+++ b/platform/ebpf/attach_xdp_test.go
@@ -1,0 +1,37 @@
+package ebpf
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/cilium/ebpf/link"
+)
+
+// TestShouldFallbackToGeneric covers the BPFMAN-43 decision: a
+// native-mode XDP attach rejected with ERANGE retries in generic
+// mode, and nothing else does -- so a generic-mode attach that also
+// returns ERANGE cannot loop.
+func TestShouldFallbackToGeneric(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		err   error
+		flags link.XDPAttachFlags
+		want  bool
+	}{
+		{"ERANGE in native mode falls back", syscall.ERANGE, 0, true},
+		{"success does not fall back", nil, 0, false},
+		{"non-ERANGE error does not fall back", syscall.EPERM, 0, false},
+		{"ERANGE already in generic mode does not loop", syscall.ERANGE, link.XDPGenericMode, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldFallbackToGeneric(tt.err, tt.flags); got != tt.want {
+				t.Errorf("shouldFallbackToGeneric(%v, %d) = %v, want %v", tt.err, tt.flags, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
XDP attach fails on every OpenShift pod veth. The kernel returns `numerical result out of range` -- ERANGE. Tracked as [BPFMAN-43](https://redhat.atlassian.net/browse/BPFMAN-43).

The veth driver is the cause. Native XDP takes one memory page per packet. After overhead that leaves about 3506 bytes on a 4K-page host. OVN-Kubernetes sets the pod veth MTU to 8901. That does not fit, so the driver rejects native XDP with ERANGE. Generic (SKB) mode has no such check; it runs XDP in the stack's software path.

The Rust bpfman never hit this. It asked for native mode, and on failure retried in SKB mode. The Go rewrite dropped that retry. Same kernel, same error -- the Go port just gave up instead of falling back.

The fix is that retry, ported back. On ERANGE, attach again with `link.XDPGenericMode`. One helper covers both attach paths: the single-program attach and the dispatcher link.

## Show and tell

I did not want to take the ticket on faith, so I proved the failure three ways on a jumbo-MTU veth. The ticket guessed Rust dodged this by using netlink rather than the BPF-link path Go uses. That is wrong. Both use `BPF_LINK_CREATE`, both fail identically in native mode, and only the SKB fallback saves either. It is the mode, not the mechanism.

Go, through cilium/ebpf -- bpfman's own attach code:

```
[1] driver mode (Flags=0, bpfman today):
  attach FAILED: failed to attach link: create link: numerical result out of range
  errors.Is(err, ERANGE) = true
[2] generic/SKB mode (Flags=XDPGenericMode, proposed fix):
  attach OK
```

Rust, through aya 0.13.1 -- the same version and features the Rust bpfman built against:

```
[1] DRV mode (aya default, bpfman's first attempt):
  attach FAILED: `bpf_link_create` failed
    caused by: Numerical result out of range (os error 34)
[2] SKB mode (bpfman's fallback):
  attach OK
```

netlink, through `ip` -- the mechanism the ticket thought Rust used:

```
[1] netlink DRIVER mode: Error: veth: Peer MTU is too large to set XDP.
[2] netlink GENERIC/SKB mode: OK
```

Three attach paths, one story: native fails, generic works.

Now the same thing end to end, through the real daemon. The new `.bpfman` script builds a netns veth pair, raises it to MTU 8901 with `ip`, and attaches XDP through bpfman. With the fallback removed, it is red at the attach line:

```
[guard] FAIL at scripts/TestXDP_JumboMTUGenericFallback.bpfman:37:1
command:
  bpfman link attach xdp $prog ...a --priority 50 --netns ... -m owner=xdp
stderr:
  bpfman: error: create XDP link: attach XDP to ifindex 38688: failed to attach link: create link: numerical result out of range
```

With the fallback in place it is green. The kernel confirms the link is generic mode, not native, and traffic drives the counter:

```
xdp mode on ...a: 2 (1=native, 2=generic/SKB)
xdp count: before=0 after=6 delta=6
```

That `xdp.mode == 2` comes straight from `ip -j -d link show` inside the namespace. So the proof that the fallback fired is the kernel's own word, not bpfman's.

## Test plan

- `go test ./platform/ebpf/` -- the fallback unit test: ERANGE retries in generic, other errors do not, and an ERANGE in both modes does not loop.
- `make run-e2e-scripts TEST='TestBPFManScripts/scripts/TestXDP_JumboMTUGenericFallback\.bpfman$'` -- green with the fix, red with the fallback removed. Both runs are shown above.
- Needs a 4K-page host. It reproduces on a plain 6.18 kernel as well as the RHEL 5.14 in the ticket.

## The scripts

Not part of the change set. Inlined for anyone who wants to reproduce the three-way show-and-tell above. They live under `repro-bpfman-43/` in my tree. Each takes a throwaway veth and runs as root.

<details>
<summary>Go prover -- cilium/ebpf, bpfman's own attach path</summary>

`main.go`:

```go
// Command xdprepro reproduces BPFMAN-43 empirically. It attaches a
// trivial XDP program to a network interface via cilium/ebpf's
// link.AttachXDP -- the exact BPF_LINK_CREATE path bpfman's Go
// rewrite uses -- first in driver/native mode (Flags=0, bpfman's
// current behaviour) and then in generic/SKB mode (Flags=
// XDPGenericMode, the proposed fix).
package main

import (
	"errors"
	"fmt"
	"net"
	"os"
	"syscall"

	"github.com/cilium/ebpf"
	"github.com/cilium/ebpf/asm"
	"github.com/cilium/ebpf/link"
)

func main() {
	if len(os.Args) != 2 {
		fmt.Fprintf(os.Stderr, "usage: %s <ifname>\n", os.Args[0])
		os.Exit(2)
	}
	ifname := os.Args[1]

	iface, err := net.InterfaceByName(ifname)
	if err != nil {
		fmt.Fprintf(os.Stderr, "resolve %s: %v\n", ifname, err)
		os.Exit(1)
	}
	fmt.Printf("interface %s ifindex=%d mtu=%d\n", ifname, iface.Index, iface.MTU)

	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
		Name: "xdp_pass",
		Type: ebpf.XDP,
		Instructions: asm.Instructions{
			asm.Mov.Imm(asm.R0, 2), // XDP_PASS
			asm.Return(),
		},
		License: "GPL",
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "load XDP program: %v\n", err)
		os.Exit(1)
	}
	defer prog.Close()

	fmt.Println("\n[1] driver mode (Flags=0, bpfman today):")
	driverErr := attach(prog, iface.Index, 0)
	report(driverErr)

	fmt.Println("\n[2] generic/SKB mode (Flags=XDPGenericMode, proposed fix):")
	genErr := attach(prog, iface.Index, link.XDPGenericMode)
	report(genErr)

	fmt.Println()
	switch {
	case errors.Is(driverErr, syscall.ERANGE) && genErr == nil:
		fmt.Println("RESULT: reproduced -- driver mode returns ERANGE, generic mode succeeds.")
	case driverErr == nil:
		fmt.Println("RESULT: NOT reproduced -- driver mode succeeded on this interface/kernel.")
	default:
		fmt.Println("RESULT: inconclusive -- see errors above.")
	}
}

func attach(prog *ebpf.Program, ifindex int, flags link.XDPAttachFlags) error {
	l, err := link.AttachXDP(link.XDPOptions{
		Program:   prog,
		Interface: ifindex,
		Flags:     flags,
	})
	if err != nil {
		return err
	}
	l.Close()
	return nil
}

func report(err error) {
	if err == nil {
		fmt.Println("  attach OK")
		return
	}
	fmt.Printf("  attach FAILED: %v\n", err)
	fmt.Printf("  errors.Is(err, ERANGE) = %v\n", errors.Is(err, syscall.ERANGE))
}
```

`repro_go.sh`:

```sh
#!/usr/bin/env bash
# BPFMAN-43 -- Go / cilium-ebpf reproduction.
set -euo pipefail

MTU="${MTU:-8901}"
VETH=repro43a
PEER=repro43b
HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
BIN="$(mktemp -d)/xdprepro"

cleanup() { sudo ip link del "$VETH" 2>/dev/null || true; rm -rf "$(dirname "$BIN")"; }
trap cleanup EXIT

echo "=== building xdprepro ==="
( cd "$HERE/.." && go build -o "$BIN" ./repro-bpfman-43 )

echo "=== creating veth pair $VETH/$PEER at MTU $MTU ==="
sudo ip link del "$VETH" 2>/dev/null || true
sudo ip link add "$VETH" mtu "$MTU" type veth peer name "$PEER" mtu "$MTU"
ip link show "$VETH" | head -1

echo "=== attaching via BPF_LINK_CREATE (bpfman's path) ==="
sudo "$BIN" "$VETH"
```

</details>

<details>
<summary>Rust prover -- aya 0.13.1, matching the Rust bpfman</summary>

`rust/main.rs`:

```rust
//! BPFMAN-43 -- Rust/aya reproduction. Mirrors the Rust bpfman's
//! multiprog/xdp.rs attach path: Xdp::attach in DRV (native) mode,
//! and on failure fall back to SKB (generic) mode.

use std::error::Error;
use std::fmt::Debug;
use std::process::exit;

use aya::{
    programs::{xdp::XdpLinkId, Xdp, XdpFlags},
    EbpfLoader,
};

// report walks the error source chain so the underlying io::Error
// (ERANGE) is visible, not just aya's "bpf_link_create failed".
fn report(r: &Result<XdpLinkId, impl Error + Debug>) {
    match r {
        Ok(_) => println!("  attach OK"),
        Err(e) => {
            println!("  attach FAILED: {e}");
            let mut src = e.source();
            while let Some(s) = src {
                println!("    caused by: {s} (raw_os_error={:?})", downcast_errno(s));
                src = s.source();
            }
        }
    }
}

fn downcast_errno(e: &(dyn Error + 'static)) -> Option<i32> {
    e.downcast_ref::<std::io::Error>().and_then(|io| io.raw_os_error())
}

fn main() {
    let iface = match std::env::args().nth(1) {
        Some(i) => i,
        None => {
            eprintln!("usage: xdp-erange-repro <ifname>");
            exit(2);
        }
    };

    let obj = concat!(env!("CARGO_MANIFEST_DIR"), "/../bpf/xdp_pass.o");
    let mut bpf = EbpfLoader::new().load_file(obj).expect("load xdp_pass.o");
    let prog: &mut Xdp = bpf
        .program_mut("xdp_pass")
        .expect("program xdp_pass not found in object")
        .try_into()
        .expect("xdp_pass is not an XDP program");
    prog.load().expect("verifier load failed");

    println!("\n[1] DRV mode (aya default, bpfman's first attempt):");
    let drv = prog.attach(&iface, XdpFlags::DRV_MODE);
    report(&drv);

    println!("\n[2] SKB mode (bpfman's fallback):");
    let skb = prog.attach(&iface, XdpFlags::SKB_MODE);
    report(&skb);

    println!();
    match (drv.is_err(), skb.is_ok()) {
        (true, true) => println!("RESULT: reproduced -- DRV mode fails, SKB fallback succeeds."),
        (false, _) => println!("RESULT: NOT reproduced -- DRV mode succeeded on this interface/kernel."),
        _ => println!("RESULT: inconclusive -- see errors above."),
    }
}
```

`rust/Cargo.toml` -- pinned to match bpfman exactly (aya 0.13.1, `default-features = false`):

```toml
[package]
name = "xdp-erange-repro"
version = "0.0.0"
edition = "2021"
publish = false

[[bin]]
name = "xdp-erange-repro"
path = "main.rs"

[dependencies]
aya = { version = "0.13.1", default-features = false }

[workspace]
```

`repro_rust.sh`:

```sh
#!/usr/bin/env bash
# BPFMAN-43 -- Rust / aya reproduction. aya 0.13.1's Xdp::attach uses
# BPF_LINK_CREATE (not netlink), so the error is the same as Go's.
set -euo pipefail

MTU="${MTU:-8901}"
VETH=repro43a
PEER=repro43b
HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
FLAKE="${FLAKE:-/home/aim/src/github.com/frobware/nix-bpfman}"

cleanup() { sudo ip link del "$VETH" 2>/dev/null || true; }
trap cleanup EXIT

echo "=== building minimal XDP object ==="
clang -O2 -g -target bpf -c "$HERE/bpf/xdp_pass.c" -o "$HERE/bpf/xdp_pass.o"

echo "=== building aya repro ==="
if [ -n "${CARGO:-}" ]; then
	( cd "$HERE/rust" && CARGO_NET_OFFLINE=true "$CARGO" build )
else
	( cd "$HERE/rust" && CARGO_NET_OFFLINE=true nix develop "$FLAKE" -c cargo build )
fi
BIN="$HERE/rust/target/debug/xdp-erange-repro"

echo "=== creating veth pair $VETH/$PEER at MTU $MTU ==="
sudo ip link del "$VETH" 2>/dev/null || true
sudo ip link add "$VETH" mtu "$MTU" type veth peer name "$PEER" mtu "$MTU"
ip link show "$VETH" | head -1

echo "=== attaching via aya Xdp::attach (DRV then SKB) ==="
sudo "$BIN" "$VETH"
```

</details>

<details>
<summary>netlink prover -- ip, the mechanism the ticket assumed</summary>

`bpf/xdp_pass.c`:

```c
#include <linux/bpf.h>
__attribute__((section("xdp"), used))
int xdp_pass(void *ctx) { return 2; /* XDP_PASS */ }
char _license[] __attribute__((section("license"), used)) = "GPL";
```

`repro_netlink.sh`:

```sh
#!/usr/bin/env bash
# BPFMAN-43 -- netlink reproduction (aya's Xdp::attach uses the same
# RTM_SETLINK path as `ip link set ... xdp`). Proves netlink DRIVER
# mode fails identically; only the SKB fallback (xdpgeneric) saves it.
set -euo pipefail

MTU="${MTU:-8901}"
VETH=repro43a
PEER=repro43b
HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
OBJ="$(mktemp -d)/xdp_pass.o"

cleanup() {
	sudo ip link set dev "$VETH" xdpgeneric off 2>/dev/null || true
	sudo ip link del "$VETH" 2>/dev/null || true
	rm -rf "$(dirname "$OBJ")"
}
trap cleanup EXIT

echo "=== building minimal XDP object ==="
clang -O2 -g -target bpf -c "$HERE/bpf/xdp_pass.c" -o "$OBJ"

echo "=== creating veth pair $VETH/$PEER at MTU $MTU ==="
sudo ip link del "$VETH" 2>/dev/null || true
sudo ip link add "$VETH" mtu "$MTU" type veth peer name "$PEER" mtu "$MTU"
ip link show "$VETH" | head -1

echo
echo "=== [1] netlink DRIVER mode (aya/Rust default) ==="
if sudo ip link set dev "$VETH" xdp obj "$OBJ" sec xdp; then
	echo "-> driver mode OK (unexpected)"
else
	echo "-> driver mode FAILED (expected: Peer MTU too large / ERANGE)"
fi

echo
echo "=== [2] netlink GENERIC/SKB mode (the Rust SKB fallback) ==="
if sudo ip link set dev "$VETH" xdpgeneric obj "$OBJ" sec xdp; then
	echo "-> generic mode OK (expected)"
	ip link show "$VETH" | grep -o 'xdpgeneric' || true
else
	echo "-> generic mode FAILED (unexpected)"
fi
```

</details>
