### PR TITLE
Add support for eBPF LSM programs

### DIFF
--- a/attach_kind.go
+++ b/attach_kind.go
@@ -23,6 +23,8 @@ func attachVerb(spec AttachSpec) (verb string, accepts []ProgramType) {
 		return "fentry", []ProgramType{ProgramTypeFentry}
 	case FexitAttachSpec:
 		return "fexit", []ProgramType{ProgramTypeFexit}
+	case LsmAttachSpec:
+		return "lsm", []ProgramType{ProgramTypeLsm}
 	case XDPAttachSpec:
 		return "xdp", []ProgramType{ProgramTypeXDP}
 	case TCAttachSpec:

--- a/attach_spec.go
+++ b/attach_spec.go
@@ -234,6 +234,27 @@ func (FexitAttachSpec) attachSpec() {}
 // ProgramID returns the kernel ID of the program to attach.
 func (s FexitAttachSpec) ProgramID() kernel.ProgramID { return s.programID }
 
+// LsmAttachSpec specifies how to attach an LSM program.
+// Note: the hook comes from the program's stored metadata (set at load
+// time from the lsm/<hook> ELF section), not from user input.
+type LsmAttachSpec struct {
+	attachMetadata
+	programID kernel.ProgramID
+}
+
+// NewLsmAttachSpec creates a LsmAttachSpec with validated fields.
+func NewLsmAttachSpec(programID kernel.ProgramID) (LsmAttachSpec, error) {
+	if programID == 0 {
+		return LsmAttachSpec{}, errors.New("programID is required")
+	}
+	return LsmAttachSpec{programID: programID}, nil
+}
+
+func (LsmAttachSpec) attachSpec() {}
+
+// ProgramID returns the kernel ID of the program to attach.
+func (s LsmAttachSpec) ProgramID() kernel.ProgramID { return s.programID }
+
 // XDPAttachSpec specifies how to attach XDP.
 type XDPAttachSpec struct {
 	attachMetadata
@@ -501,6 +522,12 @@ func (s FentryAttachSpec) WithMetadata(md map[string]string) FentryAttachSpec {
 
 // WithMetadata returns a copy of s with the given link labels set.
 func (s FexitAttachSpec) WithMetadata(md map[string]string) FexitAttachSpec {
+	s.metadata = md
+	return s
+}
+
+// WithMetadata returns a copy of s with the given link labels set.
+func (s LsmAttachSpec) WithMetadata(md map[string]string) LsmAttachSpec {
 	s.metadata = md
 	return s
 }

--- a/cmd/bpfman-shell/fixturemode/lsm.go
+++ b/cmd/bpfman-shell/fixturemode/lsm.go
@@ -1,0 +1,59 @@
+// Test-fixture mode for the LSM family of e2e/scripts. When
+// BPFMAN_SHELL_MODE=lsm-open-worker, bpfman-shell runs as a short-lived
+// worker that sets its own comm to a caller-chosen marker and then opens
+// a target file N times. Each open fires the security_file_open LSM
+// hook; an LSM program that filters file_open by that marker comm counts
+// exactly these opens, isolated from the host's own file activity.
+//
+// The comm is set through /proc/thread-self/comm after locking the
+// goroutine to its OS thread, so the marker names the exact thread the
+// opens run on. The Go runtime's own startup file activity happens
+// before the marker is set and under the binary's default comm, so it is
+// not attributed to the marker.
+package fixturemode
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func runLsmOpenWorker(args []string) error {
+	if len(args) != 3 {
+		return fmt.Errorf("lsm-open-worker: usage: MARKER FILE COUNT (got %d args)", len(args))
+	}
+	marker := args[0]
+	file := args[1]
+	n, err := strconv.Atoi(args[2])
+	if err != nil {
+		return fmt.Errorf("lsm-open-worker: invalid COUNT %q: %w", args[2], err)
+	}
+
+	if n < 0 {
+		return fmt.Errorf("lsm-open-worker: COUNT must not be negative (got %d)", n)
+	}
+
+	// Pin to the OS thread so the comm we set and the opens we make are
+	// the same task the LSM program observes. Never unlocked: this is a
+	// throwaway worker process.
+	runtime.LockOSThread()
+
+	// Setting comm opens /proc/thread-self/comm first -- that open runs
+	// under the old comm, before the marker takes effect, so it is not
+	// counted.
+	if err := os.WriteFile("/proc/thread-self/comm", []byte(marker), 0o644); err != nil {
+		return fmt.Errorf("lsm-open-worker: set comm %q: %w", marker, err)
+	}
+
+	for i := range n {
+		fd, err := unix.Open(file, unix.O_RDONLY, 0)
+		if err != nil {
+			return fmt.Errorf("lsm-open-worker: open %s (%d/%d): %w", file, i+1, n, err)
+		}
+		_ = unix.Close(fd)
+	}
+	return nil
+}

--- a/cmd/bpfman-shell/fixturemode/mode.go
+++ b/cmd/bpfman-shell/fixturemode/mode.go
@@ -17,6 +17,8 @@ func Run(mode string, args []string) error {
 		return runKillFireWorker(args)
 	case "ldso-cache-writer":
 		return runLdSoCacheWriter(args)
+	case "lsm-open-worker":
+		return runLsmOpenWorker(args)
 	default:
 		return fmt.Errorf("unknown BPFMAN_SHELL_MODE %q", mode)
 	}

--- a/cmd/bpfman-shell/internal/builtins/lsm.go
+++ b/cmd/bpfman-shell/internal/builtins/lsm.go
@@ -1,0 +1,147 @@
+// lsm is the e2e built-in for deterministic LSM file_open stimulus. It
+// leases a probe -- a unique marker comm plus a target file -- and fires
+// opens of that file under the marker, so an LSM program filtering
+// file_open by the marker comm counts exactly the fixture's opens,
+// isolated from the host's own file activity. The marker crosses into
+// the program at load time via the probe's marker_hex global.
+package builtins
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/bpfman/bpfman/cmd/bpfman-shell/driver"
+	"github.com/bpfman/bpfman/cmd/bpfman-shell/shell/runtime"
+	"github.com/bpfman/bpfman/cmd/bpfman-shell/shell/semantics"
+)
+
+func init() {
+	Register(driver.Builtin{
+		Name:     "lsm",
+		Handler:  handleLsm,
+		Category: driver.CategoryJobs,
+		Usage:    "lsm probe  |  lsm fire $probe N",
+		Summary:  "Lease and fire a deterministic LSM file_open probe for e2e tests.",
+		Detail: "lsm probe leases a unique 8-byte marker comm and a target file in " +
+			"a fresh tempdir, returning $probe with .marker, .marker_hex, .file, and " +
+			".dir. Load an lsm/file_open program with -g target_comm=0x${probe.marker_hex} " +
+			"so it counts only the marker's opens, then lsm fire $probe N opens the " +
+			"target N times under the marker comm. Remove $probe.dir on cleanup.",
+	})
+}
+
+func handleLsm(c driver.Ctx) (runtime.Value, error) {
+	if len(c.Args) == 0 {
+		return runtime.Value{}, fmt.Errorf("lsm: subcommand required (valid: probe, fire)")
+	}
+	sub := driver.ArgText(c.Args[0])
+	rest := c.Args[1:]
+	switch sub {
+	case "probe":
+		return handleLsmProbe(rest)
+	case "fire":
+		return handleLsmFire(c, rest)
+	default:
+		return runtime.Value{}, fmt.Errorf("lsm: unknown subcommand %q (valid: probe, fire)", sub)
+	}
+}
+
+// handleLsmProbe leases a probe: a unique marker comm and a target file
+// in a fresh tempdir. The marker is 8 lowercase letters so it fits the
+// comm field with room to spare and packs cleanly into the u64 the
+// program's filter compares.
+func handleLsmProbe(args []runtime.Arg) (runtime.Value, error) {
+	if len(args) != 0 {
+		return runtime.Value{}, fmt.Errorf("lsm probe: takes no arguments")
+	}
+	marker, err := randomMarker()
+	if err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm probe: %w", err)
+	}
+
+	dir, err := os.MkdirTemp("", "lsm-probe-")
+	if err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm probe: create tempdir: %w", err)
+	}
+
+	file := filepath.Join(dir, "target")
+	if err := os.WriteFile(file, []byte("lsm probe target\n"), 0o644); err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm probe: create target file: %w", err)
+	}
+
+	return runtime.ValueFromLsmProbe(&runtime.LsmProbe{
+		Marker:    marker,
+		MarkerHex: hex.EncodeToString([]byte(marker)),
+		File:      file,
+		Dir:       dir,
+	}), nil
+}
+
+// handleLsmFire opens the probe's target file N times from a worker
+// subprocess whose comm is the probe's marker, so the program's filter
+// attributes exactly those opens. The worker is a re-exec of this binary
+// in lsm-open-worker mode; it runs synchronously so the counter is
+// settled when fire returns.
+func handleLsmFire(c driver.Ctx, args []runtime.Arg) (runtime.Value, error) {
+	if len(args) != 2 {
+		return runtime.Value{}, fmt.Errorf("lsm fire: requires $probe and N")
+	}
+	probe, err := lsmProbeFromArg(args[0])
+	if err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm fire: %w", err)
+	}
+
+	n, err := strconv.Atoi(driver.ArgText(args[1]))
+	if err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm fire: N: %w", err)
+	}
+
+	if n < 0 {
+		return runtime.Value{}, fmt.Errorf("lsm fire: N must not be negative (got %d)", n)
+	}
+
+	shellPath, err := os.Executable()
+	if err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm fire: resolve executable path: %w", err)
+	}
+
+	cmd := exec.CommandContext(c.Ctx, shellPath, probe.Marker, probe.File, strconv.Itoa(n))
+	cmd.Env = append(os.Environ(), "BPFMAN_SHELL_MODE=lsm-open-worker")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return runtime.Value{}, fmt.Errorf("lsm fire: worker failed: %w: %s", err, out)
+	}
+	return runtime.ValueFromEnvelope(runtime.OkEnvelope()), nil
+}
+
+// randomMarker returns 8 lowercase ASCII letters, unique enough per
+// probe that concurrent lsm fixtures on one host do not share a comm.
+func randomMarker() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("read random marker: %w", err)
+	}
+	for i := range b {
+		b[i] = 'a' + b[i]%26
+	}
+	return string(b[:]), nil
+}
+
+func lsmProbeFromArg(a runtime.Arg) (*runtime.LsmProbe, error) {
+	sva, ok := a.(runtime.StructuredValueArg)
+	if !ok {
+		return nil, fmt.Errorf("expected a $probe argument, got %T", a)
+	}
+	if sva.Value.Kind() != semantics.OriginLsm {
+		return nil, fmt.Errorf("expected a $probe argument, got a %s value", sva.Value.Kind())
+	}
+	probe, ok := sva.Value.Origin().(*runtime.LsmProbe)
+	if !ok {
+		return nil, fmt.Errorf("$probe has no underlying handle (got %T)", sva.Value.Origin())
+	}
+	return probe, nil
+}

--- a/cmd/bpfman-shell/shell/runtime/lsm.go
+++ b/cmd/bpfman-shell/shell/runtime/lsm.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"github.com/bpfman/bpfman/cmd/bpfman-shell/shell/semantics"
+)
+
+// LsmProbe is the user-visible handle for one LSM fixture probe,
+// produced by `lsm probe` and consumed by `lsm fire`. It owns a unique
+// marker comm and a target file: `lsm fire` opens the target under the
+// marker comm so an LSM program filtering file_open by that comm counts
+// exactly the fixture's opens, isolated from the host's own file
+// activity. The marker is carried into the program at load time via the
+// marker_hex global-data value.
+type LsmProbe struct {
+	// Marker is the 8-byte comm the fire worker sets on itself before
+	// opening the target; the attach point for the program's filter.
+	Marker string
+
+	// MarkerHex is Marker's bytes in order as hex, for the load-time
+	// `-g target_comm=0x<hex>` global that seeds the program's filter.
+	MarkerHex string
+
+	// File is the target file the fire worker opens; each open is one
+	// file_open event carrying the marker comm.
+	File string
+
+	// Dir is the tempdir owning File, for the script to remove on
+	// cleanup (`defer exec rm -rf $probe.dir`).
+	Dir string
+}
+
+// ValueFromLsmProbe wraps p as a Value with semantics.OriginLsm.
+func ValueFromLsmProbe(p *LsmProbe) Value {
+	mirror := map[string]any{
+		"marker":     p.Marker,
+		"marker_hex": p.MarkerHex,
+		"file":       p.File,
+		"dir":        p.Dir,
+	}
+	return Value{v: mirror, origin: p, kind: semantics.OriginLsm}
+}

--- a/cmd/bpfman-shell/shell/runtime/origin_test.go
+++ b/cmd/bpfman-shell/shell/runtime/origin_test.go
@@ -26,6 +26,7 @@ func TestOriginKind_String(t *testing.T) {
 		{semantics.OriginEnvelope, "result"},
 		{semantics.OriginNetnsVethPair, "netns-veth-pair"},
 		{semantics.OriginNetnsVethEndpoint, "netns-veth-pair endpoint"},
+		{semantics.OriginLsm, "lsm probe"},
 		{semantics.OriginKind(999), "OriginKind(999)"},
 	}
 	for _, tc := range cases {
@@ -112,6 +113,11 @@ func TestValue_InternalOriginMirrorKeysMatchSealedShapeFields(t *testing.T) {
 			name: semantics.OriginNetnsVethEndpoint.String(),
 			kind: semantics.OriginNetnsVethEndpoint,
 			v:    valueFromNetnsVethEndpoint(testNetnsVethPair().A),
+		},
+		{
+			name: semantics.OriginLsm.String(),
+			kind: semantics.OriginLsm,
+			v:    ValueFromLsmProbe(&LsmProbe{Marker: "lsmf0001", MarkerHex: "6c736d6630303031", File: "/tmp/lsm-probe/target", Dir: "/tmp/lsm-probe"}),
 		},
 	}
 	for _, tc := range cases {

--- a/cmd/bpfman-shell/shell/semantics/bindshape.go
+++ b/cmd/bpfman-shell/shell/semantics/bindshape.go
@@ -27,6 +27,7 @@ var bindShapeRegistry = map[string]bindShapeFn{
 	"fire":          staticBindShape(KindShape(OriginJob)),
 	"kfunc":         inferKfuncBindShape,
 	"kill":          staticBindShape(KindShape(OriginEnvelope)),
+	"lsm":           inferLsmBindShape,
 	"linkinfo":      staticBindShape(KindShape(OriginLinkInfo)),
 	"net":           inferNetBindShape,
 	"process":       staticBindShape(Shape{Sealed: false, Kind: OriginUnknown}),
@@ -91,6 +92,23 @@ func inferKfuncBindShape(args []syntax.Expr) Shape {
 	case "acquire":
 		return KindShape(OriginKfunc)
 	case "release", "fire":
+		return KindShape(OriginEnvelope)
+	}
+	return Shape{Sealed: false, Kind: OriginUnknown}
+}
+
+func inferLsmBindShape(args []syntax.Expr) Shape {
+	if len(args) < 1 {
+		return Shape{Sealed: false, Kind: OriginUnknown}
+	}
+	sub, ok := args[0].(*syntax.LiteralExpr)
+	if !ok || sub.Quoted {
+		return Shape{Sealed: false, Kind: OriginUnknown}
+	}
+	switch sub.Text {
+	case "probe":
+		return KindShape(OriginLsm)
+	case "fire":
 		return KindShape(OriginEnvelope)
 	}
 	return Shape{Sealed: false, Kind: OriginUnknown}

--- a/cmd/bpfman-shell/shell/semantics/origin.go
+++ b/cmd/bpfman-shell/shell/semantics/origin.go
@@ -137,6 +137,16 @@ const (
 	// tag) read by id or from a pinned path. Like OriginLinkInfo
 	// it is a snapshot rather than a handle.
 	OriginProgInfo
+
+	// OriginLsm tags a Value that wraps an LsmProbe: the handle
+	// returned by `lsm probe`, owning a unique marker comm and a
+	// target file used to drive deterministic, self-attributed
+	// file_open events past an LSM program. `lsm fire` opens the
+	// target under the marker comm so the program's comm filter
+	// counts exactly those opens. Field reads (marker, marker_hex,
+	// file, dir) expose the marker for load-time global data and
+	// the tempdir for cleanup.
+	OriginLsm
 )
 
 // String returns the canonical name used in user-facing error
@@ -178,6 +188,8 @@ func (k OriginKind) String() string {
 		return "link info"
 	case OriginProgInfo:
 		return "program info"
+	case OriginLsm:
+		return "lsm probe"
 	default:
 		return fmt.Sprintf("OriginKind(%d)", int(k))
 	}
@@ -338,6 +350,16 @@ var (
 				"type": {Sealed: true, Kind: OriginScalar},
 				"name": {Sealed: true, Kind: OriginScalar},
 				"tag":  {Sealed: true, Kind: OriginScalar},
+			},
+		},
+		OriginLsm: {
+			Sealed: true,
+			Kind:   OriginLsm,
+			Fields: map[string]Shape{
+				"marker":     {Sealed: true, Kind: OriginScalar},
+				"marker_hex": {Sealed: true, Kind: OriginScalar},
+				"file":       {Sealed: true, Kind: OriginScalar},
+				"dir":        {Sealed: true, Kind: OriginScalar},
 			},
 		},
 		OriginMap:     {Sealed: false, Kind: OriginMap},

--- a/cmd/bpfman/attach.go
+++ b/cmd/bpfman/attach.go
@@ -42,6 +42,9 @@ type AttachCmd struct {
 	// Fexit attaches a loaded program to a function-exit tracing
 	// point.
 	Fexit AttachFexitCmd `cmd:"" help:"Attach a program to a function exit tracing point."`
+
+	// Lsm attaches a loaded program to an LSM hook.
+	Lsm AttachLsmCmd `cmd:"" help:"Attach a program to an LSM hook."`
 }
 
 // runAttach is the common attach pattern: build the spec, create the
@@ -406,6 +409,33 @@ func (c *AttachFexitCmd) Run(cli *runtime.CLI, ctx context.Context) error {
 		spec, err := bpfman.NewFexitAttachSpec(c.ProgramID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid fexit spec: %w", err)
+		}
+
+		return spec.WithMetadata(args.MetadataMap(c.Metadata)), nil
+	})
+}
+
+// AttachLsmCmd attaches a program to an LSM hook.
+type AttachLsmCmd struct {
+	// OutputFlags carries the -o/--output flag selecting text or
+	// JSON rendering of the created link.
+	cliformat.OutputFlags
+
+	// MetadataFlags carries the repeatable -m/--metadata
+	// key/value labels recorded on the new link.
+	MetadataFlags
+
+	// ProgramID is the kernel ID of the loaded LSM program to
+	// attach. The hook is fixed at load time, so no further target
+	// is required.
+	ProgramID kernel.ProgramID `arg:"" name:"program-id" help:"Program ID to attach."`
+}
+
+func (c *AttachLsmCmd) Run(cli *runtime.CLI, ctx context.Context) error {
+	return runAttach(cli, ctx, &c.OutputFlags, func() (bpfman.AttachSpec, error) {
+		spec, err := bpfman.NewLsmAttachSpec(c.ProgramID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid lsm spec: %w", err)
 		}
 
 		return spec.WithMetadata(args.MetadataMap(c.Metadata)), nil

--- a/cmd/bpfman/cliformat/format.go
+++ b/cmd/bpfman/cliformat/format.go
@@ -371,6 +371,8 @@ func formatAttachDetails(details bpfman.LinkDetails) string {
 		return d.FnName
 	case bpfman.FexitDetails:
 		return d.FnName
+	case bpfman.LsmDetails:
+		return d.HookName
 	case bpfman.XDPDetails:
 		return fmt.Sprintf("%s (ifindex=%d, pos=%d)", d.Interface, d.Ifindex, d.Position)
 	case bpfman.TCDetails:

--- a/cmd/bpfman/cliformat/link.go
+++ b/cmd/bpfman/cliformat/link.go
@@ -155,6 +155,8 @@ func attachmentSummary(details bpfman.LinkDetails) string {
 		return d.FnName
 	case bpfman.FexitDetails:
 		return d.FnName
+	case bpfman.LsmDetails:
+		return d.HookName
 	default:
 		return "<none>"
 	}
@@ -203,6 +205,8 @@ func linkDetailRows(view LinkGetView) []row {
 		add("Target Function", d.FnName)
 	case bpfman.FexitDetails:
 		add("Target Function", d.FnName)
+	case bpfman.LsmDetails:
+		add("LSM Hook", d.HookName)
 	case bpfman.KprobeDetails:
 		if d.Retprobe {
 			add("Attach Type", "kretprobe")

--- a/cmd/bpfman/load_file.go
+++ b/cmd/bpfman/load_file.go
@@ -36,7 +36,7 @@ type loadFlags struct {
 	// the ATTACH_FUNC component is required. The flag is required: there is
 	// no untyped bulk load, because a section-derived type would be a guess
 	// (classifier sections cannot distinguish tc from tcx).
-	Programs []args.ProgramSpec `name:"programs" sep:"," required:"" help:"TYPE:NAME or TYPE:NAME:ATTACH_FUNC program to load (comma-separated or repeated). For fentry/fexit, ATTACH_FUNC is required. Every program to load must be named."`
+	Programs []args.ProgramSpec `name:"programs" sep:"," required:"" help:"TYPE:NAME or TYPE:NAME:ATTACH_FUNC program to load (comma-separated or repeated). For fentry/fexit/lsm, ATTACH_FUNC is required (the traced function, or the lsm hook). Every program to load must be named."`
 
 	// Application groups the loaded programs under an application name,
 	// stored as the bpfman.io/application metadata key.

--- a/cmd/internal/args/types.go
+++ b/cmd/internal/args/types.go
@@ -155,7 +155,8 @@ func GlobalDataMap(gds []GlobalData) map[string][]byte {
 }
 
 // ProgramSpec represents a TYPE:NAME[:ATTACH_FUNC] program specification for loading.
-// For fentry and fexit, the attach function is required.
+// For fentry, fexit and lsm, the attach function (the traced function, or
+// the lsm hook) is required.
 type ProgramSpec struct {
 	// Type is the validated program type parsed from the spec's first component.
 	Type bpfman.ProgramType
@@ -163,7 +164,7 @@ type ProgramSpec struct {
 	// Name is the program name within the ELF object, taken from the spec's second component.
 	Name string
 
-	// AttachFunc is the optional attach function from the spec's third component; it is required for fentry and fexit.
+	// AttachFunc is the optional attach function from the spec's third component; it is required for fentry, fexit and lsm.
 	AttachFunc string
 }
 
@@ -172,9 +173,11 @@ type ProgramSpec struct {
 //   - "xdp:xdp_pass"
 //   - "tc:stats"
 //   - "fentry:test_fentry:do_unlinkat"
+//   - "lsm:test_lsm:file_open"
 //
 // The type is validated against known program types at parse time.
-// For fentry and fexit, the attach function (third component) is required.
+// For fentry, fexit and lsm, the attach function (third component,
+// the traced function or the lsm hook) is required.
 func ParseProgramSpec(s string) (ProgramSpec, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -202,11 +205,12 @@ func ParseProgramSpec(s string) (ProgramSpec, error) {
 
 	progType, err := bpfman.ParseProgramType(typeStr)
 	if err != nil {
-		return ProgramSpec{}, fmt.Errorf("invalid program spec %q: unknown type %q (valid: xdp, tc, tcx, tracepoint, kprobe, kretprobe, uprobe, uretprobe, fentry, fexit)", s, typeStr)
+		return ProgramSpec{}, fmt.Errorf("invalid program spec %q: unknown type %q (valid: xdp, tc, tcx, tracepoint, kprobe, kretprobe, uprobe, uretprobe, fentry, fexit, lsm)", s, typeStr)
 	}
 
-	// Validate fentry/fexit require attach function
-	if (progType == bpfman.ProgramTypeFentry || progType == bpfman.ProgramTypeFexit) && attachFunc == "" {
+	// fentry/fexit require the traced function and lsm the hook, all
+	// supplied as the third component (see RequiresAttachFunc).
+	if progType.RequiresAttachFunc() && attachFunc == "" {
 		return ProgramSpec{}, fmt.Errorf("invalid program spec %q: %s requires attach function (format: %s:FUNC_NAME:ATTACH_FUNC)", s, typeStr, typeStr)
 	}
 

--- a/e2e/grpc/lifecycle_test.go
+++ b/e2e/grpc/lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -59,6 +60,10 @@ type typeSpec struct {
 	enumType      pb.BpfmanProgramType
 	loadInfo      *pb.ProgSpecificInfo
 	attachBuilder func(t *testing.T, gid int) func() *pb.AttachInfo
+	// precheck, when set, runs once at the start of the type's
+	// sub-test and may t.Skip it -- used by lsm to skip on kernels
+	// without the BPF LSM in the active list.
+	precheck func(t *testing.T)
 }
 
 // TestParallel_GRPC runs each program type's lifecycle as a
@@ -82,6 +87,7 @@ func TestParallel_GRPC(t *testing.T) {
 		tracepointSpec(),
 		fentrySpec(),
 		fexitSpec(),
+		lsmSpec(),
 		uprobeSpec(),
 		xdpSpec(),
 		tcSpec(),
@@ -163,6 +169,9 @@ func TestParallel_GRPC(t *testing.T) {
 		counter := counts[spec.name]
 		t.Run(spec.name, func(t *testing.T) {
 			t.Parallel()
+			if spec.precheck != nil {
+				spec.precheck(t)
+			}
 			runParallelLifecycles(t, spec, counter)
 		})
 	}
@@ -522,6 +531,47 @@ func fexitSpec() typeSpec {
 				FexitAttachInfo: &pb.FexitAttachInfo{},
 			},
 		}),
+	}
+}
+
+// grpcLsmHook is the LSM hook the lsm sub-test loads and attaches
+// against. file_open is a mandatory, always-present hook; the program
+// always allows (returns 0), so cycling it under load is safe.
+const grpcLsmHook = "file_open"
+
+func lsmSpec() typeSpec {
+	return typeSpec{
+		name:     "lsm",
+		object:   "lsm_exact.bpf.o",
+		progName: "test_lsm",
+		enumType: pb.BpfmanProgramType_LSM,
+		loadInfo: &pb.ProgSpecificInfo{
+			Info: &pb.ProgSpecificInfo_LsmLoadInfo{
+				LsmLoadInfo: &pb.LsmLoadInfo{HookName: grpcLsmHook},
+			},
+		},
+		attachBuilder: constantAttachBuilder(&pb.AttachInfo{
+			Info: &pb.AttachInfo_LsmAttachInfo{
+				LsmAttachInfo: &pb.LsmAttachInfo{},
+			},
+		}),
+		precheck: skipUnlessBPFLSM,
+	}
+}
+
+// skipUnlessBPFLSM skips the caller unless the running kernel has the
+// BPF LSM in its active list. Attaching a BPF_PROG_TYPE_LSM program
+// needs "bpf" present in /sys/kernel/security/lsm (CONFIG_BPF_LSM plus
+// lsm=...,bpf); GitHub-hosted runners ship CONFIG_BPF_LSM=y but not the
+// active entry, and it cannot be enabled without a reboot. Mirrors the
+// kmod-availability skip guarding TestParallel_GRPC.
+func skipUnlessBPFLSM(t *testing.T) {
+	data, err := os.ReadFile("/sys/kernel/security/lsm")
+	if err != nil {
+		t.Skipf("cannot read /sys/kernel/security/lsm (%v); BPF LSM support unknown", err)
+	}
+	if !slices.Contains(strings.Split(strings.TrimSpace(string(data)), ","), "bpf") {
+		t.Skipf("BPF LSM not in the active list (%s); boot with lsm=...,bpf to run the lsm sub-test", strings.TrimSpace(string(data)))
 	}
 }
 

--- a/e2e/scriptrunner/scripts_test.go
+++ b/e2e/scriptrunner/scripts_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -126,6 +127,7 @@ func TestBPFManScripts(t *testing.T) {
 	// subtest, so one malformed pragma does not abort
 	// registration of the rest of the corpus.
 	selector := scriptLabelSelector(t)
+	bpfLSM := bpfLSMActive()
 	serial := make(map[string]bool, len(matches))
 	exclusive := make(map[string]bool, len(matches))
 	metadata := make(map[string]scriptMetadata, len(matches))
@@ -177,6 +179,11 @@ func TestBPFManScripts(t *testing.T) {
 					meta.mode.Labels.Get("requires-clsact-reclaim") == "true" &&
 					!tcpolicy.ReclaimClsactOnDetach {
 					skipReason = "tcpolicy.ReclaimClsactOnDetach is false; flip it to true to run this"
+				}
+				if skipReason == "" &&
+					meta.mode.Labels.Get("requires-bpf-lsm") == "true" &&
+					!bpfLSM {
+					skipReason = "BPF LSM not in the active list (/sys/kernel/security/lsm lacks bpf); boot with lsm=...,bpf to run this"
 				}
 			}
 			t.Run(name, func(t *testing.T) {
@@ -363,6 +370,20 @@ func scriptLabelSelector(t *testing.T) k8slabels.Selector {
 	}
 
 	return selector
+}
+
+// bpfLSMActive reports whether the running kernel has the BPF LSM in
+// its active list, read from /sys/kernel/security/lsm. Scripts labelled
+// requires-bpf-lsm=true attach BPF_PROG_TYPE_LSM programs, which needs
+// "bpf" in that list (CONFIG_BPF_LSM plus lsm=...,bpf); GitHub-hosted
+// runners ship CONFIG_BPF_LSM=y without the active entry and cannot add
+// it without a reboot, so those scripts skip there rather than fail.
+func bpfLSMActive() bool {
+	data, err := os.ReadFile("/sys/kernel/security/lsm")
+	if err != nil {
+		return false
+	}
+	return slices.Contains(strings.Split(strings.TrimSpace(string(data)), ","), "bpf")
 }
 
 func scriptSelectorSkipReason(selector k8slabels.Selector, labels k8slabels.Set) string {

--- a/e2e/scripts/TestLsm_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestLsm_LinkRoundTrip.bpfman
@@ -1,0 +1,93 @@
+# -*- mode: bpfman -*-
+#pragma labels={"program":"lsm","requires-bpf-lsm":"true"}
+#
+# Given: an LSM program attached to the file_open hook, counting only
+# opens made by a leased fixture probe (identified by its marker comm),
+# so the count is deterministic despite file_open being system-wide
+#
+# When: the link is fetched and listed, the probe fires a known number
+# of opens, then the link is detached and the probe fires again
+#
+# Then: get/list round-trip the link, the link details carry the LSM
+# hook name exhaustively, the program counts exactly the fired opens,
+# and after detach further opens are not counted
+
+import ../lib.bpfman
+
+let count = 50
+
+# Lease a probe: a unique marker comm plus a target file. The program
+# counts only opens whose comm matches this marker, so the box's own
+# file activity does not perturb the count.
+guard probe <- lsm probe
+defer exec rm -rf $probe.dir
+
+guard loaded <- bpfman program load file testdata/bpf/lsm_exact.bpf.o --programs "lsm:test_lsm:file_open" -g "target_comm=0x${probe.marker_hex}"
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+
+# bpfman program type lsm; kernel program type lsm (distinct from
+# fentry/fexit's tracing). The hook is stored in attach_func, shared
+# with fentry/fexit.
+expect_program_load $prog lsm lsm test_lsm
+assert $prog.record.load.attach_func == file_open
+
+guard link <- bpfman link attach lsm $prog -m owner=lsm
+let linkID = $link.record.id
+expect_pinned_link_identity $link
+
+assert $link.record.kind == lsm
+assert $link.record.metadata.owner == lsm
+assert $link.record.program_id == $pid
+assert $link.status.kernel_seen
+
+# The new LSM link detail: the hook name, matched exhaustively so an
+# extra or renamed detail field is caught.
+assert $link.record.details matches exhaustive {
+    hook_name: file_open
+}
+
+guard gotLink <- bpfman link get $linkID
+expect_link_get_identity $gotLink $link $linkID
+assert $gotLink.record.id == $linkID
+assert $gotLink.record.kind == lsm
+assert $gotLink.record.details.hook_name == file_open
+
+guard listed <- bpfman link list -o json
+expect_link_list_identity $listed $link $linkID lsm
+
+# Behavioural: nothing carries the marker comm yet, so the counter
+# starts at zero. Firing the probe opens the target exactly $count
+# times under the marker, and the program counts exactly those.
+# The program carries a .rodata global map alongside the counter, so
+# select the counter map by name rather than by position.
+let mapID = $prog.status.maps |> jq '[.[] | select(.name == "lsm_count")][0].id'
+let counterFilter = "fromjson | .[0].formatted.value | tonumber"
+
+guard beforeDump <- bpftool map dump id $mapID -j
+let before = $beforeDump.stdout |> jq $counterFilter
+assert $before == 0
+
+guard _ <- lsm fire $probe $count
+
+guard afterDump <- bpftool map dump id $mapID -j
+let after = $afterDump.stdout |> jq $counterFilter
+print "lsm hook=file_open marker=${probe.marker} count=${after} want=${count}"
+assert $after == $count
+
+bpfman link detach $link
+assert fail bpfman link get $linkID
+
+guard listedAfter <- bpfman link list -o json
+assert_link_absent $listedAfter $linkID
+
+# After detach the program no longer observes the hook, so firing the
+# probe again leaves the counter untouched.
+guard _ <- lsm fire $probe $count
+guard detachedDump <- bpftool map dump id $mapID -j
+let afterDetach = $detachedDump.stdout |> jq $counterFilter
+print "lsm after-detach count=${afterDetach} want=${after}"
+assert $afterDetach == $after
+
+bpfman program unload $pid
+assert fail bpfman program get $prog

--- a/e2e/scripts/TestLsm_LoadAndGet.bpfman
+++ b/e2e/scripts/TestLsm_LoadAndGet.bpfman
@@ -1,0 +1,61 @@
+# -*- mode: bpfman -*-
+#pragma labels={"program":"lsm","requires-bpf-lsm":"true"}
+#
+# Given: an LSM program loaded with its hook, with no attach, traffic,
+# or detach activity
+#
+# When: the Program record is read back through program load and
+# program get
+#
+# Then: the load block matches exhaustively -- so a new or renamed field
+# is caught -- pinning the bpfman program type to lsm and the reused
+# attach_func to the file_open hook, while the kernel program type reads
+# lsm (distinct from fentry/fexit's tracing)
+
+import ../lib.bpfman
+
+guard loaded <- bpfman program load file testdata/bpf/lsm_exact.bpf.o --programs "lsm:test_lsm:file_open" -m owner=e2e -m purpose=load-and-get
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+
+expect_program_load $prog lsm lsm test_lsm
+
+# The load block, matched exhaustively. program_type is the bpfman type
+# lsm; attach_func carries the hook (LSM reuses the fentry/fexit
+# attach_func field rather than a separate hook column). Deterministic
+# LSM-specific fields are pinned to literals; the file-load-vs-image
+# fields echo the load response so both source modes assert exactly.
+assert $prog.record.load matches exhaustive {
+    object_path:  not-empty
+    source_path:  $prog.record.load.source_path
+    program_name: test_lsm
+    program_type: lsm
+    attach_func:  file_open
+    map_owner_id: null
+    global_data:  empty
+    image_source: $prog.record.load.image_source
+}
+assert $pid > 0
+
+guard got <- bpfman program get $pid
+expect_program_round_trip $got $prog
+assert $got.record.load matches exhaustive {
+    object_path:  $prog.record.load.object_path
+    source_path:  $prog.record.load.source_path
+    program_name: test_lsm
+    program_type: lsm
+    attach_func:  file_open
+    map_owner_id: $prog.record.load.map_owner_id
+    global_data:  empty
+    image_source: $prog.record.load.image_source
+}
+assert $got.status.kernel.program_type == lsm
+
+guard listed <- bpfman program list -o json
+let ours = $listed |> jq ".programs[] | select(.record.program_id == ${pid})"
+assert present $ours
+assert $ours.record.load.program_type == lsm
+assert $ours.record.load.attach_func == file_open
+
+bpfman program unload $pid
+assert fail bpfman program get $pid

--- a/e2e/testdata/bpf/lsm_exact.bpf.c
+++ b/e2e/testdata/bpf/lsm_exact.bpf.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+// LSM file_open counter for the e2e tests. Attaches to the file_open
+// LSM hook and always allows (returns 0), counting only opens made by
+// the fixture worker -- identified by its 8-byte marker comm, passed in
+// as the target_comm global. file_open fires system-wide, so the comm
+// filter is what makes the count deterministic: the box's own file
+// activity (daemon, shell, bpftool) has a different comm and is ignored.
+// The `lsm` bpfman-shell fixture leases the marker and drives the
+// matching worker. Reading struct file would need vmlinux/CO-RE; the
+// comm helper needs neither, so the program stays on plain UAPI headers.
+
+#include <linux/bpf.h>
+
+#include <bpf/bpf_helpers.h>
+
+// target_comm is the fixture worker's comm, its first 8 bytes packed
+// little-endian into a u64. Set per program instance via global data so
+// concurrent lsm fixtures on one host stay isolated.
+volatile const __u64 target_comm = 0;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __type(key, __u32);
+  __type(value, __u64);
+  __uint(max_entries, 1);
+  __uint(pinning, LIBBPF_PIN_NONE);
+} lsm_count SEC(".maps");
+
+SEC("lsm/file_open")
+int test_lsm(void *ctx) {
+  char comm[16] = {};
+  bpf_get_current_comm(&comm, sizeof(comm));
+
+  __u64 got = 0;
+  __builtin_memcpy(&got, comm, sizeof(got));
+  if (got != target_comm)
+    return 0;
+
+  __u32 key = 0;
+  __u64 *val = bpf_map_lookup_elem(&lsm_count, &key);
+  if (val)
+    __sync_fetch_and_add(val, 1);
+  return 0;
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/link.go
+++ b/link.go
@@ -206,6 +206,18 @@ func (FexitDetails) linkDetails() {}
 // Kind returns LinkKindFexit.
 func (FexitDetails) Kind() LinkKind { return LinkKindFexit }
 
+// LsmDetails contains fields specific to LSM attachments.
+type LsmDetails struct {
+	// HookName is the LSM hook the program guards (e.g. file_open),
+	// fixed at load time from the lsm/<hook> ELF section.
+	HookName string `json:"hook_name"`
+}
+
+func (LsmDetails) linkDetails() {}
+
+// Kind returns LinkKindLsm.
+func (LsmDetails) Kind() LinkKind { return LinkKindLsm }
+
 // XDPDetails contains fields specific to XDP attachments.
 // Netns empty means the root network namespace.
 type XDPDetails struct {
@@ -394,6 +406,7 @@ const (
 	LinkKindUretprobe  LinkKind = "uretprobe"
 	LinkKindFentry     LinkKind = "fentry"
 	LinkKindFexit      LinkKind = "fexit"
+	LinkKindLsm        LinkKind = "lsm"
 	LinkKindXDP        LinkKind = "xdp"
 	LinkKindTC         LinkKind = "tc"
 	LinkKindTCX        LinkKind = "tcx"
@@ -408,6 +421,7 @@ var allLinkKinds = []LinkKind{
 	LinkKindUretprobe,
 	LinkKindFentry,
 	LinkKindFexit,
+	LinkKindLsm,
 	LinkKindXDP,
 	LinkKindTC,
 	LinkKindTCX,
@@ -457,6 +471,8 @@ func ParseLinkKind(s string) (LinkKind, error) {
 		return LinkKindFentry, nil
 	case "fexit":
 		return LinkKindFexit, nil
+	case "lsm":
+		return LinkKindLsm, nil
 	case "xdp":
 		return LinkKindXDP, nil
 	case "tc":
@@ -554,14 +570,16 @@ func newLinkDetails(kind LinkKind) LinkDetails {
 		return &FentryDetails{}
 	case LinkKindFexit:
 		return &FexitDetails{}
+	case LinkKindLsm:
+		return &LsmDetails{}
 	}
 	return nil
 }
 
 // LinkAttachKinds returns the attach subcommand keywords the CLI
 // exposes (xdp, tc, tcx, tracepoint, kprobe, uprobe, fentry,
-// fexit). Eight entries, not ten -- kprobe / kretprobe and uprobe
-// / uretprobe collapse into the kprobe and uprobe attach
+// fexit, lsm). Nine entries, not eleven -- kprobe / kretprobe and
+// uprobe / uretprobe collapse into the kprobe and uprobe attach
 // subcommands respectively, with --retprobe selecting the paired
 // LinkKind at attach time.
 func LinkAttachKinds() []string {
@@ -574,6 +592,7 @@ func LinkAttachKinds() []string {
 		"uprobe",
 		"fentry",
 		"fexit",
+		"lsm",
 	}
 }
 
@@ -601,6 +620,8 @@ func LinkAttachKindDetailsType(attachKind string) reflect.Type {
 		return reflect.TypeFor[FentryDetails]()
 	case "fexit":
 		return reflect.TypeFor[FexitDetails]()
+	case "lsm":
+		return reflect.TypeFor[LsmDetails]()
 	}
 	return nil
 }

--- a/link_list_options_test.go
+++ b/link_list_options_test.go
@@ -103,7 +103,8 @@ func TestLinkKindNames(t *testing.T) {
 	assert.Contains(t, names, "tracepoint")
 	assert.Contains(t, names, "fentry")
 	assert.Contains(t, names, "fexit")
-	assert.Len(t, names, 10)
+	assert.Contains(t, names, "lsm")
+	assert.Len(t, names, 11)
 }
 
 func TestAllLinkKinds(t *testing.T) {
@@ -121,5 +122,6 @@ func TestAllLinkKinds(t *testing.T) {
 	assert.Contains(t, kinds, bpfman.LinkKindTracepoint)
 	assert.Contains(t, kinds, bpfman.LinkKindFentry)
 	assert.Contains(t, kinds, bpfman.LinkKindFexit)
-	assert.Len(t, kinds, 10)
+	assert.Contains(t, kinds, bpfman.LinkKindLsm)
+	assert.Len(t, kinds, 11)
 }

--- a/link_test.go
+++ b/link_test.go
@@ -263,6 +263,7 @@ func TestLinkAttachKindDetailsType_CoversEveryAttachKind(t *testing.T) {
 		"uprobe":     reflect.TypeFor[bpfman.UprobeDetails](),
 		"fentry":     reflect.TypeFor[bpfman.FentryDetails](),
 		"fexit":      reflect.TypeFor[bpfman.FexitDetails](),
+		"lsm":        reflect.TypeFor[bpfman.LsmDetails](),
 	}
 
 	for _, kind := range bpfman.LinkAttachKinds() {

--- a/load_spec.go
+++ b/load_spec.go
@@ -31,10 +31,13 @@ type LoadSpec struct {
 	mapOwnerID      kernel.ProgramID
 }
 
-// RequiresAttachFunc returns true if this program type requires an attach
-// function (fentry and fexit).
+// RequiresAttachFunc returns true if this program type binds its attach
+// target at load time (fentry, fexit and lsm). For fentry/fexit the
+// target is the traced kernel function; for lsm it is the hook, which
+// resolves to the kernel function bpf_lsm_<hook>. All three flow through
+// the same attachFunc field and load-time ProgramSpec.AttachTo.
 func (t ProgramType) RequiresAttachFunc() bool {
-	return t == ProgramTypeFentry || t == ProgramTypeFexit
+	return t == ProgramTypeFentry || t == ProgramTypeFexit || t == ProgramTypeLsm
 }
 
 // Valid reports whether t is one of the known program types. It is the
@@ -150,8 +153,9 @@ func (s LoadSpec) ImageUsername() string { return s.imageUsername }
 // or empty when none was set.
 func (s LoadSpec) ImagePassword() string { return s.imagePassword }
 
-// AttachFunc returns the attach function for fentry/fexit programs, or
-// empty for program types that do not use one.
+// AttachFunc returns the load-time attach target for fentry/fexit/lsm
+// programs (the traced function, or the lsm hook), or empty for program
+// types that do not use one.
 func (s LoadSpec) AttachFunc() string { return s.attachFunc }
 
 // MapOwnerID returns the kernel ID of the program whose maps this

--- a/manager/action/action.go
+++ b/manager/action/action.go
@@ -240,6 +240,20 @@ type AttachFexit struct {
 
 func (AttachFexit) isAction() {}
 
+// AttachLsm attaches a pinned program to an LSM hook.
+type AttachLsm struct {
+	// ProgPinPath is the bpffs program pin of the program to attach.
+	ProgPinPath bpfman.ProgPinPath
+
+	// HookName is the LSM hook the program guards (e.g. file_open).
+	HookName string
+
+	// LinkPinPath is the bpffs path at which to pin the resulting link.
+	LinkPinPath bpfman.LinkPath
+}
+
+func (AttachLsm) isAction() {}
+
 // Kernel link actions - operations on kernel links
 
 // DetachLink tears down a kernel-attached BPF link synchronously

--- a/manager/action/doc.go
+++ b/manager/action/doc.go
@@ -15,7 +15,7 @@
 //   - Kernel:     LoadProgram, UnloadProgram, DetachLink, RemoveMapsPins,
 //     AttachTracepoint, AttachKprobe, AttachTCX,
 //     AttachUprobeLocal, AttachUprobeContainer, AttachFentry,
-//     AttachFexit
+//     AttachFexit, AttachLsm
 //   - Filesystem: PublishBytecode, RemoveProgramDir,
 //     RemoveDispatcherRevDir
 //   - Rebuild:    RebuildXDPDispatcher, RebuildTCDispatcher,

--- a/manager/attach.go
+++ b/manager/attach.go
@@ -47,6 +47,8 @@ func (m *Manager) Attach(ctx context.Context, writeLock lock.WriterScope, spec b
 		return m.attachFentry(ctx, s)
 	case bpfman.FexitAttachSpec:
 		return m.attachFexit(ctx, s)
+	case bpfman.LsmAttachSpec:
+		return m.attachLsm(ctx, s)
 	case bpfman.XDPAttachSpec:
 		return m.attachXDP(ctx, s)
 	case bpfman.TCAttachSpec:

--- a/manager/attach_test.go
+++ b/manager/attach_test.go
@@ -214,6 +214,119 @@ func TestFexit_FullLifecycle(t *testing.T) {
 }
 
 // =============================================================================
+// LSM Lifecycle Tests
+// =============================================================================
+//
+// LSM programs bind their hook at load time and reuse the fentry/fexit
+// attach-func plumbing: the hook is supplied to NewAttachLoadSpec and
+// stored in the program's AttachFunc, then surfaced on the link as
+// LsmDetails.HookName.
+
+// TestLsm_AttachSucceeds verifies that:
+//
+//	Given a loaded LSM program with its hook specified,
+//	When I attach it,
+//	Then a link is created.
+func TestLsm_AttachSucceeds(t *testing.T) {
+	t.Parallel()
+
+	fix := newTestFixture(t)
+	ctx := context.Background()
+
+	spec, err := bpfman.NewAttachLoadSpec(fix.BytecodeFile("lsm.o"), "lsm_prog", bpfman.ProgramTypeLsm, "file_open")
+	require.NoError(t, err, "failed to create load spec")
+
+	prog, err := fix.Load(ctx, spec, manager.LoadOpts{})
+	require.NoError(t, err, "Load should succeed")
+
+	attachSpec, err := bpfman.NewLsmAttachSpec(prog.Record.ProgramID)
+	require.NoError(t, err, "failed to create attach spec")
+	link, err := fix.Attach(ctx, attachSpec)
+	require.NoError(t, err, "AttachLsm should succeed")
+	require.NotZero(t, link.Record.ID, "link ID should be non-zero")
+
+	assert.Equal(t, 1, fix.Kernel.LinkCount(), "should have 1 link in kernel")
+}
+
+// TestLsm_LoadWithoutHookName_Fails verifies that:
+//
+//	Given an LSM program load request without a hook specified,
+//	When I try to create the spec,
+//	Then spec creation fails because lsm requires an attach func.
+func TestLsm_LoadWithoutHookName_Fails(t *testing.T) {
+	t.Parallel()
+
+	fix := newTestFixture(t)
+
+	_, err := bpfman.NewLoadSpec("/path/to/lsm.o", "lsm_prog", bpfman.ProgramTypeLsm)
+	require.Error(t, err, "spec creation should fail without a hook for lsm")
+	assert.Contains(t, err.Error(), "attachFunc", "error should mention attachFunc")
+
+	assert.Equal(t, 0, fix.Kernel.ProgramCount(), "no programs should exist")
+}
+
+// TestLsm_FullLifecycle verifies the complete LSM lifecycle and that the
+// hook is surfaced on the link as LsmDetails.HookName.
+func TestLsm_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	fix := newTestFixture(t)
+	ctx := context.Background()
+
+	// Step 1: Load LSM program
+	spec, err := bpfman.NewAttachLoadSpec(fix.BytecodeFile("lsm.o"), "lsm_prog", bpfman.ProgramTypeLsm, "file_open")
+	require.NoError(t, err)
+	prog, err := fix.Load(ctx, spec, manager.LoadOpts{})
+	require.NoError(t, err, "Load should succeed")
+
+	// Step 2: Attach
+	attachSpec, err := bpfman.NewLsmAttachSpec(prog.Record.ProgramID)
+	require.NoError(t, err)
+	link, err := fix.Attach(ctx, attachSpec)
+	require.NoError(t, err, "Attach should succeed")
+
+	assert.Equal(t, 1, fix.Kernel.ProgramCount(), "should have 1 program")
+	assert.Equal(t, 1, fix.Kernel.LinkCount(), "should have 1 link")
+
+	// Step 3: Verify link details carry the hook
+	assert.Equal(t, bpfman.LinkKindLsm, link.Record.Kind, "link kind should be lsm")
+	details, ok := link.Record.Details.(bpfman.LsmDetails)
+	require.Truef(t, ok, "expected LsmDetails, got %T", link.Record.Details)
+	assert.Equal(t, "file_open", details.HookName, "hook name should be preserved")
+
+	// Step 4: Detach
+	err = fix.Detach(ctx, link.Record.ID)
+	require.NoError(t, err, "Detach should succeed")
+	assert.Equal(t, 0, fix.Kernel.LinkCount(), "should have 0 links after detach")
+
+	// Step 5: Unload
+	err = fix.Unload(ctx, prog.Record.ProgramID)
+	require.NoError(t, err, "Unload should succeed")
+
+	// Step 6: Verify clean state
+	fix.AssertCleanState()
+}
+
+// TestLsm_HookNamePreservedAfterLoad verifies that the hook specified at
+// load time is recoverable from the stored program record (in AttachFunc,
+// which lsm shares with fentry/fexit).
+func TestLsm_HookNamePreservedAfterLoad(t *testing.T) {
+	t.Parallel()
+
+	fix := newTestFixture(t)
+	ctx := context.Background()
+
+	spec, err := bpfman.NewAttachLoadSpec(fix.BytecodeFile("lsm.o"), "lsm_prog", bpfman.ProgramTypeLsm, "socket_connect")
+	require.NoError(t, err)
+
+	prog, err := fix.Load(ctx, spec, manager.LoadOpts{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "socket_connect", prog.Record.Load.AttachFunc(), "hook should be preserved in the stored record")
+	assert.Equal(t, bpfman.ProgramTypeLsm, prog.Record.Load.ProgramType(), "program type should be lsm")
+}
+
+// =============================================================================
 // Kprobe Lifecycle Tests
 // =============================================================================
 

--- a/manager/attach_tracing.go
+++ b/manager/attach_tracing.go
@@ -206,3 +206,31 @@ func (m *Manager) attachFexit(ctx context.Context, spec bpfman.FexitAttachSpec) 
 		},
 	})
 }
+
+// attachLsm attaches a pinned LSM program to its target hook. The hook
+// was specified at load time (from the lsm/<hook> ELF section) and
+// stored in the program's AttachFunc, alongside fentry/fexit.
+func (m *Manager) attachLsm(ctx context.Context, spec bpfman.LsmAttachSpec) (bpfman.Link, error) {
+	return m.simpleAttach(ctx, attachParams{
+		programID:     spec.ProgramID(),
+		metadata:      spec.Metadata(),
+		defaultTarget: fmt.Sprintf("lsm/program/%d", spec.ProgramID()),
+		prepare: func(prog bpfman.ProgramRecord, progPinPath bpfman.ProgPinPath) (attachPlan, error) {
+			hookName := prog.Load.AttachFunc()
+			if hookName == "" {
+				return attachPlan{}, fmt.Errorf("program %d has no hook name (lsm requires hook name at load time)", spec.ProgramID())
+			}
+			return attachPlan{
+				target:  hookName,
+				details: bpfman.LsmDetails{HookName: hookName},
+				attachAction: func(linkPinPath bpfman.LinkPath) action.Action {
+					return action.AttachLsm{
+						ProgPinPath: progPinPath,
+						HookName:    hookName,
+						LinkPinPath: linkPinPath,
+					}
+				},
+			}, nil
+		},
+	})
+}

--- a/manager/executor.go
+++ b/manager/executor.go
@@ -91,6 +91,9 @@ func (e *executor) ExecuteResult(ctx context.Context, a action.Action) (any, err
 	case action.AttachFexit:
 		return e.kernel.AttachFexit(ctx, a.ProgPinPath, a.FnName, a.LinkPinPath)
 
+	case action.AttachLsm:
+		return e.kernel.AttachLsm(ctx, a.ProgPinPath, a.HookName, a.LinkPinPath)
+
 	case action.AttachTCX:
 		return e.kernel.AttachTCX(ctx, a.Ifindex, a.Direction, a.ProgPinPath, a.LinkPinPath, a.NetnsPath, a.Order)
 

--- a/manager/fake_kernel_test.go
+++ b/manager/fake_kernel_test.go
@@ -993,6 +993,34 @@ func (f *fakeKernel) AttachFexit(_ context.Context, progPinPath bpfman.ProgPinPa
 	}, nil
 }
 
+func (f *fakeKernel) AttachLsm(_ context.Context, progPinPath bpfman.ProgPinPath, hookName string, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error) {
+	linkID := kernel.LinkID(f.nextID.Add(1))
+	createPinFile(linkPinPath)
+	kl := kernel.Link{ID: linkID, ProgramID: 0, LinkType: "lsm"}
+	// Store for DetachLink lookup and kernel iteration
+	link := bpfman.Link{
+		Record: bpfman.LinkRecord{
+			ID:           bpfman.LinkID(linkID),
+			Kind:         bpfman.LinkKindLsm,
+			KernelLinkID: &linkID,
+			PinPath:      bpfman.NewLinkPath(linkPinPath),
+			CreatedAt:    time.Now(),
+			Details:      bpfman.LsmDetails{HookName: hookName},
+		},
+		Status: bpfman.LinkStatus{
+			Kernel:     &kl,
+			KernelSeen: true,
+			PinPresent: linkPinPath != "",
+		},
+	}
+	f.links[linkID] = &link
+	return bpfman.AttachOutput{
+		KernelLinkID: &linkID,
+		KernelLink:   &kl,
+		PinPath:      linkPinPath,
+	}, nil
+}
+
 func (f *fakeKernel) DetachLink(_ context.Context, linkPinPath bpfman.LinkPath) error {
 	path := linkPinPath.String()
 	for id, link := range f.links {

--- a/platform/ebpf/attach_tracing.go
+++ b/platform/ebpf/attach_tracing.go
@@ -114,6 +114,27 @@ func (k *kernelAdapter) AttachFexit(ctx context.Context, progPinPath bpfman.Prog
 	return k.attachTracing(ctx, progPinPath, fnName, linkPinPath)
 }
 
+// AttachLsm attaches a pinned LSM program to its hook. The hook was
+// specified at load time (from the lsm/<hook> ELF section, propagated to
+// ProgramSpec.AttachTo) and baked into the program, so link.AttachLSM
+// takes no hook argument -- mirroring how fentry/fexit bind at load.
+func (k *kernelAdapter) AttachLsm(ctx context.Context, progPinPath bpfman.ProgPinPath, hookName string, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error) {
+	prog, err := ebpf.LoadPinnedProgram(progPinPath.String(), nil)
+	if err != nil {
+		return bpfman.AttachOutput{}, fmt.Errorf("load pinned program %s: %w", progPinPath, err)
+	}
+	defer prog.Close()
+
+	lnk, err := link.AttachLSM(link.LSMOptions{
+		Program: prog,
+	})
+	if err != nil {
+		return bpfman.AttachOutput{}, fmt.Errorf("attach lsm to %s: %w", hookName, err)
+	}
+
+	return k.finishProbeAttach(lnk, linkPinPath)
+}
+
 // attachTracing is the shared implementation for fentry and fexit attachment.
 func (k *kernelAdapter) attachTracing(ctx context.Context, progPinPath bpfman.ProgPinPath, fnName string, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error) {
 	prog, err := ebpf.LoadPinnedProgram(progPinPath.String(), nil)

--- a/platform/ebpf/convert.go
+++ b/platform/ebpf/convert.go
@@ -47,6 +47,8 @@ func inferProgramType(sectionName string) bpfman.ProgramType {
 		return bpfman.ProgramTypeFentry
 	case strings.HasPrefix(sectionName, "fexit"):
 		return bpfman.ProgramTypeFexit
+	case strings.HasPrefix(sectionName, "lsm"):
+		return bpfman.ProgramTypeLsm
 	case strings.HasPrefix(sectionName, "xdp"):
 		return bpfman.ProgramTypeXDP
 	case strings.HasPrefix(sectionName, "tcx"):

--- a/platform/ebpf/validate.go
+++ b/platform/ebpf/validate.go
@@ -44,6 +44,7 @@ var _ platform.ProgramValidator = (*ProgramValidator)(nil)
 //   - tcx/* -> tcx
 //   - fentry/* -> fentry
 //   - fexit/* -> fexit
+//   - lsm/* -> lsm
 func InferProgramType(sectionName string) bpfman.ProgramType {
 	return inferProgramType(sectionName)
 }

--- a/platform/interfaces.go
+++ b/platform/interfaces.go
@@ -356,6 +356,10 @@ type ProgramAttacher interface {
 	// AttachFexit attaches a pinned program to a kernel function exit point.
 	// The fnName was specified at load time and stored with the program.
 	AttachFexit(ctx context.Context, progPinPath bpfman.ProgPinPath, fnName string, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error)
+
+	// AttachLsm attaches a pinned program to an LSM hook. The hookName
+	// was specified at load time and stored with the program.
+	AttachLsm(ctx context.Context, progPinPath bpfman.ProgPinPath, hookName string, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error)
 }
 
 // XDPDispatcherResult holds the result of loading an XDP dispatcher.

--- a/platform/store/sqlite/links.go
+++ b/platform/store/sqlite/links.go
@@ -348,6 +348,14 @@ func (s *sqliteStore) populateLinkDetails(ctx context.Context, links []bpfman.Li
 			}
 			return bpfman.LinkID(linkID), d, nil
 		}},
+		{s.stmtListAllLsmDetails, "lsm", func(rows *sql.Rows) (bpfman.LinkID, bpfman.LinkDetails, error) {
+			var linkID int64
+			var d bpfman.LsmDetails
+			if err := rows.Scan(&linkID, &d.HookName); err != nil {
+				return 0, nil, err
+			}
+			return bpfman.LinkID(linkID), d, nil
+		}},
 		{s.stmtListAllXDPDetails, "xdp", func(rows *sql.Rows) (bpfman.LinkID, bpfman.LinkDetails, error) {
 			var linkID int64
 			var d bpfman.XDPDetails
@@ -488,6 +496,10 @@ func (s *sqliteStore) createLink(ctx context.Context, spec bpfman.LinkSpec) (bpf
 	case bpfman.FexitDetails:
 		err = s.saveDetails(ctx, s.stmtSaveFexitDetails, "Fexit", func() ([]any, error) {
 			return []any{id, d.FnName}, nil
+		})
+	case bpfman.LsmDetails:
+		err = s.saveDetails(ctx, s.stmtSaveLsmDetails, "Lsm", func() ([]any, error) {
+			return []any{id, d.HookName}, nil
 		})
 	case bpfman.XDPDetails:
 		err = s.saveDetails(ctx, s.stmtSaveXDPDetails, "XDP", func() ([]any, error) {
@@ -767,6 +779,12 @@ func (s *sqliteStore) getLinkDetails(ctx context.Context, kind bpfman.LinkKind, 
 		return s.getDetailsFromRow(ctx, s.stmtGetFexitDetails, "fexit", linkID, func(row *sql.Row) (bpfman.LinkDetails, error) {
 			var d bpfman.FexitDetails
 			err := row.Scan(&d.FnName)
+			return d, err
+		})
+	case bpfman.LinkKindLsm:
+		return s.getDetailsFromRow(ctx, s.stmtGetLsmDetails, "lsm", linkID, func(row *sql.Row) (bpfman.LinkDetails, error) {
+			var d bpfman.LsmDetails
+			err := row.Scan(&d.HookName)
 			return d, err
 		})
 	case bpfman.LinkKindXDP:

--- a/platform/store/sqlite/migrations/00002_add_lsm.sql
+++ b/platform/store/sqlite/migrations/00002_add_lsm.sql
@@ -1,0 +1,23 @@
+-- Add the 'lsm' link kind's detail table.
+--
+-- LSM programs load like fentry/fexit: the attach target (here the LSM
+-- hook, e.g. file_open) is fixed at load time and stored in
+-- managed_programs.attach_func, so no new program column is needed.
+-- program_type and links.kind are plain TEXT columns whose permitted
+-- values are enforced in the domain, not by a schema CHECK, so adding a
+-- new type needs no table rebuild. The only additive change is the
+-- link_lsm_details table for the hook name shown on lsm links, 1:1 with
+-- links on id and cascading on delete, mirroring link_fexit_details.
+
+-- +goose Up
+CREATE TABLE link_lsm_details (
+    id INTEGER PRIMARY KEY,
+    hook_name TEXT NOT NULL,
+
+    FOREIGN KEY (id)
+        REFERENCES links(id)
+        ON DELETE CASCADE
+) STRICT;
+
+-- +goose Down
+DROP TABLE link_lsm_details;

--- a/platform/store/sqlite/sqlite.go
+++ b/platform/store/sqlite/sqlite.go
@@ -157,6 +157,7 @@ type sqliteStore struct {
 	stmtGetUprobeDetails     *sql.Stmt
 	stmtGetFentryDetails     *sql.Stmt
 	stmtGetFexitDetails      *sql.Stmt
+	stmtGetLsmDetails        *sql.Stmt
 	stmtGetXDPDetails        *sql.Stmt
 	stmtGetTCDetails         *sql.Stmt
 	stmtGetTCXDetails        *sql.Stmt
@@ -167,6 +168,7 @@ type sqliteStore struct {
 	stmtSaveUprobeDetails     *sql.Stmt
 	stmtSaveFentryDetails     *sql.Stmt
 	stmtSaveFexitDetails      *sql.Stmt
+	stmtSaveLsmDetails        *sql.Stmt
 	stmtSaveXDPDetails        *sql.Stmt
 	stmtSaveTCDetails         *sql.Stmt
 	stmtSaveTCXDetails        *sql.Stmt
@@ -177,6 +179,7 @@ type sqliteStore struct {
 	stmtListAllUprobeDetails     *sql.Stmt
 	stmtListAllFentryDetails     *sql.Stmt
 	stmtListAllFexitDetails      *sql.Stmt
+	stmtListAllLsmDetails        *sql.Stmt
 	stmtListAllXDPDetails        *sql.Stmt
 	stmtListAllTCDetails         *sql.Stmt
 	stmtListAllTCXDetails        *sql.Stmt
@@ -400,6 +403,7 @@ func (s *sqliteStore) closeStatements() {
 		s.stmtGetUprobeDetails,
 		s.stmtGetFentryDetails,
 		s.stmtGetFexitDetails,
+		s.stmtGetLsmDetails,
 		s.stmtGetXDPDetails,
 		s.stmtGetTCDetails,
 		s.stmtGetTCXDetails,
@@ -408,6 +412,7 @@ func (s *sqliteStore) closeStatements() {
 		s.stmtSaveUprobeDetails,
 		s.stmtSaveFentryDetails,
 		s.stmtSaveFexitDetails,
+		s.stmtSaveLsmDetails,
 		s.stmtSaveXDPDetails,
 		s.stmtSaveTCDetails,
 		s.stmtSaveTCXDetails,
@@ -416,6 +421,7 @@ func (s *sqliteStore) closeStatements() {
 		s.stmtListAllUprobeDetails,
 		s.stmtListAllFentryDetails,
 		s.stmtListAllFexitDetails,
+		s.stmtListAllLsmDetails,
 		s.stmtListAllXDPDetails,
 		s.stmtListAllTCDetails,
 		s.stmtListAllTCXDetails,
@@ -594,6 +600,7 @@ func (s *sqliteStore) runTransactionAttempt(ctx context.Context, logger *slog.Lo
 		stmtGetUprobeDetails:     tx.StmtContext(ctx, s.stmtGetUprobeDetails),
 		stmtGetFentryDetails:     tx.StmtContext(ctx, s.stmtGetFentryDetails),
 		stmtGetFexitDetails:      tx.StmtContext(ctx, s.stmtGetFexitDetails),
+		stmtGetLsmDetails:        tx.StmtContext(ctx, s.stmtGetLsmDetails),
 		stmtGetXDPDetails:        tx.StmtContext(ctx, s.stmtGetXDPDetails),
 		stmtGetTCDetails:         tx.StmtContext(ctx, s.stmtGetTCDetails),
 		stmtGetTCXDetails:        tx.StmtContext(ctx, s.stmtGetTCXDetails),
@@ -603,6 +610,7 @@ func (s *sqliteStore) runTransactionAttempt(ctx context.Context, logger *slog.Lo
 		stmtSaveUprobeDetails:     tx.StmtContext(ctx, s.stmtSaveUprobeDetails),
 		stmtSaveFentryDetails:     tx.StmtContext(ctx, s.stmtSaveFentryDetails),
 		stmtSaveFexitDetails:      tx.StmtContext(ctx, s.stmtSaveFexitDetails),
+		stmtSaveLsmDetails:        tx.StmtContext(ctx, s.stmtSaveLsmDetails),
 		stmtSaveXDPDetails:        tx.StmtContext(ctx, s.stmtSaveXDPDetails),
 		stmtSaveTCDetails:         tx.StmtContext(ctx, s.stmtSaveTCDetails),
 		stmtSaveTCXDetails:        tx.StmtContext(ctx, s.stmtSaveTCXDetails),
@@ -612,6 +620,7 @@ func (s *sqliteStore) runTransactionAttempt(ctx context.Context, logger *slog.Lo
 		stmtListAllUprobeDetails:     tx.StmtContext(ctx, s.stmtListAllUprobeDetails),
 		stmtListAllFentryDetails:     tx.StmtContext(ctx, s.stmtListAllFentryDetails),
 		stmtListAllFexitDetails:      tx.StmtContext(ctx, s.stmtListAllFexitDetails),
+		stmtListAllLsmDetails:        tx.StmtContext(ctx, s.stmtListAllLsmDetails),
 		stmtListAllXDPDetails:        tx.StmtContext(ctx, s.stmtListAllXDPDetails),
 		stmtListAllTCDetails:         tx.StmtContext(ctx, s.stmtListAllTCDetails),
 		stmtListAllTCXDetails:        tx.StmtContext(ctx, s.stmtListAllTCXDetails),

--- a/platform/store/sqlite/stmts.go
+++ b/platform/store/sqlite/stmts.go
@@ -208,6 +208,11 @@ func (s *sqliteStore) prepareLinkDetailStatements(ctx context.Context) error {
 		return fmt.Errorf("prepare GetFexitDetails: %w", err)
 	}
 
+	const sqlGetLsmDetails = "SELECT hook_name FROM link_lsm_details WHERE id = ?"
+	if s.stmtGetLsmDetails, err = s.db.PrepareContext(ctx, sqlGetLsmDetails); err != nil {
+		return fmt.Errorf("prepare GetLsmDetails: %w", err)
+	}
+
 	const sqlGetXDPDetails = `
 		SELECT d.interface, d.ifindex, d.priority, d.position, d.proceed_on, d.netns, d.nsid, d.dispatcher_program_id, disp.revision
 		FROM link_xdp_details d
@@ -276,6 +281,13 @@ func (s *sqliteStore) prepareLinkDetailStatements(ctx context.Context) error {
 		return fmt.Errorf("prepare SaveFexitDetails: %w", err)
 	}
 
+	const sqlSaveLsmDetails = `
+		INSERT INTO link_lsm_details (id, hook_name)
+		VALUES (?, ?)`
+	if s.stmtSaveLsmDetails, err = s.db.PrepareContext(ctx, sqlSaveLsmDetails); err != nil {
+		return fmt.Errorf("prepare SaveLsmDetails: %w", err)
+	}
+
 	const sqlSaveXDPDetails = `
 		INSERT INTO link_xdp_details (id, interface, ifindex, priority, position, proceed_on, netns, nsid, dispatcher_program_id)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -321,6 +333,11 @@ func (s *sqliteStore) prepareLinkDetailStatements(ctx context.Context) error {
 	const sqlListAllFexitDetails = "SELECT id, fn_name FROM link_fexit_details"
 	if s.stmtListAllFexitDetails, err = s.db.PrepareContext(ctx, sqlListAllFexitDetails); err != nil {
 		return fmt.Errorf("prepare ListAllFexitDetails: %w", err)
+	}
+
+	const sqlListAllLsmDetails = "SELECT id, hook_name FROM link_lsm_details"
+	if s.stmtListAllLsmDetails, err = s.db.PrepareContext(ctx, sqlListAllLsmDetails); err != nil {
+		return fmt.Errorf("prepare ListAllLsmDetails: %w", err)
 	}
 
 	const sqlListAllXDPDetails = `

--- a/program.go
+++ b/program.go
@@ -39,6 +39,7 @@ const (
 	ProgramTypeUretprobe  ProgramType = "uretprobe"
 	ProgramTypeFentry     ProgramType = "fentry"
 	ProgramTypeFexit      ProgramType = "fexit"
+	ProgramTypeLsm        ProgramType = "lsm"
 )
 
 // allProgramTypes is the canonical list of valid program types.
@@ -54,6 +55,7 @@ var allProgramTypes = []ProgramType{
 	ProgramTypeUretprobe,
 	ProgramTypeFentry,
 	ProgramTypeFexit,
+	ProgramTypeLsm,
 }
 
 // AllProgramTypes returns all valid program types.
@@ -89,6 +91,8 @@ func (t ProgramType) KernelType() kernel.ProgramType {
 		return kernel.NewProgramType("kprobe")
 	case ProgramTypeFentry, ProgramTypeFexit:
 		return kernel.NewProgramType("tracing")
+	case ProgramTypeLsm:
+		return kernel.NewProgramType("lsm")
 	case ProgramTypeXDP:
 		return kernel.NewProgramType("xdp")
 	case ProgramTypeTracepoint:
@@ -123,6 +127,8 @@ func ParseProgramType(s string) (ProgramType, error) {
 		return ProgramTypeFentry, nil
 	case "fexit":
 		return ProgramTypeFexit, nil
+	case "lsm":
+		return ProgramTypeLsm, nil
 	default:
 		return "", fmt.Errorf("unknown program type %q", s)
 	}

--- a/program_test.go
+++ b/program_test.go
@@ -120,6 +120,7 @@ func TestProgramType_KernelType(t *testing.T) {
 		bpfman.ProgramTypeUretprobe:  "kprobe",
 		bpfman.ProgramTypeFentry:     "tracing",
 		bpfman.ProgramTypeFexit:      "tracing",
+		bpfman.ProgramTypeLsm:        "lsm",
 	}
 	for pt, want := range cases {
 		assert.Equalf(t, want, pt.KernelType().String(), "KernelType of %s", pt)

--- a/proto/bpfman.proto
+++ b/proto/bpfman.proto
@@ -164,6 +164,15 @@ message FexitAttachInfo {
     map<string, string> metadata = 1;
 }
 
+/* LsmAttachInfo represents the program specific metadata which bpfman
+ * needs to attach an LSM program. The hook is fixed at load time, so no
+ * additional fields are required here.
+ */
+
+message LsmAttachInfo {
+    map<string, string> metadata = 1;
+}
+
 /* Program specific parameters, mostly concerning where and how to attach
  * the eBPF program.
  */
@@ -178,6 +187,7 @@ message AttachInfo {
         TCXAttachInfo tcx_attach_info = 6;
         FentryAttachInfo fentry_attach_info = 7;
         FexitAttachInfo fexit_attach_info = 8;
+        LsmAttachInfo lsm_attach_info = 9;
     }
 };
 
@@ -200,6 +210,7 @@ enum BpfmanProgramType {
     FENTRY = 5;
     FEXIT = 6;
     TCX = 7;
+    LSM = 8;
 }
 
 /* LoadInfo contains per-program information for LoadRequest. */
@@ -219,11 +230,18 @@ message FexitLoadInfo {
     string fn_name = 1;
 }
 
+/* LsmLoadInfo contains the program-specific load information for LoadInfo.
+ * hook_name is the LSM hook the program guards (e.g. file_open). */
+message LsmLoadInfo {
+    string hook_name = 1;
+}
+
 /* ProgSpecificInfo contains the program-specific load information for LoadInfo. */
 message ProgSpecificInfo {
     oneof info {
         FentryLoadInfo fentry_load_info = 1;
         FexitLoadInfo fexit_load_info = 2;
+        LsmLoadInfo lsm_load_info = 3;
     }
 }
 

--- a/server/attach.go
+++ b/server/attach.go
@@ -62,6 +62,9 @@ func (s *Server) Attach(ctx context.Context, req *pb.AttachRequest) (*pb.AttachR
 		case *pb.AttachInfo_FexitAttachInfo:
 			attachType = "fexit"
 			resp, err = s.attachFexit(ctx, writeLock, programID, info.FexitAttachInfo)
+		case *pb.AttachInfo_LsmAttachInfo:
+			attachType = "lsm"
+			resp, err = s.attachLsm(ctx, writeLock, programID, info.LsmAttachInfo)
 		default:
 			return nil, status.Errorf(codes.Unimplemented, "attach type %T not yet implemented", req.Attach.Info)
 		}
@@ -311,6 +314,26 @@ func (s *Server) attachFexit(ctx context.Context, writeLock lock.WriterScope, pr
 	link, err := s.mgr.Attach(ctx, writeLock, spec)
 	if err != nil {
 		return nil, attachManagerError(programID, "fexit", err)
+	}
+
+	return &pb.AttachResponse{
+		LinkId: grpcLinkID(link.Record.ID),
+	}, nil
+}
+
+// attachLsm handles LSM attachment via the manager.
+// The hook name is stored in the program metadata from load time.
+func (s *Server) attachLsm(ctx context.Context, writeLock lock.WriterScope, programID kernel.ProgramID, _ *pb.LsmAttachInfo) (*pb.AttachResponse, error) {
+	// Construct LsmAttachSpec with validated input
+	spec, err := bpfman.NewLsmAttachSpec(programID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lsm attach spec: %v", err)
+	}
+
+	// Call manager
+	link, err := s.mgr.Attach(ctx, writeLock, spec)
+	if err != nil {
+		return nil, attachManagerError(programID, "lsm", err)
 	}
 
 	return &pb.AttachResponse{

--- a/server/convert.go
+++ b/server/convert.go
@@ -30,6 +30,8 @@ func protoToBpfmanType(pt pb.BpfmanProgramType) (bpfman.ProgramType, error) {
 		return bpfman.ProgramTypeFexit, nil
 	case pb.BpfmanProgramType_TCX:
 		return bpfman.ProgramTypeTCX, nil
+	case pb.BpfmanProgramType_LSM:
+		return bpfman.ProgramTypeLsm, nil
 	default:
 		return "", fmt.Errorf("unknown program type: %d", pt)
 	}
@@ -54,6 +56,8 @@ func bpfmanTypeToProto(pt bpfman.ProgramType) uint32 {
 		return uint32(pb.BpfmanProgramType_FEXIT)
 	case bpfman.ProgramTypeTCX:
 		return uint32(pb.BpfmanProgramType_TCX)
+	case bpfman.ProgramTypeLsm:
+		return uint32(pb.BpfmanProgramType_LSM)
 	default:
 		return uint32(pb.BpfmanProgramType_XDP) // zero value
 	}

--- a/server/load.go
+++ b/server/load.go
@@ -59,7 +59,9 @@ func (s *Server) Load(ctx context.Context, req *pb.LoadRequest) (*pb.LoadRespons
 			return nil, status.Errorf(codes.InvalidArgument, "invalid program type for %s: %v", info.Name, err)
 		}
 
-		// Extract AttachFunc from ProgSpecificInfo for fentry/fexit
+		// Extract the load-time attach target from ProgSpecificInfo:
+		// the traced function for fentry/fexit, or the hook for lsm.
+		// All three share the AttachFunc field (see RequiresAttachFunc).
 		var attachFunc string
 		if info.Info != nil {
 			switch i := info.Info.Info.(type) {
@@ -67,6 +69,8 @@ func (s *Server) Load(ctx context.Context, req *pb.LoadRequest) (*pb.LoadRespons
 				attachFunc = i.FentryLoadInfo.FnName
 			case *pb.ProgSpecificInfo_FexitLoadInfo:
 				attachFunc = i.FexitLoadInfo.FnName
+			case *pb.ProgSpecificInfo_LsmLoadInfo:
+				attachFunc = i.LsmLoadInfo.HookName
 			}
 		}
 

--- a/server/pb/bpfman.pb.go
+++ b/server/pb/bpfman.pb.go
@@ -32,6 +32,7 @@ const (
 	BpfmanProgramType_FENTRY     BpfmanProgramType = 5
 	BpfmanProgramType_FEXIT      BpfmanProgramType = 6
 	BpfmanProgramType_TCX        BpfmanProgramType = 7
+	BpfmanProgramType_LSM        BpfmanProgramType = 8
 )
 
 // Enum value maps for BpfmanProgramType.
@@ -45,6 +46,7 @@ var (
 		5: "FENTRY",
 		6: "FEXIT",
 		7: "TCX",
+		8: "LSM",
 	}
 	BpfmanProgramType_value = map[string]int32{
 		"XDP":        0,
@@ -55,6 +57,7 @@ var (
 		"FENTRY":     5,
 		"FEXIT":      6,
 		"TCX":        7,
+		"LSM":        8,
 	}
 )
 
@@ -1032,6 +1035,50 @@ func (x *FexitAttachInfo) GetMetadata() map[string]string {
 	return nil
 }
 
+type LsmAttachInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metadata      map[string]string      `protobuf:"bytes,1,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsmAttachInfo) Reset() {
+	*x = LsmAttachInfo{}
+	mi := &file_bpfman_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsmAttachInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsmAttachInfo) ProtoMessage() {}
+
+func (x *LsmAttachInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_bpfman_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsmAttachInfo.ProtoReflect.Descriptor instead.
+func (*LsmAttachInfo) Descriptor() ([]byte, []int) {
+	return file_bpfman_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *LsmAttachInfo) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type AttachInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Info:
@@ -1044,6 +1091,7 @@ type AttachInfo struct {
 	//	*AttachInfo_TcxAttachInfo
 	//	*AttachInfo_FentryAttachInfo
 	//	*AttachInfo_FexitAttachInfo
+	//	*AttachInfo_LsmAttachInfo
 	Info          isAttachInfo_Info `protobuf_oneof:"info"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1051,7 +1099,7 @@ type AttachInfo struct {
 
 func (x *AttachInfo) Reset() {
 	*x = AttachInfo{}
-	mi := &file_bpfman_proto_msgTypes[12]
+	mi := &file_bpfman_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1063,7 +1111,7 @@ func (x *AttachInfo) String() string {
 func (*AttachInfo) ProtoMessage() {}
 
 func (x *AttachInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[12]
+	mi := &file_bpfman_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1076,7 +1124,7 @@ func (x *AttachInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachInfo.ProtoReflect.Descriptor instead.
 func (*AttachInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{12}
+	return file_bpfman_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *AttachInfo) GetInfo() isAttachInfo_Info {
@@ -1158,6 +1206,15 @@ func (x *AttachInfo) GetFexitAttachInfo() *FexitAttachInfo {
 	return nil
 }
 
+func (x *AttachInfo) GetLsmAttachInfo() *LsmAttachInfo {
+	if x != nil {
+		if x, ok := x.Info.(*AttachInfo_LsmAttachInfo); ok {
+			return x.LsmAttachInfo
+		}
+	}
+	return nil
+}
+
 type isAttachInfo_Info interface {
 	isAttachInfo_Info()
 }
@@ -1194,6 +1251,10 @@ type AttachInfo_FexitAttachInfo struct {
 	FexitAttachInfo *FexitAttachInfo `protobuf:"bytes,8,opt,name=fexit_attach_info,json=fexitAttachInfo,proto3,oneof"`
 }
 
+type AttachInfo_LsmAttachInfo struct {
+	LsmAttachInfo *LsmAttachInfo `protobuf:"bytes,9,opt,name=lsm_attach_info,json=lsmAttachInfo,proto3,oneof"`
+}
+
 func (*AttachInfo_XdpAttachInfo) isAttachInfo_Info() {}
 
 func (*AttachInfo_TcAttachInfo) isAttachInfo_Info() {}
@@ -1210,6 +1271,8 @@ func (*AttachInfo_FentryAttachInfo) isAttachInfo_Info() {}
 
 func (*AttachInfo_FexitAttachInfo) isAttachInfo_Info() {}
 
+func (*AttachInfo_LsmAttachInfo) isAttachInfo_Info() {}
+
 // LoadRequest represents a request to load and attach a bpf program.
 type LoadRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1225,7 +1288,7 @@ type LoadRequest struct {
 
 func (x *LoadRequest) Reset() {
 	*x = LoadRequest{}
-	mi := &file_bpfman_proto_msgTypes[13]
+	mi := &file_bpfman_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1237,7 +1300,7 @@ func (x *LoadRequest) String() string {
 func (*LoadRequest) ProtoMessage() {}
 
 func (x *LoadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[13]
+	mi := &file_bpfman_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1250,7 +1313,7 @@ func (x *LoadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadRequest.ProtoReflect.Descriptor instead.
 func (*LoadRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{13}
+	return file_bpfman_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *LoadRequest) GetBytecode() *BytecodeLocation {
@@ -1307,7 +1370,7 @@ type LoadInfo struct {
 
 func (x *LoadInfo) Reset() {
 	*x = LoadInfo{}
-	mi := &file_bpfman_proto_msgTypes[14]
+	mi := &file_bpfman_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1319,7 +1382,7 @@ func (x *LoadInfo) String() string {
 func (*LoadInfo) ProtoMessage() {}
 
 func (x *LoadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[14]
+	mi := &file_bpfman_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1332,7 +1395,7 @@ func (x *LoadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadInfo.ProtoReflect.Descriptor instead.
 func (*LoadInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{14}
+	return file_bpfman_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *LoadInfo) GetName() string {
@@ -1366,7 +1429,7 @@ type FentryLoadInfo struct {
 
 func (x *FentryLoadInfo) Reset() {
 	*x = FentryLoadInfo{}
-	mi := &file_bpfman_proto_msgTypes[15]
+	mi := &file_bpfman_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1378,7 +1441,7 @@ func (x *FentryLoadInfo) String() string {
 func (*FentryLoadInfo) ProtoMessage() {}
 
 func (x *FentryLoadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[15]
+	mi := &file_bpfman_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1391,7 +1454,7 @@ func (x *FentryLoadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FentryLoadInfo.ProtoReflect.Descriptor instead.
 func (*FentryLoadInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{15}
+	return file_bpfman_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *FentryLoadInfo) GetFnName() string {
@@ -1411,7 +1474,7 @@ type FexitLoadInfo struct {
 
 func (x *FexitLoadInfo) Reset() {
 	*x = FexitLoadInfo{}
-	mi := &file_bpfman_proto_msgTypes[16]
+	mi := &file_bpfman_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1423,7 +1486,7 @@ func (x *FexitLoadInfo) String() string {
 func (*FexitLoadInfo) ProtoMessage() {}
 
 func (x *FexitLoadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[16]
+	mi := &file_bpfman_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1436,12 +1499,58 @@ func (x *FexitLoadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FexitLoadInfo.ProtoReflect.Descriptor instead.
 func (*FexitLoadInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{16}
+	return file_bpfman_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *FexitLoadInfo) GetFnName() string {
 	if x != nil {
 		return x.FnName
+	}
+	return ""
+}
+
+// LsmLoadInfo contains the program-specific load information for LoadInfo.
+// hook_name is the LSM hook the program guards (e.g. file_open).
+type LsmLoadInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HookName      string                 `protobuf:"bytes,1,opt,name=hook_name,json=hookName,proto3" json:"hook_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsmLoadInfo) Reset() {
+	*x = LsmLoadInfo{}
+	mi := &file_bpfman_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsmLoadInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsmLoadInfo) ProtoMessage() {}
+
+func (x *LsmLoadInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_bpfman_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsmLoadInfo.ProtoReflect.Descriptor instead.
+func (*LsmLoadInfo) Descriptor() ([]byte, []int) {
+	return file_bpfman_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *LsmLoadInfo) GetHookName() string {
+	if x != nil {
+		return x.HookName
 	}
 	return ""
 }
@@ -1453,6 +1562,7 @@ type ProgSpecificInfo struct {
 	//
 	//	*ProgSpecificInfo_FentryLoadInfo
 	//	*ProgSpecificInfo_FexitLoadInfo
+	//	*ProgSpecificInfo_LsmLoadInfo
 	Info          isProgSpecificInfo_Info `protobuf_oneof:"info"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1460,7 +1570,7 @@ type ProgSpecificInfo struct {
 
 func (x *ProgSpecificInfo) Reset() {
 	*x = ProgSpecificInfo{}
-	mi := &file_bpfman_proto_msgTypes[17]
+	mi := &file_bpfman_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1472,7 +1582,7 @@ func (x *ProgSpecificInfo) String() string {
 func (*ProgSpecificInfo) ProtoMessage() {}
 
 func (x *ProgSpecificInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[17]
+	mi := &file_bpfman_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1485,7 +1595,7 @@ func (x *ProgSpecificInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgSpecificInfo.ProtoReflect.Descriptor instead.
 func (*ProgSpecificInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{17}
+	return file_bpfman_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ProgSpecificInfo) GetInfo() isProgSpecificInfo_Info {
@@ -1513,6 +1623,15 @@ func (x *ProgSpecificInfo) GetFexitLoadInfo() *FexitLoadInfo {
 	return nil
 }
 
+func (x *ProgSpecificInfo) GetLsmLoadInfo() *LsmLoadInfo {
+	if x != nil {
+		if x, ok := x.Info.(*ProgSpecificInfo_LsmLoadInfo); ok {
+			return x.LsmLoadInfo
+		}
+	}
+	return nil
+}
+
 type isProgSpecificInfo_Info interface {
 	isProgSpecificInfo_Info()
 }
@@ -1525,9 +1644,15 @@ type ProgSpecificInfo_FexitLoadInfo struct {
 	FexitLoadInfo *FexitLoadInfo `protobuf:"bytes,2,opt,name=fexit_load_info,json=fexitLoadInfo,proto3,oneof"`
 }
 
+type ProgSpecificInfo_LsmLoadInfo struct {
+	LsmLoadInfo *LsmLoadInfo `protobuf:"bytes,3,opt,name=lsm_load_info,json=lsmLoadInfo,proto3,oneof"`
+}
+
 func (*ProgSpecificInfo_FentryLoadInfo) isProgSpecificInfo_Info() {}
 
 func (*ProgSpecificInfo_FexitLoadInfo) isProgSpecificInfo_Info() {}
+
+func (*ProgSpecificInfo_LsmLoadInfo) isProgSpecificInfo_Info() {}
 
 // LoadResponseInfo represents the state for a single eBPF program that is maintained
 // internally by bpfman.
@@ -1541,7 +1666,7 @@ type LoadResponseInfo struct {
 
 func (x *LoadResponseInfo) Reset() {
 	*x = LoadResponseInfo{}
-	mi := &file_bpfman_proto_msgTypes[18]
+	mi := &file_bpfman_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1678,7 @@ func (x *LoadResponseInfo) String() string {
 func (*LoadResponseInfo) ProtoMessage() {}
 
 func (x *LoadResponseInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[18]
+	mi := &file_bpfman_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1691,7 @@ func (x *LoadResponseInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadResponseInfo.ProtoReflect.Descriptor instead.
 func (*LoadResponseInfo) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{18}
+	return file_bpfman_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LoadResponseInfo) GetInfo() *ProgramInfo {
@@ -1595,7 +1720,7 @@ type LoadResponse struct {
 
 func (x *LoadResponse) Reset() {
 	*x = LoadResponse{}
-	mi := &file_bpfman_proto_msgTypes[19]
+	mi := &file_bpfman_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1607,7 +1732,7 @@ func (x *LoadResponse) String() string {
 func (*LoadResponse) ProtoMessage() {}
 
 func (x *LoadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[19]
+	mi := &file_bpfman_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1620,7 +1745,7 @@ func (x *LoadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadResponse.ProtoReflect.Descriptor instead.
 func (*LoadResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{19}
+	return file_bpfman_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *LoadResponse) GetPrograms() []*LoadResponseInfo {
@@ -1641,7 +1766,7 @@ type UnloadRequest struct {
 
 func (x *UnloadRequest) Reset() {
 	*x = UnloadRequest{}
-	mi := &file_bpfman_proto_msgTypes[20]
+	mi := &file_bpfman_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1653,7 +1778,7 @@ func (x *UnloadRequest) String() string {
 func (*UnloadRequest) ProtoMessage() {}
 
 func (x *UnloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[20]
+	mi := &file_bpfman_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1666,7 +1791,7 @@ func (x *UnloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnloadRequest.ProtoReflect.Descriptor instead.
 func (*UnloadRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{20}
+	return file_bpfman_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UnloadRequest) GetId() uint32 {
@@ -1685,7 +1810,7 @@ type UnloadResponse struct {
 
 func (x *UnloadResponse) Reset() {
 	*x = UnloadResponse{}
-	mi := &file_bpfman_proto_msgTypes[21]
+	mi := &file_bpfman_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1697,7 +1822,7 @@ func (x *UnloadResponse) String() string {
 func (*UnloadResponse) ProtoMessage() {}
 
 func (x *UnloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[21]
+	mi := &file_bpfman_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1710,7 +1835,7 @@ func (x *UnloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnloadResponse.ProtoReflect.Descriptor instead.
 func (*UnloadResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{21}
+	return file_bpfman_proto_rawDescGZIP(), []int{23}
 }
 
 // AttachRequest represents a request to attach an eBPF program that was loaded
@@ -1725,7 +1850,7 @@ type AttachRequest struct {
 
 func (x *AttachRequest) Reset() {
 	*x = AttachRequest{}
-	mi := &file_bpfman_proto_msgTypes[22]
+	mi := &file_bpfman_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1737,7 +1862,7 @@ func (x *AttachRequest) String() string {
 func (*AttachRequest) ProtoMessage() {}
 
 func (x *AttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[22]
+	mi := &file_bpfman_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1750,7 +1875,7 @@ func (x *AttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachRequest.ProtoReflect.Descriptor instead.
 func (*AttachRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{22}
+	return file_bpfman_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AttachRequest) GetId() uint32 {
@@ -1777,7 +1902,7 @@ type AttachResponse struct {
 
 func (x *AttachResponse) Reset() {
 	*x = AttachResponse{}
-	mi := &file_bpfman_proto_msgTypes[23]
+	mi := &file_bpfman_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1789,7 +1914,7 @@ func (x *AttachResponse) String() string {
 func (*AttachResponse) ProtoMessage() {}
 
 func (x *AttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[23]
+	mi := &file_bpfman_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1802,7 +1927,7 @@ func (x *AttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResponse.ProtoReflect.Descriptor instead.
 func (*AttachResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{23}
+	return file_bpfman_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *AttachResponse) GetLinkId() uint32 {
@@ -1823,7 +1948,7 @@ type DetachRequest struct {
 
 func (x *DetachRequest) Reset() {
 	*x = DetachRequest{}
-	mi := &file_bpfman_proto_msgTypes[24]
+	mi := &file_bpfman_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +1960,7 @@ func (x *DetachRequest) String() string {
 func (*DetachRequest) ProtoMessage() {}
 
 func (x *DetachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[24]
+	mi := &file_bpfman_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +1973,7 @@ func (x *DetachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetachRequest.ProtoReflect.Descriptor instead.
 func (*DetachRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{24}
+	return file_bpfman_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DetachRequest) GetLinkId() uint32 {
@@ -1867,7 +1992,7 @@ type DetachResponse struct {
 
 func (x *DetachResponse) Reset() {
 	*x = DetachResponse{}
-	mi := &file_bpfman_proto_msgTypes[25]
+	mi := &file_bpfman_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1879,7 +2004,7 @@ func (x *DetachResponse) String() string {
 func (*DetachResponse) ProtoMessage() {}
 
 func (x *DetachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[25]
+	mi := &file_bpfman_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1892,7 +2017,7 @@ func (x *DetachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DetachResponse.ProtoReflect.Descriptor instead.
 func (*DetachResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{25}
+	return file_bpfman_proto_rawDescGZIP(), []int{27}
 }
 
 type ListRequest struct {
@@ -1906,7 +2031,7 @@ type ListRequest struct {
 
 func (x *ListRequest) Reset() {
 	*x = ListRequest{}
-	mi := &file_bpfman_proto_msgTypes[26]
+	mi := &file_bpfman_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1918,7 +2043,7 @@ func (x *ListRequest) String() string {
 func (*ListRequest) ProtoMessage() {}
 
 func (x *ListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[26]
+	mi := &file_bpfman_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1931,7 +2056,7 @@ func (x *ListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRequest.ProtoReflect.Descriptor instead.
 func (*ListRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{26}
+	return file_bpfman_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListRequest) GetProgramType() uint32 {
@@ -1964,7 +2089,7 @@ type ListResponse struct {
 
 func (x *ListResponse) Reset() {
 	*x = ListResponse{}
-	mi := &file_bpfman_proto_msgTypes[27]
+	mi := &file_bpfman_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2101,7 @@ func (x *ListResponse) String() string {
 func (*ListResponse) ProtoMessage() {}
 
 func (x *ListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[27]
+	mi := &file_bpfman_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2114,7 @@ func (x *ListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse.ProtoReflect.Descriptor instead.
 func (*ListResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{27}
+	return file_bpfman_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListResponse) GetResults() []*ListResponse_ListResult {
@@ -2008,7 +2133,7 @@ type PullBytecodeRequest struct {
 
 func (x *PullBytecodeRequest) Reset() {
 	*x = PullBytecodeRequest{}
-	mi := &file_bpfman_proto_msgTypes[28]
+	mi := &file_bpfman_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2145,7 @@ func (x *PullBytecodeRequest) String() string {
 func (*PullBytecodeRequest) ProtoMessage() {}
 
 func (x *PullBytecodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[28]
+	mi := &file_bpfman_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2158,7 @@ func (x *PullBytecodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullBytecodeRequest.ProtoReflect.Descriptor instead.
 func (*PullBytecodeRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{28}
+	return file_bpfman_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PullBytecodeRequest) GetImage() *BytecodeImage {
@@ -2051,7 +2176,7 @@ type PullBytecodeResponse struct {
 
 func (x *PullBytecodeResponse) Reset() {
 	*x = PullBytecodeResponse{}
-	mi := &file_bpfman_proto_msgTypes[29]
+	mi := &file_bpfman_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2063,7 +2188,7 @@ func (x *PullBytecodeResponse) String() string {
 func (*PullBytecodeResponse) ProtoMessage() {}
 
 func (x *PullBytecodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[29]
+	mi := &file_bpfman_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2076,7 +2201,7 @@ func (x *PullBytecodeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullBytecodeResponse.ProtoReflect.Descriptor instead.
 func (*PullBytecodeResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{29}
+	return file_bpfman_proto_rawDescGZIP(), []int{31}
 }
 
 type GetRequest struct {
@@ -2088,7 +2213,7 @@ type GetRequest struct {
 
 func (x *GetRequest) Reset() {
 	*x = GetRequest{}
-	mi := &file_bpfman_proto_msgTypes[30]
+	mi := &file_bpfman_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2100,7 +2225,7 @@ func (x *GetRequest) String() string {
 func (*GetRequest) ProtoMessage() {}
 
 func (x *GetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[30]
+	mi := &file_bpfman_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2113,7 +2238,7 @@ func (x *GetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRequest.ProtoReflect.Descriptor instead.
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{30}
+	return file_bpfman_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetRequest) GetId() uint32 {
@@ -2133,7 +2258,7 @@ type GetResponse struct {
 
 func (x *GetResponse) Reset() {
 	*x = GetResponse{}
-	mi := &file_bpfman_proto_msgTypes[31]
+	mi := &file_bpfman_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2270,7 @@ func (x *GetResponse) String() string {
 func (*GetResponse) ProtoMessage() {}
 
 func (x *GetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[31]
+	mi := &file_bpfman_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +2283,7 @@ func (x *GetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetResponse.ProtoReflect.Descriptor instead.
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{31}
+	return file_bpfman_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetResponse) GetInfo() *ProgramInfo {
@@ -2185,7 +2310,7 @@ type ListResponse_ListResult struct {
 
 func (x *ListResponse_ListResult) Reset() {
 	*x = ListResponse_ListResult{}
-	mi := &file_bpfman_proto_msgTypes[45]
+	mi := &file_bpfman_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2197,7 +2322,7 @@ func (x *ListResponse_ListResult) String() string {
 func (*ListResponse_ListResult) ProtoMessage() {}
 
 func (x *ListResponse_ListResult) ProtoReflect() protoreflect.Message {
-	mi := &file_bpfman_proto_msgTypes[45]
+	mi := &file_bpfman_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2210,7 +2335,7 @@ func (x *ListResponse_ListResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse_ListResult.ProtoReflect.Descriptor instead.
 func (*ListResponse_ListResult) Descriptor() ([]byte, []int) {
-	return file_bpfman_proto_rawDescGZIP(), []int{27, 0}
+	return file_bpfman_proto_rawDescGZIP(), []int{29, 0}
 }
 
 func (x *ListResponse_ListResult) GetInfo() *ProgramInfo {
@@ -2355,7 +2480,12 @@ const file_bpfman_proto_rawDesc = "" +
 	"\bmetadata\x18\x01 \x03(\v2(.bpfman.v1.FexitAttachInfo.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe7\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x90\x01\n" +
+	"\rLsmAttachInfo\x12B\n" +
+	"\bmetadata\x18\x01 \x03(\v2&.bpfman.v1.LsmAttachInfo.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xab\x05\n" +
 	"\n" +
 	"AttachInfo\x12B\n" +
 	"\x0fxdp_attach_info\x18\x01 \x01(\v2\x18.bpfman.v1.XDPAttachInfoH\x00R\rxdpAttachInfo\x12?\n" +
@@ -2365,7 +2495,8 @@ const file_bpfman_proto_rawDesc = "" +
 	"\x12uprobe_attach_info\x18\x05 \x01(\v2\x1b.bpfman.v1.UprobeAttachInfoH\x00R\x10uprobeAttachInfo\x12B\n" +
 	"\x0ftcx_attach_info\x18\x06 \x01(\v2\x18.bpfman.v1.TCXAttachInfoH\x00R\rtcxAttachInfo\x12K\n" +
 	"\x12fentry_attach_info\x18\a \x01(\v2\x1b.bpfman.v1.FentryAttachInfoH\x00R\x10fentryAttachInfo\x12H\n" +
-	"\x11fexit_attach_info\x18\b \x01(\v2\x1a.bpfman.v1.FexitAttachInfoH\x00R\x0ffexitAttachInfoB\x06\n" +
+	"\x11fexit_attach_info\x18\b \x01(\v2\x1a.bpfman.v1.FexitAttachInfoH\x00R\x0ffexitAttachInfo\x12B\n" +
+	"\x0flsm_attach_info\x18\t \x01(\v2\x18.bpfman.v1.LsmAttachInfoH\x00R\rlsmAttachInfoB\x06\n" +
 	"\x04info\"\xd0\x03\n" +
 	"\vLoadRequest\x127\n" +
 	"\bbytecode\x18\x01 \x01(\v2\x1b.bpfman.v1.BytecodeLocationR\bbytecode\x12@\n" +
@@ -2392,10 +2523,13 @@ const file_bpfman_proto_rawDesc = "" +
 	"\x0eFentryLoadInfo\x12\x17\n" +
 	"\afn_name\x18\x01 \x01(\tR\x06fnName\"(\n" +
 	"\rFexitLoadInfo\x12\x17\n" +
-	"\afn_name\x18\x01 \x01(\tR\x06fnName\"\xa5\x01\n" +
+	"\afn_name\x18\x01 \x01(\tR\x06fnName\"*\n" +
+	"\vLsmLoadInfo\x12\x1b\n" +
+	"\thook_name\x18\x01 \x01(\tR\bhookName\"\xe3\x01\n" +
 	"\x10ProgSpecificInfo\x12E\n" +
 	"\x10fentry_load_info\x18\x01 \x01(\v2\x19.bpfman.v1.FentryLoadInfoH\x00R\x0efentryLoadInfo\x12B\n" +
-	"\x0ffexit_load_info\x18\x02 \x01(\v2\x18.bpfman.v1.FexitLoadInfoH\x00R\rfexitLoadInfoB\x06\n" +
+	"\x0ffexit_load_info\x18\x02 \x01(\v2\x18.bpfman.v1.FexitLoadInfoH\x00R\rfexitLoadInfo\x12<\n" +
+	"\rlsm_load_info\x18\x03 \x01(\v2\x16.bpfman.v1.LsmLoadInfoH\x00R\vlsmLoadInfoB\x06\n" +
 	"\x04info\"}\n" +
 	"\x10LoadResponseInfo\x12*\n" +
 	"\x04info\x18\x01 \x01(\v2\x16.bpfman.v1.ProgramInfoR\x04info\x12=\n" +
@@ -2441,7 +2575,7 @@ const file_bpfman_proto_rawDesc = "" +
 	"\x04info\x18\x01 \x01(\v2\x16.bpfman.v1.ProgramInfoH\x00R\x04info\x88\x01\x01\x12=\n" +
 	"\vkernel_info\x18\x02 \x01(\v2\x1c.bpfman.v1.KernelProgramInfoR\n" +
 	"kernelInfoB\a\n" +
-	"\x05_info*l\n" +
+	"\x05_info*u\n" +
 	"\x11BpfmanProgramType\x12\a\n" +
 	"\x03XDP\x10\x00\x12\x06\n" +
 	"\x02TC\x10\x01\x12\x0e\n" +
@@ -2454,7 +2588,8 @@ const file_bpfman_proto_rawDesc = "" +
 	"\n" +
 	"\x06FENTRY\x10\x05\x12\t\n" +
 	"\x05FEXIT\x10\x06\x12\a\n" +
-	"\x03TCX\x10\a2\xbe\x03\n" +
+	"\x03TCX\x10\a\x12\a\n" +
+	"\x03LSM\x10\b2\xbe\x03\n" +
 	"\x06Bpfman\x127\n" +
 	"\x04Load\x12\x16.bpfman.v1.LoadRequest\x1a\x17.bpfman.v1.LoadResponse\x12=\n" +
 	"\x06Unload\x12\x18.bpfman.v1.UnloadRequest\x1a\x19.bpfman.v1.UnloadResponse\x12=\n" +
@@ -2477,7 +2612,7 @@ func file_bpfman_proto_rawDescGZIP() []byte {
 }
 
 var file_bpfman_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_bpfman_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
+var file_bpfman_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_bpfman_proto_goTypes = []any{
 	(BpfmanProgramType)(0),          // 0: bpfman.v1.BpfmanProgramType
 	(*BytecodeImage)(nil),           // 1: bpfman.v1.BytecodeImage
@@ -2492,100 +2627,106 @@ var file_bpfman_proto_goTypes = []any{
 	(*UprobeAttachInfo)(nil),        // 10: bpfman.v1.UprobeAttachInfo
 	(*FentryAttachInfo)(nil),        // 11: bpfman.v1.FentryAttachInfo
 	(*FexitAttachInfo)(nil),         // 12: bpfman.v1.FexitAttachInfo
-	(*AttachInfo)(nil),              // 13: bpfman.v1.AttachInfo
-	(*LoadRequest)(nil),             // 14: bpfman.v1.LoadRequest
-	(*LoadInfo)(nil),                // 15: bpfman.v1.LoadInfo
-	(*FentryLoadInfo)(nil),          // 16: bpfman.v1.FentryLoadInfo
-	(*FexitLoadInfo)(nil),           // 17: bpfman.v1.FexitLoadInfo
-	(*ProgSpecificInfo)(nil),        // 18: bpfman.v1.ProgSpecificInfo
-	(*LoadResponseInfo)(nil),        // 19: bpfman.v1.LoadResponseInfo
-	(*LoadResponse)(nil),            // 20: bpfman.v1.LoadResponse
-	(*UnloadRequest)(nil),           // 21: bpfman.v1.UnloadRequest
-	(*UnloadResponse)(nil),          // 22: bpfman.v1.UnloadResponse
-	(*AttachRequest)(nil),           // 23: bpfman.v1.AttachRequest
-	(*AttachResponse)(nil),          // 24: bpfman.v1.AttachResponse
-	(*DetachRequest)(nil),           // 25: bpfman.v1.DetachRequest
-	(*DetachResponse)(nil),          // 26: bpfman.v1.DetachResponse
-	(*ListRequest)(nil),             // 27: bpfman.v1.ListRequest
-	(*ListResponse)(nil),            // 28: bpfman.v1.ListResponse
-	(*PullBytecodeRequest)(nil),     // 29: bpfman.v1.PullBytecodeRequest
-	(*PullBytecodeResponse)(nil),    // 30: bpfman.v1.PullBytecodeResponse
-	(*GetRequest)(nil),              // 31: bpfman.v1.GetRequest
-	(*GetResponse)(nil),             // 32: bpfman.v1.GetResponse
-	nil,                             // 33: bpfman.v1.ProgramInfo.GlobalDataEntry
-	nil,                             // 34: bpfman.v1.ProgramInfo.MetadataEntry
-	nil,                             // 35: bpfman.v1.XDPAttachInfo.MetadataEntry
-	nil,                             // 36: bpfman.v1.TCAttachInfo.MetadataEntry
-	nil,                             // 37: bpfman.v1.TCXAttachInfo.MetadataEntry
-	nil,                             // 38: bpfman.v1.TracepointAttachInfo.MetadataEntry
-	nil,                             // 39: bpfman.v1.KprobeAttachInfo.MetadataEntry
-	nil,                             // 40: bpfman.v1.UprobeAttachInfo.MetadataEntry
-	nil,                             // 41: bpfman.v1.FentryAttachInfo.MetadataEntry
-	nil,                             // 42: bpfman.v1.FexitAttachInfo.MetadataEntry
-	nil,                             // 43: bpfman.v1.LoadRequest.MetadataEntry
-	nil,                             // 44: bpfman.v1.LoadRequest.GlobalDataEntry
-	nil,                             // 45: bpfman.v1.ListRequest.MatchMetadataEntry
-	(*ListResponse_ListResult)(nil), // 46: bpfman.v1.ListResponse.ListResult
+	(*LsmAttachInfo)(nil),           // 13: bpfman.v1.LsmAttachInfo
+	(*AttachInfo)(nil),              // 14: bpfman.v1.AttachInfo
+	(*LoadRequest)(nil),             // 15: bpfman.v1.LoadRequest
+	(*LoadInfo)(nil),                // 16: bpfman.v1.LoadInfo
+	(*FentryLoadInfo)(nil),          // 17: bpfman.v1.FentryLoadInfo
+	(*FexitLoadInfo)(nil),           // 18: bpfman.v1.FexitLoadInfo
+	(*LsmLoadInfo)(nil),             // 19: bpfman.v1.LsmLoadInfo
+	(*ProgSpecificInfo)(nil),        // 20: bpfman.v1.ProgSpecificInfo
+	(*LoadResponseInfo)(nil),        // 21: bpfman.v1.LoadResponseInfo
+	(*LoadResponse)(nil),            // 22: bpfman.v1.LoadResponse
+	(*UnloadRequest)(nil),           // 23: bpfman.v1.UnloadRequest
+	(*UnloadResponse)(nil),          // 24: bpfman.v1.UnloadResponse
+	(*AttachRequest)(nil),           // 25: bpfman.v1.AttachRequest
+	(*AttachResponse)(nil),          // 26: bpfman.v1.AttachResponse
+	(*DetachRequest)(nil),           // 27: bpfman.v1.DetachRequest
+	(*DetachResponse)(nil),          // 28: bpfman.v1.DetachResponse
+	(*ListRequest)(nil),             // 29: bpfman.v1.ListRequest
+	(*ListResponse)(nil),            // 30: bpfman.v1.ListResponse
+	(*PullBytecodeRequest)(nil),     // 31: bpfman.v1.PullBytecodeRequest
+	(*PullBytecodeResponse)(nil),    // 32: bpfman.v1.PullBytecodeResponse
+	(*GetRequest)(nil),              // 33: bpfman.v1.GetRequest
+	(*GetResponse)(nil),             // 34: bpfman.v1.GetResponse
+	nil,                             // 35: bpfman.v1.ProgramInfo.GlobalDataEntry
+	nil,                             // 36: bpfman.v1.ProgramInfo.MetadataEntry
+	nil,                             // 37: bpfman.v1.XDPAttachInfo.MetadataEntry
+	nil,                             // 38: bpfman.v1.TCAttachInfo.MetadataEntry
+	nil,                             // 39: bpfman.v1.TCXAttachInfo.MetadataEntry
+	nil,                             // 40: bpfman.v1.TracepointAttachInfo.MetadataEntry
+	nil,                             // 41: bpfman.v1.KprobeAttachInfo.MetadataEntry
+	nil,                             // 42: bpfman.v1.UprobeAttachInfo.MetadataEntry
+	nil,                             // 43: bpfman.v1.FentryAttachInfo.MetadataEntry
+	nil,                             // 44: bpfman.v1.FexitAttachInfo.MetadataEntry
+	nil,                             // 45: bpfman.v1.LsmAttachInfo.MetadataEntry
+	nil,                             // 46: bpfman.v1.LoadRequest.MetadataEntry
+	nil,                             // 47: bpfman.v1.LoadRequest.GlobalDataEntry
+	nil,                             // 48: bpfman.v1.ListRequest.MatchMetadataEntry
+	(*ListResponse_ListResult)(nil), // 49: bpfman.v1.ListResponse.ListResult
 }
 var file_bpfman_proto_depIdxs = []int32{
 	1,  // 0: bpfman.v1.BytecodeLocation.image:type_name -> bpfman.v1.BytecodeImage
 	2,  // 1: bpfman.v1.ProgramInfo.bytecode:type_name -> bpfman.v1.BytecodeLocation
-	33, // 2: bpfman.v1.ProgramInfo.global_data:type_name -> bpfman.v1.ProgramInfo.GlobalDataEntry
-	34, // 3: bpfman.v1.ProgramInfo.metadata:type_name -> bpfman.v1.ProgramInfo.MetadataEntry
-	35, // 4: bpfman.v1.XDPAttachInfo.metadata:type_name -> bpfman.v1.XDPAttachInfo.MetadataEntry
-	36, // 5: bpfman.v1.TCAttachInfo.metadata:type_name -> bpfman.v1.TCAttachInfo.MetadataEntry
-	37, // 6: bpfman.v1.TCXAttachInfo.metadata:type_name -> bpfman.v1.TCXAttachInfo.MetadataEntry
-	38, // 7: bpfman.v1.TracepointAttachInfo.metadata:type_name -> bpfman.v1.TracepointAttachInfo.MetadataEntry
-	39, // 8: bpfman.v1.KprobeAttachInfo.metadata:type_name -> bpfman.v1.KprobeAttachInfo.MetadataEntry
-	40, // 9: bpfman.v1.UprobeAttachInfo.metadata:type_name -> bpfman.v1.UprobeAttachInfo.MetadataEntry
-	41, // 10: bpfman.v1.FentryAttachInfo.metadata:type_name -> bpfman.v1.FentryAttachInfo.MetadataEntry
-	42, // 11: bpfman.v1.FexitAttachInfo.metadata:type_name -> bpfman.v1.FexitAttachInfo.MetadataEntry
-	5,  // 12: bpfman.v1.AttachInfo.xdp_attach_info:type_name -> bpfman.v1.XDPAttachInfo
-	6,  // 13: bpfman.v1.AttachInfo.tc_attach_info:type_name -> bpfman.v1.TCAttachInfo
-	8,  // 14: bpfman.v1.AttachInfo.tracepoint_attach_info:type_name -> bpfman.v1.TracepointAttachInfo
-	9,  // 15: bpfman.v1.AttachInfo.kprobe_attach_info:type_name -> bpfman.v1.KprobeAttachInfo
-	10, // 16: bpfman.v1.AttachInfo.uprobe_attach_info:type_name -> bpfman.v1.UprobeAttachInfo
-	7,  // 17: bpfman.v1.AttachInfo.tcx_attach_info:type_name -> bpfman.v1.TCXAttachInfo
-	11, // 18: bpfman.v1.AttachInfo.fentry_attach_info:type_name -> bpfman.v1.FentryAttachInfo
-	12, // 19: bpfman.v1.AttachInfo.fexit_attach_info:type_name -> bpfman.v1.FexitAttachInfo
-	2,  // 20: bpfman.v1.LoadRequest.bytecode:type_name -> bpfman.v1.BytecodeLocation
-	43, // 21: bpfman.v1.LoadRequest.metadata:type_name -> bpfman.v1.LoadRequest.MetadataEntry
-	44, // 22: bpfman.v1.LoadRequest.global_data:type_name -> bpfman.v1.LoadRequest.GlobalDataEntry
-	15, // 23: bpfman.v1.LoadRequest.info:type_name -> bpfman.v1.LoadInfo
-	0,  // 24: bpfman.v1.LoadInfo.program_type:type_name -> bpfman.v1.BpfmanProgramType
-	18, // 25: bpfman.v1.LoadInfo.info:type_name -> bpfman.v1.ProgSpecificInfo
-	16, // 26: bpfman.v1.ProgSpecificInfo.fentry_load_info:type_name -> bpfman.v1.FentryLoadInfo
-	17, // 27: bpfman.v1.ProgSpecificInfo.fexit_load_info:type_name -> bpfman.v1.FexitLoadInfo
-	4,  // 28: bpfman.v1.LoadResponseInfo.info:type_name -> bpfman.v1.ProgramInfo
-	3,  // 29: bpfman.v1.LoadResponseInfo.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
-	19, // 30: bpfman.v1.LoadResponse.programs:type_name -> bpfman.v1.LoadResponseInfo
-	13, // 31: bpfman.v1.AttachRequest.attach:type_name -> bpfman.v1.AttachInfo
-	45, // 32: bpfman.v1.ListRequest.match_metadata:type_name -> bpfman.v1.ListRequest.MatchMetadataEntry
-	46, // 33: bpfman.v1.ListResponse.results:type_name -> bpfman.v1.ListResponse.ListResult
-	1,  // 34: bpfman.v1.PullBytecodeRequest.image:type_name -> bpfman.v1.BytecodeImage
-	4,  // 35: bpfman.v1.GetResponse.info:type_name -> bpfman.v1.ProgramInfo
-	3,  // 36: bpfman.v1.GetResponse.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
-	4,  // 37: bpfman.v1.ListResponse.ListResult.info:type_name -> bpfman.v1.ProgramInfo
-	3,  // 38: bpfman.v1.ListResponse.ListResult.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
-	14, // 39: bpfman.v1.Bpfman.Load:input_type -> bpfman.v1.LoadRequest
-	21, // 40: bpfman.v1.Bpfman.Unload:input_type -> bpfman.v1.UnloadRequest
-	23, // 41: bpfman.v1.Bpfman.Attach:input_type -> bpfman.v1.AttachRequest
-	25, // 42: bpfman.v1.Bpfman.Detach:input_type -> bpfman.v1.DetachRequest
-	27, // 43: bpfman.v1.Bpfman.List:input_type -> bpfman.v1.ListRequest
-	29, // 44: bpfman.v1.Bpfman.PullBytecode:input_type -> bpfman.v1.PullBytecodeRequest
-	31, // 45: bpfman.v1.Bpfman.Get:input_type -> bpfman.v1.GetRequest
-	20, // 46: bpfman.v1.Bpfman.Load:output_type -> bpfman.v1.LoadResponse
-	22, // 47: bpfman.v1.Bpfman.Unload:output_type -> bpfman.v1.UnloadResponse
-	24, // 48: bpfman.v1.Bpfman.Attach:output_type -> bpfman.v1.AttachResponse
-	26, // 49: bpfman.v1.Bpfman.Detach:output_type -> bpfman.v1.DetachResponse
-	28, // 50: bpfman.v1.Bpfman.List:output_type -> bpfman.v1.ListResponse
-	30, // 51: bpfman.v1.Bpfman.PullBytecode:output_type -> bpfman.v1.PullBytecodeResponse
-	32, // 52: bpfman.v1.Bpfman.Get:output_type -> bpfman.v1.GetResponse
-	46, // [46:53] is the sub-list for method output_type
-	39, // [39:46] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	35, // 2: bpfman.v1.ProgramInfo.global_data:type_name -> bpfman.v1.ProgramInfo.GlobalDataEntry
+	36, // 3: bpfman.v1.ProgramInfo.metadata:type_name -> bpfman.v1.ProgramInfo.MetadataEntry
+	37, // 4: bpfman.v1.XDPAttachInfo.metadata:type_name -> bpfman.v1.XDPAttachInfo.MetadataEntry
+	38, // 5: bpfman.v1.TCAttachInfo.metadata:type_name -> bpfman.v1.TCAttachInfo.MetadataEntry
+	39, // 6: bpfman.v1.TCXAttachInfo.metadata:type_name -> bpfman.v1.TCXAttachInfo.MetadataEntry
+	40, // 7: bpfman.v1.TracepointAttachInfo.metadata:type_name -> bpfman.v1.TracepointAttachInfo.MetadataEntry
+	41, // 8: bpfman.v1.KprobeAttachInfo.metadata:type_name -> bpfman.v1.KprobeAttachInfo.MetadataEntry
+	42, // 9: bpfman.v1.UprobeAttachInfo.metadata:type_name -> bpfman.v1.UprobeAttachInfo.MetadataEntry
+	43, // 10: bpfman.v1.FentryAttachInfo.metadata:type_name -> bpfman.v1.FentryAttachInfo.MetadataEntry
+	44, // 11: bpfman.v1.FexitAttachInfo.metadata:type_name -> bpfman.v1.FexitAttachInfo.MetadataEntry
+	45, // 12: bpfman.v1.LsmAttachInfo.metadata:type_name -> bpfman.v1.LsmAttachInfo.MetadataEntry
+	5,  // 13: bpfman.v1.AttachInfo.xdp_attach_info:type_name -> bpfman.v1.XDPAttachInfo
+	6,  // 14: bpfman.v1.AttachInfo.tc_attach_info:type_name -> bpfman.v1.TCAttachInfo
+	8,  // 15: bpfman.v1.AttachInfo.tracepoint_attach_info:type_name -> bpfman.v1.TracepointAttachInfo
+	9,  // 16: bpfman.v1.AttachInfo.kprobe_attach_info:type_name -> bpfman.v1.KprobeAttachInfo
+	10, // 17: bpfman.v1.AttachInfo.uprobe_attach_info:type_name -> bpfman.v1.UprobeAttachInfo
+	7,  // 18: bpfman.v1.AttachInfo.tcx_attach_info:type_name -> bpfman.v1.TCXAttachInfo
+	11, // 19: bpfman.v1.AttachInfo.fentry_attach_info:type_name -> bpfman.v1.FentryAttachInfo
+	12, // 20: bpfman.v1.AttachInfo.fexit_attach_info:type_name -> bpfman.v1.FexitAttachInfo
+	13, // 21: bpfman.v1.AttachInfo.lsm_attach_info:type_name -> bpfman.v1.LsmAttachInfo
+	2,  // 22: bpfman.v1.LoadRequest.bytecode:type_name -> bpfman.v1.BytecodeLocation
+	46, // 23: bpfman.v1.LoadRequest.metadata:type_name -> bpfman.v1.LoadRequest.MetadataEntry
+	47, // 24: bpfman.v1.LoadRequest.global_data:type_name -> bpfman.v1.LoadRequest.GlobalDataEntry
+	16, // 25: bpfman.v1.LoadRequest.info:type_name -> bpfman.v1.LoadInfo
+	0,  // 26: bpfman.v1.LoadInfo.program_type:type_name -> bpfman.v1.BpfmanProgramType
+	20, // 27: bpfman.v1.LoadInfo.info:type_name -> bpfman.v1.ProgSpecificInfo
+	17, // 28: bpfman.v1.ProgSpecificInfo.fentry_load_info:type_name -> bpfman.v1.FentryLoadInfo
+	18, // 29: bpfman.v1.ProgSpecificInfo.fexit_load_info:type_name -> bpfman.v1.FexitLoadInfo
+	19, // 30: bpfman.v1.ProgSpecificInfo.lsm_load_info:type_name -> bpfman.v1.LsmLoadInfo
+	4,  // 31: bpfman.v1.LoadResponseInfo.info:type_name -> bpfman.v1.ProgramInfo
+	3,  // 32: bpfman.v1.LoadResponseInfo.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
+	21, // 33: bpfman.v1.LoadResponse.programs:type_name -> bpfman.v1.LoadResponseInfo
+	14, // 34: bpfman.v1.AttachRequest.attach:type_name -> bpfman.v1.AttachInfo
+	48, // 35: bpfman.v1.ListRequest.match_metadata:type_name -> bpfman.v1.ListRequest.MatchMetadataEntry
+	49, // 36: bpfman.v1.ListResponse.results:type_name -> bpfman.v1.ListResponse.ListResult
+	1,  // 37: bpfman.v1.PullBytecodeRequest.image:type_name -> bpfman.v1.BytecodeImage
+	4,  // 38: bpfman.v1.GetResponse.info:type_name -> bpfman.v1.ProgramInfo
+	3,  // 39: bpfman.v1.GetResponse.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
+	4,  // 40: bpfman.v1.ListResponse.ListResult.info:type_name -> bpfman.v1.ProgramInfo
+	3,  // 41: bpfman.v1.ListResponse.ListResult.kernel_info:type_name -> bpfman.v1.KernelProgramInfo
+	15, // 42: bpfman.v1.Bpfman.Load:input_type -> bpfman.v1.LoadRequest
+	23, // 43: bpfman.v1.Bpfman.Unload:input_type -> bpfman.v1.UnloadRequest
+	25, // 44: bpfman.v1.Bpfman.Attach:input_type -> bpfman.v1.AttachRequest
+	27, // 45: bpfman.v1.Bpfman.Detach:input_type -> bpfman.v1.DetachRequest
+	29, // 46: bpfman.v1.Bpfman.List:input_type -> bpfman.v1.ListRequest
+	31, // 47: bpfman.v1.Bpfman.PullBytecode:input_type -> bpfman.v1.PullBytecodeRequest
+	33, // 48: bpfman.v1.Bpfman.Get:input_type -> bpfman.v1.GetRequest
+	22, // 49: bpfman.v1.Bpfman.Load:output_type -> bpfman.v1.LoadResponse
+	24, // 50: bpfman.v1.Bpfman.Unload:output_type -> bpfman.v1.UnloadResponse
+	26, // 51: bpfman.v1.Bpfman.Attach:output_type -> bpfman.v1.AttachResponse
+	28, // 52: bpfman.v1.Bpfman.Detach:output_type -> bpfman.v1.DetachResponse
+	30, // 53: bpfman.v1.Bpfman.List:output_type -> bpfman.v1.ListResponse
+	32, // 54: bpfman.v1.Bpfman.PullBytecode:output_type -> bpfman.v1.PullBytecodeResponse
+	34, // 55: bpfman.v1.Bpfman.Get:output_type -> bpfman.v1.GetResponse
+	49, // [49:56] is the sub-list for method output_type
+	42, // [42:49] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_bpfman_proto_init() }
@@ -2604,7 +2745,7 @@ func file_bpfman_proto_init() {
 	file_bpfman_proto_msgTypes[6].OneofWrappers = []any{}
 	file_bpfman_proto_msgTypes[8].OneofWrappers = []any{}
 	file_bpfman_proto_msgTypes[9].OneofWrappers = []any{}
-	file_bpfman_proto_msgTypes[12].OneofWrappers = []any{
+	file_bpfman_proto_msgTypes[13].OneofWrappers = []any{
 		(*AttachInfo_XdpAttachInfo)(nil),
 		(*AttachInfo_TcAttachInfo)(nil),
 		(*AttachInfo_TracepointAttachInfo)(nil),
@@ -2613,23 +2754,25 @@ func file_bpfman_proto_init() {
 		(*AttachInfo_TcxAttachInfo)(nil),
 		(*AttachInfo_FentryAttachInfo)(nil),
 		(*AttachInfo_FexitAttachInfo)(nil),
+		(*AttachInfo_LsmAttachInfo)(nil),
 	}
-	file_bpfman_proto_msgTypes[13].OneofWrappers = []any{}
 	file_bpfman_proto_msgTypes[14].OneofWrappers = []any{}
-	file_bpfman_proto_msgTypes[17].OneofWrappers = []any{
+	file_bpfman_proto_msgTypes[15].OneofWrappers = []any{}
+	file_bpfman_proto_msgTypes[19].OneofWrappers = []any{
 		(*ProgSpecificInfo_FentryLoadInfo)(nil),
 		(*ProgSpecificInfo_FexitLoadInfo)(nil),
+		(*ProgSpecificInfo_LsmLoadInfo)(nil),
 	}
-	file_bpfman_proto_msgTypes[26].OneofWrappers = []any{}
-	file_bpfman_proto_msgTypes[31].OneofWrappers = []any{}
-	file_bpfman_proto_msgTypes[45].OneofWrappers = []any{}
+	file_bpfman_proto_msgTypes[28].OneofWrappers = []any{}
+	file_bpfman_proto_msgTypes[33].OneofWrappers = []any{}
+	file_bpfman_proto_msgTypes[48].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bpfman_proto_rawDesc), len(file_bpfman_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   46,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
Adds eBPF LSM program support -- load, attach, detach, and list a `BPF_PROG_TYPE_LSM` program whose hook (for example `file_open`) is fixed at load time from the `lsm/<hook>` ELF section. This ports the LSM work [Dave Tucker](https://github.com/dave-tucker) did in [frobware/go-bpfman#109](https://github.com/frobware/go-bpfman/pull/109); the feature is his.

The go-bpfman core has moved a long way since that PR -- `ProgramType` is a plain string now, the store is driven by goose migrations, and discovery and the shell were reorganised -- so this is a re-implementation against the current tree rather than a cherry-pick. It is also the first change to alter the schema and exercise the goose migration path end to end: `00002_add_lsm.sql` adds a `link_lsm_details` table, and that is the whole migration -- `program_type` and `links.kind` are plain `TEXT` columns whose permitted values the domain enforces, so adding a type needs no constraint change. Rather than add Dave's separate `hook_name` column, the hook reuses the `attach_func` field fentry and fexit already thread from ELF section to `AttachTo`, so the programs table is untouched.

## Show and tell

The type is represented faithfully at every boundary. `TestLsm_LoadAndGet.bpfman` pins the load record exhaustively -- an added or renamed field fails the test:

```
assert $prog.record.load matches exhaustive {
    ...
    program_name: test_lsm
    program_type: lsm
    attach_func:  file_open
    ...
}
```

and the link carries the hook, matched exhaustively too:

```
assert $link.record.details matches exhaustive {
    hook_name: file_open
}
```

Behaviour is proven, not taken on faith. `file_open` fires for every open on the box, so a global counter is meaningless. The new `lsm` shell fixture leases a probe -- a unique marker comm and a target file -- and opens that file under the marker; the program counts only that comm, so the count is exactly the fixture's opens and nothing else. `TestLsm_LinkRoundTrip.bpfman` fires 50 opens, checks the count, detaches, fires again, and checks the count is frozen:

```
lsm hook=file_open marker=xwfzelqa count=50 want=50
lsm after-detach count=50 want=50
```

Zero before, exactly 50 after, still 50 once detached: the program observed precisely the fixture's opens, and detach really stopped it. Both scripts pass:

```
--- PASS: TestBPFManScripts/scripts/TestLsm_LoadAndGet.bpfman
--- PASS: TestBPFManScripts/scripts/TestLsm_LinkRoundTrip.bpfman
```

## Test plan

- `make test` -- the LSM manager lifecycle (load/attach/detach/unload), the link and program exhaustiveness tests, and the sqlite test that applies `00002_add_lsm.sql` forward and back.
- `make test-e2e-scripts TEST='TestBPFManScripts/scripts/TestLsm_'` -- both scripts, shown above.
- `make test-e2e-grpc` -- the parallel lifecycle test gains an `lsm` spec cycling the type through the real daemon.
- Attaching an LSM program needs `bpf` in the active LSM list (`/sys/kernel/security/lsm`). Hosted CI runners ship `CONFIG_BPF_LSM=y` but not the active entry, and cannot add it without a reboot, so the gRPC spec skips at runtime and the scripts carry a `requires-bpf-lsm` pragma the runner skips on -- they run wherever the kernel supports it and skip cleanly where it does not.
- The `nested-vm-e2e / e2e (nested Fedora VM, LSM)` job boots a guest kernel with bpf in the active LSM list, so the LSM tests run for real in CI rather than skipping. On this PR's head the job runs the scripts corpus with `STRESS_COUNT=5`: both scripts passed on all five iterations, the gRPC `lsm` spec passed, and the log contains no lsm skips:

  ```
  --- PASS: TestParallel_GRPC/lsm (38.14s)

  scripts_test.go:222: lsm hook=file_open marker=bhnpuqgm count=50 want=50
      lsm after-detach count=50 want=50
  --- PASS: TestBPFManScripts/scripts/TestLsm_LoadAndGet.bpfman (0.53s)
  --- PASS: TestBPFManScripts/scripts/TestLsm_LinkRoundTrip.bpfman (1.12s)
  ```