### PR TITLE
Fix API doc generation broken by vendoring

### DIFF
--- a/scripts/api-docs/generate.sh
+++ b/scripts/api-docs/generate.sh
@@ -32,11 +32,15 @@ gendoc::build() {
     go install github.com/ahmetb/gen-crd-api-reference-docs@latest
 }
 
-# Exec the doc generator.
+# Exec the doc generator. -mod=mod is required because this repo vendors
+# its dependencies, but go mod vendor prunes the operator's parent "apis"
+# package (nothing imports it), leaving the generator's go/build unable to
+# resolve it and nil-panicking. -mod=mod bypasses vendor/ and resolves the
+# package from the module cache instead.
 gendoc::exec() {
     local readonly confdir="${REPO}/scripts/api-docs"
 
-    ${GOBIN}/gen-crd-api-reference-docs \
+    GOFLAGS="${GOFLAGS:-} -mod=mod" ${GOBIN}/gen-crd-api-reference-docs \
         -template-dir ${confdir} \
         -config ${confdir}/config.json \
         "$@"


### PR DESCRIPTION
Note: this fix is necessary but was not sufficient on its own to turn the `bpfman-docs` build green. A second, independent regression -- the CI Go toolchain setup pinning 1.21 under `GOTOOLCHAIN=local` while `go.mod` requires 1.25.7 -- fails earlier with the same nil-panic and is fixed in #1680. Both changes are required.

---

The `bpfman-docs` workflow has failed on every push to `main` since #1673 (merged 7 July 2026), which imported the Go implementation at the repository root and added a `vendor/` tree. The `Build API docs` step runs `gen-crd-api-reference-docs` against the operator's CRD types and has been nil-panicking (`k8s.io/gengo/parser.AddDirRecursive`, `parse.go:234`) ever since. It is a separate workflow from CI, so CI staying green masked it.

The cause is the interaction between vendoring and the generator. `go mod vendor` prunes the operator's parent `apis` package because nothing in bpfman imports it (only `apis/v1alpha1` is imported, and that is vendored complete). The script points `-api-dir` at the parent `apis`, and the generator resolves that root before descending into `v1alpha1`; in vendor mode `go/build` finds an empty directory there and dereferences a nil package. Restoring the pruned package via a blank import does not help either, because the generator unconditionally skips any package whose source path contains `/vendor/` -- a hardcoded rule with no flag to disable it -- so the vendored copy can never be documented regardless.

Running the generator with `GOFLAGS=-mod=mod` makes `go/packages` resolve the operator API package from the module cache rather than the vendor tree, whose path has no `/vendor/` segment, so the skip does not fire and resolution succeeds. The module cache is byte-identical to the vendored copy for the documented types, and the generated `apidocs.html` matches the last successful build exactly (verified by sha256). This is the smallest change that restores the pre-vendoring behaviour without altering the tool or its output.

## Test plan

Ran `./scripts/api-docs/generate.sh apidocs.html` locally against the current tree: it now exits 0 and writes `apidocs.html`. The output is byte-identical to what the last green `bpfman-docs` build (21 April 2026) produced and to the currently-published API spec page.