### PR TITLE
ci: fix the API doc build and run it in the PR gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,16 @@ jobs:
       - name: Checkout bpfman
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # @v4
 
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # @v5
+        with:
+          go-version-file: go.mod
+
       - name: Install required-version defined in pyproject.toml
         uses: astral-sh/setup-uv@v7
+
+      - name: Build API docs
+        run: |
+          ./scripts/api-docs/generate.sh apidocs.html
 
       - name: Mkdocs Build
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -25,8 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # @v5
         with:
-          # prettier-ignore
-          go-version: '1.21' # yamllint disable-line rule:quoted-strings
+          go-version-file: go.mod
 
       - name: Build API docs
         run: |


### PR DESCRIPTION
Follow-up to #1679, which fixed the vendor-pruning panic in the API doc generator but was not sufficient to turn the `bpfman-docs` build green. Two further problems remained, both fixed here.

First, the workflow pins `setup-go` to Go 1.21 while `go.mod` requires 1.25.7. Because `setup-go` pins the toolchain (`GOTOOLCHAIN=local`), the 1.21 toolchain is not upgraded to satisfy `go.mod`, so the generator fails before it starts -- the same `AddDirRecursive` nil-panic as the vendor bug, which is why #1679 looked like it should have been enough. Switching `docs-build.yml` to `go-version-file: go.mod` makes `setup-go` install exactly the version `go.mod` requires, so the CI Go version can no longer drift from it.

Second, that generation only runs in the `bpfman-docs` workflow, which fires on push to main, so breakage is caught after merge rather than on the pull request that introduces it. The `build-docs` job in `build.yml` runs on pull requests and feeds `build-workflow-complete`, which mergify requires before merging, but it built the docs with mkdocs without ever generating `apidocs.html` -- leaving the API spec page silently empty and the generator never exercised on a PR. This runs the generator in that job, before the mkdocs build, so a change that breaks generation fails the PR gate, and the rendered spec is no longer empty.

## Test plan

Ran the generator and `mkdocs build --strict` locally against the current tree: both succeed, `apidocs.html` is byte-identical to the last successful `bpfman-docs` build, and the API spec page renders the CRD types instead of empty. Also reproduced the CI toolchain conditions (`GOTOOLCHAIN=local`, empty module cache, a toolchain satisfying `go.mod`) and confirmed generation succeeds. Full confirmation is the on-push `bpfman-docs` run and the PR `build-docs` gate after merge.