### PR TITLE
Assert the verifier rejection in the broken-sibling load test

### DIFF
--- a/e2e/scripts/TestLoad_NamedProgramSkipsBrokenSibling.bpfman
+++ b/e2e/scripts/TestLoad_NamedProgramSkipsBrokenSibling.bpfman
@@ -6,17 +6,22 @@
 # When: the good program is selected by name
 #
 # Then: it loads successfully, while requesting the broken sibling or
-# the whole object fails
+# the whole object fails.
 
-let bad <- bpfman program load file testdata/bpf/multi_prog_one_bad.bpf.o --programs xdp:bad
-assert not $bad.ok
+let broken <- bpfman program load file testdata/bpf/multi_prog_one_bad.bpf.o --programs xdp:bad
+assert not $broken.ok
+assert contains $broken.stderr "invalid access to packet"
 
 # Control: loading both programs (bad included) fails as a unit.
 let whole <- bpfman program load file testdata/bpf/multi_prog_one_bad.bpf.o --programs xdp:good,xdp:bad
 assert not $whole.ok
+assert contains $whole.stderr "invalid access to packet"
 
-# The behaviour under test: requesting only good succeeds despite bad
-# sharing the object.
+# The behaviour under test: requesting only good succeeds and loads
+# exactly that one program -- proof the broken sibling was not dragged
+# in.
 guard loaded <- bpfman program load file testdata/bpf/multi_prog_one_bad.bpf.o --programs xdp:good
-let prog = $loaded.programs[0]
-defer bpfman program unload $prog
+let count = $loaded |> jq ".programs | length"
+assert $count == 1
+assert $loaded.programs[0].record.load.program_name == "good"
+defer bpfman program unload $loaded.programs[0]

--- a/e2e/testdata/bpf/multi_prog_one_bad.bpf.c
+++ b/e2e/testdata/bpf/multi_prog_one_bad.bpf.c
@@ -10,9 +10,8 @@
 // kernel. A load of only "good" must succeed even though "bad" shares
 // the object; loading "bad" must fail.
 //
-// The two programs sit in distinct sections (xdp, xdp.frags) so they
-// are separate entry points -- clang merges same-section functions
-// into a single program. Both sections infer BPF_PROG_TYPE_XDP.
+// Both functions are in the "xdp" section and load as separate
+// programs, keyed by function name.
 
 #include <linux/bpf.h>
 
@@ -21,7 +20,7 @@
 SEC("xdp")
 int good(struct xdp_md *ctx) { return XDP_PASS; }
 
-SEC("xdp.frags")
+SEC("xdp")
 int bad(struct xdp_md *ctx) {
   char *p = (char *)(unsigned long)ctx->data;
   return p[100]; // no bounds check against data_end -> verifier reject


### PR DESCRIPTION
The `multi_prog_one_bad` fixture exists to prove that loading one named program from an object does not drag its unverifiable sibling through the verifier. It placed the broken `bad` program in an `xdp.frags` section, on the mistaken premise -- stated in a comment -- that two programs need distinct sections to remain separate. They do not: each `SEC`-annotated function is its own program, keyed by function name, so `good` and `bad` are already distinct within a single `xdp` section.

That section choice mattered for a reason the fixture did not intend. Loading an `xdp.frags` program is currently broken -- it fails before the verifier runs -- so the script's negative assertions (`bad` alone, and the whole object, fail) only ever checked that the load failed, never that the verifier was the cause. A load that failed for any other reason would have satisfied the test equally, and that is exactly what was happening: the test passed on the wrong error and never exercised the verifier rejection it claims to demonstrate.

This moves `bad` into the `xdp` section so it reaches the verifier, and tightens the script to assert that the two failing loads name the packet-access rejection (`invalid access to packet`) rather than merely failing. It also strengthens the positive case: selecting `good` alone now asserts that exactly one program loaded and that it is named `good`, so the test proves the sibling was skipped rather than only that something loaded.

`xdp.frags` support itself is out of scope here; a follow-up PR will add it. This change only makes the existing test rigorous and independent of that gap.

## Test plan

`make test-e2e-scripts-file TEST='TestBPFManScripts/scripts/TestLoad_NamedProgramSkipsBrokenSibling\.bpfman$'` passes. Reverting the fixture to `SEC("xdp.frags")` makes `bad` fail before the verifier, so the new `invalid access to packet` assertion fails -- i.e. the tightened test now catches the regression the old one masked.