### PR TITLE
Reset the attach type when loading programs as extensions

### DIFF
--- a/e2e/scripts/TestLoad_XDPFragsProgram.bpfman
+++ b/e2e/scripts/TestLoad_XDPFragsProgram.bpfman
@@ -1,0 +1,57 @@
+# -*- mode: bpfman -*-
+#
+# Given: an XDP program compiled into the "xdp.frags" section (so it
+# carries BPF_F_XDP_HAS_FRAGS) that counts packets, and a normal-MTU
+# netns veth pair
+#
+# When: it is loaded and attached through bpfman
+#
+# Then: the load succeeds, the program is the dispatcher's sole member,
+# and it counts traffic on the packet path. bpfman loads XDP programs as
+# BPF_PROG_TYPE_EXT against a dispatcher; the loader must reset the
+# section-derived attach type when it does so, or the load is refused
+# with "unrecognized attach type" because the xdp.frags section leaves a
+# concrete attach type on the spec that has no extension mapping in
+# cilium/ebpf.
+
+guard veth <- net netns-veth-pair
+defer net release $veth
+
+let netns = "/var/run/netns/${veth.a.ns}"
+
+guard loaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+assert $prog.record.load.program_name == "frags_pass"
+defer bpfman program unload $pid
+
+guard link <- bpfman link attach xdp $prog $veth.a.link --priority 50 --netns $netns
+defer bpfman link detach $link
+assert $link.record.kind == xdp
+assert $link.record.program_id == $pid
+assert $link.record.details.interface == $veth.a.link
+assert $link.status.kernel_seen
+
+# The program is spliced into the XDP dispatcher as its sole member.
+guard disp <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+let members = $disp |> jq ".members | length"
+assert $members == 1
+assert $disp.members[0].program_id == $pid
+assert $disp.members[0].program_name == "frags_pass"
+assert $disp.members[0].position == 0
+
+# Drive traffic to prove the frags program is on the packet path: ping a
+# from b and confirm its per-CPU packet counter advances. ARP/control
+# traffic may add packets, so five echoes is a lower bound.
+let mapID = $prog.status.maps[0].id
+let sumFilter = "fromjson | [.[0].formatted.values[].value | tonumber] | add"
+guard dumpBefore <- bpftool map dump id $mapID -j
+let before = $dumpBefore.stdout |> jq $sumFilter
+
+guard _ <- net exec $veth.b ping -c 5 -i 0.05 -W 1 $veth.a.addr
+
+guard dumpAfter <- bpftool map dump id $mapID -j
+let after = $dumpAfter.stdout |> jq $sumFilter
+let delta = $after - $before
+print "xdp frags count: before=${before} after=${after} delta=${delta}"
+assert $delta >= 5

--- a/e2e/testdata/bpf/xdp_frags_pass.bpf.c
+++ b/e2e/testdata/bpf/xdp_frags_pass.bpf.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+// Copyright Authors of bpfman
+
+// An XDP program in the "xdp.frags" section, so it is compiled with
+// BPF_F_XDP_HAS_FRAGS. It counts packets into a per-CPU map so an e2e
+// test can drive traffic and prove the program runs on the packet path.
+//
+// Loading it exercises the extension conversion path: bpfman loads XDP
+// programs as BPF_PROG_TYPE_EXT against a dispatcher, and must reset the
+// section-derived attach type, or the load is refused with
+// "unrecognized attach type".
+
+#include <linux/bpf.h>
+
+#include <bpf/bpf_helpers.h>
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, __u64);
+  __uint(max_entries, 1);
+  __uint(pinning, LIBBPF_PIN_NONE);
+} frags_pass_stats_map SEC(".maps");
+
+SEC("xdp.frags")
+int frags_pass(struct xdp_md *ctx) {
+  __u32 key = 0;
+  __u64 *val = bpf_map_lookup_elem(&frags_pass_stats_map, &key);
+  if (val)
+    (*val)++;
+  return XDP_PASS;
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/platform/ebpf/load.go
+++ b/platform/ebpf/load.go
@@ -166,6 +166,15 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 		progSpec.Type = ebpf.Extension
 		progSpec.AttachTarget = testProg
 		progSpec.AttachTo = "prog0"
+
+		// cilium/ebpf resolves an extension's freplace target from the
+		// (Type, AttachType) pair and recognises only
+		// (Extension, AttachNone), then looks the function up by name in
+		// the target BTF (see findTargetInProgram). The section sets
+		// AttachType -- xdp.frags yields XDP -- which has no mapping, so
+		// the load is refused with "unrecognized attach type". Clear it
+		// so the target resolves by name.
+		progSpec.AttachType = ebpf.AttachNone
 	}
 
 	// Check if we should share maps with another program (map_owner_id).


### PR DESCRIPTION
bpfman loads XDP and TC programs as `BPF_PROG_TYPE_EXT` (freplace) bound to a dispatcher, so each user program replaces a stub function in the dispatcher rather than attaching to a hook directly. cilium/ebpf resolves that freplace target from the program's `(Type, AttachType)` pair and recognises only `(Extension, AttachNone)`, then looks the function up by name in the target BTF. It takes `AttachType` from the ELF section, and the `xdp.frags` section yields `AttachType == XDP`. That pair has no mapping, so cilium refuses the load with `attach Extension/XDP: unrecognized attach type` before any syscall, and a program compiled into an `xdp.frags` section fails to load at all. Plain `xdp` sections are unaffected, since their attach type is already `AttachNone`.

This clears the attach type when converting a program to an extension, so the freplace target resolves by function name. bpfman-rust does not need this: aya loads freplace components through its dedicated `EbpfLoader::extension()` API, which resolves the target by BTF function name and loads the program as `BPF_PROG_TYPE_EXT` without carrying an attach type. cilium/ebpf instead reuses the XDP `ProgramSpec` -- attach type and all -- as the extension, so go-bpfman must clear the attach type itself. The same `xdp.frags` fixture that go-bpfman rejects today loads cleanly under bpfman-rust 0.6.0, confirming this is a go-bpfman-specific gap rather than a kernel or frags limitation.

The change is independent of XDP multi-buffer (frags) support proper and of the ERANGE generic-mode fallback: it is a load-path fix, whereas those are attach-path concerns. It does not make bpfman honour frags on the dispatcher; it only lets an `xdp.frags` program load and run.

## Test plan

A new e2e script, `TestLoad_XDPFragsProgram.bpfman`, loads an `xdp.frags` program, attaches it to a normal-MTU netns veth, confirms it is the dispatcher's sole member, then pings across the veth and asserts the program's per-CPU packet counter advances -- proving it is on the packet path, not merely wired up. Without the reset the script fails at the load step with `unrecognized attach type`. Run with:

`make test-e2e-scripts-file TEST='TestBPFManScripts/scripts/TestLoad_XDPFragsProgram\.bpfman$'`

Plain XDP, TC, and TCX load and attach through the same extension path is unchanged (`TestAttach_ResolvesIfaceInNetns` still passes).