### PR TITLE
WIP: Support XDP frags (BPF_F_XDP_HAS_FRAGS) in the dispatcher

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -113,6 +113,39 @@ const (
 	XDPFragsEnabled  XDPFragsMode = true
 )
 
+// FragsEligible reports whether an XDP dispatcher built from these
+// members should be loaded frags-aware: the set is non-empty and every
+// member is frags-capable. Empty, or any non-frags member, yields false.
+// TC members are never frags-capable, so this returns false for a TC
+// dispatcher. It is the single definition of the frags-eligibility rule,
+// shared by the load decision and the reported dispatcher snapshot.
+//
+// A member is frags-capable when its XDP program is compiled with a
+// SEC("xdp.frags") section: cilium/ebpf reads that section and sets
+// BPF_F_XDP_HAS_FRAGS at load, which bpfman records per member and passes
+// here as memberFrags. A plain SEC("xdp") program never carries the flag.
+//
+// The all-or-nothing rule is the libxdp dispatcher policy, not a kernel
+// constraint. BPF_F_XDP_HAS_FRAGS is a property of the dispatcher as a
+// whole -- it cannot be set per freplace member -- so it is only safe to
+// set when every member is written to handle fragmented packets; a
+// non-frags member exposed to frags can silently misbehave, and the
+// kernel cannot detect this. See lib/libxdp/protocol.org, "Supporting XDP
+// programs with frags support", in xdp-project/xdp-tools.
+func FragsEligible(memberFrags []bool) bool {
+	if len(memberFrags) == 0 {
+		return false
+	}
+
+	for _, frags := range memberFrags {
+		if !frags {
+			return false
+		}
+	}
+
+	return true
+}
+
 func proceedOnOffset(dt DispatcherType) (int32, error) {
 	switch dt {
 	case DispatcherTypeXDP:

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	"github.com/bpfman/bpfman"
 )
@@ -43,8 +44,7 @@ type XDPConfig struct {
 	NumProgsEnabled uint8
 
 	// IsXDPFrags, when nonzero, marks the dispatcher as XDP-fragments
-	// aware. This codebase never sets it, so it stays zero; the field
-	// exists only to mirror the C struct layout.
+	// aware.
 	IsXDPFrags uint8
 
 	// ChainCallActions holds the per-slot proceed-on bitmask: element i
@@ -59,9 +59,7 @@ type XDPConfig struct {
 	// stored priority and position before the config is built.
 	RunPrios [MaxPrograms]uint32
 
-	// ProgramFlags holds the per-slot program flags. This codebase never
-	// sets it, so it stays zero; the field exists only to mirror the C
-	// struct layout.
+	// ProgramFlags holds the per-slot program flags.
 	ProgramFlags [MaxPrograms]uint32
 }
 
@@ -102,6 +100,17 @@ const (
 	// does not determine chain order; user links are ordered by their
 	// stored priority and position.
 	DispatcherRunPriority = 50
+)
+
+// XDPFragsMode controls whether an XDP dispatcher is loaded as
+// fragments-aware. It is a defined bool so call sites read
+// XDPFragsEnabled/XDPFragsDisabled rather than a bare bool, while the
+// type can hold no value other than the two below.
+type XDPFragsMode bool
+
+const (
+	XDPFragsDisabled XDPFragsMode = false
+	XDPFragsEnabled  XDPFragsMode = true
 )
 
 func proceedOnOffset(dt DispatcherType) (int32, error) {
@@ -172,7 +181,7 @@ func ProceedOnActions(dt DispatcherType, mask uint32) ([]int32, error) {
 
 // NewXDPConfig creates a default XDP dispatcher config. numProgs
 // must be in the range [1, MaxPrograms].
-func NewXDPConfig(numProgs int) (XDPConfig, error) {
+func NewXDPConfig(numProgs int, fragsMode XDPFragsMode) (XDPConfig, error) {
 	if numProgs < 1 || numProgs > MaxPrograms {
 		return XDPConfig{}, fmt.Errorf("numProgs %d out of range [1, %d]", numProgs, MaxPrograms)
 	}
@@ -181,8 +190,14 @@ func NewXDPConfig(numProgs int) (XDPConfig, error) {
 		DispatcherVersion: xdpDispatcherVersion,
 		NumProgsEnabled:   uint8(numProgs),
 	}
+	if fragsMode == XDPFragsEnabled {
+		cfg.IsXDPFrags = 1
+	}
 	for i := range MaxPrograms {
 		cfg.RunPrios[i] = DispatcherRunPriority
+		if fragsMode == XDPFragsEnabled && i < numProgs {
+			cfg.ProgramFlags[i] = unix.BPF_F_XDP_HAS_FRAGS
+		}
 	}
 	return cfg, nil
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -102,17 +102,6 @@ const (
 	DispatcherRunPriority = 50
 )
 
-// XDPFragsMode controls whether an XDP dispatcher is loaded as
-// fragments-aware. It is a defined bool so call sites read
-// XDPFragsEnabled/XDPFragsDisabled rather than a bare bool, while the
-// type can hold no value other than the two below.
-type XDPFragsMode bool
-
-const (
-	XDPFragsDisabled XDPFragsMode = false
-	XDPFragsEnabled  XDPFragsMode = true
-)
-
 // FragsEligible reports whether an XDP dispatcher built from these
 // members should be loaded frags-aware: the set is non-empty and every
 // member is frags-capable. Empty, or any non-frags member, yields false.
@@ -213,8 +202,9 @@ func ProceedOnActions(dt DispatcherType, mask uint32) ([]int32, error) {
 }
 
 // NewXDPConfig creates a default XDP dispatcher config. numProgs
-// must be in the range [1, MaxPrograms].
-func NewXDPConfig(numProgs int, fragsMode XDPFragsMode) (XDPConfig, error) {
+// must be in the range [1, MaxPrograms]. fragsAware loads the dispatcher
+// frags-aware (see FragsEligible for the eligibility rule).
+func NewXDPConfig(numProgs int, fragsAware bool) (XDPConfig, error) {
 	if numProgs < 1 || numProgs > MaxPrograms {
 		return XDPConfig{}, fmt.Errorf("numProgs %d out of range [1, %d]", numProgs, MaxPrograms)
 	}
@@ -223,12 +213,15 @@ func NewXDPConfig(numProgs int, fragsMode XDPFragsMode) (XDPConfig, error) {
 		DispatcherVersion: xdpDispatcherVersion,
 		NumProgsEnabled:   uint8(numProgs),
 	}
-	if fragsMode == XDPFragsEnabled {
+
+	// IsXDPFrags is the C .rodata field (uint8, 0/1); frags is a plain
+	// bool everywhere else and converts to the ABI representation here.
+	if fragsAware {
 		cfg.IsXDPFrags = 1
 	}
 	for i := range MaxPrograms {
 		cfg.RunPrios[i] = DispatcherRunPriority
-		if fragsMode == XDPFragsEnabled && i < numProgs {
+		if fragsAware && i < numProgs {
 			cfg.ProgramFlags[i] = unix.BPF_F_XDP_HAS_FRAGS
 		}
 	}

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -41,7 +41,7 @@ func TestNewXDPConfig(t *testing.T) {
 	t.Run("valid range", func(t *testing.T) {
 		t.Parallel()
 		for n := 1; n <= dispatcher.MaxPrograms; n++ {
-			cfg, err := dispatcher.NewXDPConfig(n)
+			cfg, err := dispatcher.NewXDPConfig(n, dispatcher.XDPFragsDisabled)
 			if err != nil {
 				t.Fatalf("NewXDPConfig(%d): unexpected error: %v", n, err)
 			}
@@ -53,7 +53,7 @@ func TestNewXDPConfig(t *testing.T) {
 
 	t.Run("default priorities", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := dispatcher.NewXDPConfig(1)
+		cfg, err := dispatcher.NewXDPConfig(1, dispatcher.XDPFragsDisabled)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,23 +64,44 @@ func TestNewXDPConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("frags enabled", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := dispatcher.NewXDPConfig(2, dispatcher.XDPFragsEnabled)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.IsXDPFrags != 1 {
+			t.Fatalf("IsXDPFrags = %d, want 1", cfg.IsXDPFrags)
+		}
+		for i := range 2 {
+			if cfg.ProgramFlags[i] == 0 {
+				t.Fatalf("ProgramFlags[%d] = 0, want frags flag", i)
+			}
+		}
+		for i := 2; i < dispatcher.MaxPrograms; i++ {
+			if cfg.ProgramFlags[i] != 0 {
+				t.Fatalf("ProgramFlags[%d] = %d, want 0", i, cfg.ProgramFlags[i])
+			}
+		}
+	})
+
 	t.Run("zero", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(0); err == nil {
+		if _, err := dispatcher.NewXDPConfig(0, dispatcher.XDPFragsDisabled); err == nil {
 			t.Error("NewXDPConfig(0): expected error")
 		}
 	})
 
 	t.Run("negative", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(-1); err == nil {
+		if _, err := dispatcher.NewXDPConfig(-1, dispatcher.XDPFragsDisabled); err == nil {
 			t.Error("NewXDPConfig(-1): expected error")
 		}
 	})
 
 	t.Run("exceeds max", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(dispatcher.MaxPrograms + 1); err == nil {
+		if _, err := dispatcher.NewXDPConfig(dispatcher.MaxPrograms+1, dispatcher.XDPFragsDisabled); err == nil {
 			t.Errorf("NewXDPConfig(%d): expected error", dispatcher.MaxPrograms+1)
 		}
 	})

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -41,7 +41,7 @@ func TestNewXDPConfig(t *testing.T) {
 	t.Run("valid range", func(t *testing.T) {
 		t.Parallel()
 		for n := 1; n <= dispatcher.MaxPrograms; n++ {
-			cfg, err := dispatcher.NewXDPConfig(n, dispatcher.XDPFragsDisabled)
+			cfg, err := dispatcher.NewXDPConfig(n, false)
 			if err != nil {
 				t.Fatalf("NewXDPConfig(%d): unexpected error: %v", n, err)
 			}
@@ -53,7 +53,7 @@ func TestNewXDPConfig(t *testing.T) {
 
 	t.Run("default priorities", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := dispatcher.NewXDPConfig(1, dispatcher.XDPFragsDisabled)
+		cfg, err := dispatcher.NewXDPConfig(1, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ func TestNewXDPConfig(t *testing.T) {
 
 	t.Run("frags enabled", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := dispatcher.NewXDPConfig(2, dispatcher.XDPFragsEnabled)
+		cfg, err := dispatcher.NewXDPConfig(2, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,21 +87,21 @@ func TestNewXDPConfig(t *testing.T) {
 
 	t.Run("zero", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(0, dispatcher.XDPFragsDisabled); err == nil {
+		if _, err := dispatcher.NewXDPConfig(0, false); err == nil {
 			t.Error("NewXDPConfig(0): expected error")
 		}
 	})
 
 	t.Run("negative", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(-1, dispatcher.XDPFragsDisabled); err == nil {
+		if _, err := dispatcher.NewXDPConfig(-1, false); err == nil {
 			t.Error("NewXDPConfig(-1): expected error")
 		}
 	})
 
 	t.Run("exceeds max", func(t *testing.T) {
 		t.Parallel()
-		if _, err := dispatcher.NewXDPConfig(dispatcher.MaxPrograms+1, dispatcher.XDPFragsDisabled); err == nil {
+		if _, err := dispatcher.NewXDPConfig(dispatcher.MaxPrograms+1, false); err == nil {
 			t.Errorf("NewXDPConfig(%d): expected error", dispatcher.MaxPrograms+1)
 		}
 	})

--- a/e2e/scripts/TestFentry_LoadAndGet.bpfman
+++ b/e2e/scripts/TestFentry_LoadAndGet.bpfman
@@ -41,6 +41,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -133,6 +134,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestFexit_LoadAndGet.bpfman
+++ b/e2e/scripts/TestFexit_LoadAndGet.bpfman
@@ -41,6 +41,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -133,6 +134,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestKprobe_LoadAndGet.bpfman
+++ b/e2e/scripts/TestKprobe_LoadAndGet.bpfman
@@ -41,6 +41,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -138,6 +139,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestKretprobe_LoadAndGet.bpfman
+++ b/e2e/scripts/TestKretprobe_LoadAndGet.bpfman
@@ -38,6 +38,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -130,6 +131,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestTCX_LoadAndGet.bpfman
+++ b/e2e/scripts/TestTCX_LoadAndGet.bpfman
@@ -37,6 +37,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -129,6 +130,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestTC_LoadAndGet.bpfman
+++ b/e2e/scripts/TestTC_LoadAndGet.bpfman
@@ -37,6 +37,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -129,6 +130,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestTracepoint_LoadAndGet.bpfman
+++ b/e2e/scripts/TestTracepoint_LoadAndGet.bpfman
@@ -37,6 +37,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -129,6 +130,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestUprobe_LoadAndGet.bpfman
+++ b/e2e/scripts/TestUprobe_LoadAndGet.bpfman
@@ -37,6 +37,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -129,6 +130,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestUretprobe_LoadAndGet.bpfman
+++ b/e2e/scripts/TestUretprobe_LoadAndGet.bpfman
@@ -37,6 +37,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -129,6 +130,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
+++ b/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
@@ -36,6 +36,11 @@ defer bpfman link detach $plainLink
 # The dispatcher is downgraded: not all members are frags-capable.
 guard disp2 <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
 assert not $disp2.is_xdp_frags
+
+# The downgrade shows in dispatcher list too, not just get.
+guard dispList <- bpfman dispatcher list
+let listFrags = $dispList |> jq "[.dispatchers[] | select(.key.nsid == ${veth.a.nsid} and .key.ifindex == ${veth.a.ifindex})][0].is_xdp_frags"
+assert not $listFrags
 let members = $disp2 |> jq ".members | length"
 assert $members == 2
 let fragsMembers = $disp2 |> jq "[.members[] | select(.has_xdp_frags)] | length"

--- a/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
+++ b/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
@@ -1,0 +1,42 @@
+# -*- mode: bpfman -*-
+#
+# Given: a dispatcher holding one frags-capable XDP program
+#
+# When: a non-frags XDP program is attached to the same interface
+#
+# Then: the dispatcher is downgraded -- is_xdp_frags becomes false,
+# because BPF_F_XDP_HAS_FRAGS is only safe when every member is
+# frags-capable. Each member still records its own capability.
+
+guard veth <- net netns-veth-pair
+defer net release $veth
+
+let netns = "/var/run/netns/${veth.a.ns}"
+
+guard fragsLoaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
+let fragsProg = $fragsLoaded.programs[0]
+let fragsPid = $fragsProg.record.program_id
+defer bpfman program unload $fragsPid
+guard fragsLink <- bpfman link attach xdp $fragsProg $veth.a.link --priority 50 --netns $netns
+defer bpfman link detach $fragsLink
+
+# Frags-only: the dispatcher is frags-aware.
+guard disp1 <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+assert $disp1.is_xdp_frags
+
+# Add a non-frags program to the same interface.
+guard plainLoaded <- bpfman program load file testdata/bpf/xdp_pass.bpf.o --programs xdp:pass
+let plainProg = $plainLoaded.programs[0]
+let plainPid = $plainProg.record.program_id
+assert not $plainProg.record.has_xdp_frags
+defer bpfman program unload $plainPid
+guard plainLink <- bpfman link attach xdp $plainProg $veth.a.link --priority 60 --netns $netns
+defer bpfman link detach $plainLink
+
+# The dispatcher is downgraded: not all members are frags-capable.
+guard disp2 <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+assert not $disp2.is_xdp_frags
+let members = $disp2 |> jq ".members | length"
+assert $members == 2
+let fragsMembers = $disp2 |> jq "[.members[] | select(.has_xdp_frags)] | length"
+assert $fragsMembers == 1

--- a/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
+++ b/e2e/scripts/TestXDP_FragsDowngradeMixedMembers.bpfman
@@ -16,6 +16,7 @@ let netns = "/var/run/netns/${veth.a.ns}"
 guard fragsLoaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
 let fragsProg = $fragsLoaded.programs[0]
 let fragsPid = $fragsProg.record.program_id
+assert $fragsProg.record.has_xdp_frags
 defer bpfman program unload $fragsPid
 guard fragsLink <- bpfman link attach xdp $fragsProg $veth.a.link --priority 50 --netns $netns
 defer bpfman link detach $fragsLink

--- a/e2e/scripts/TestXDP_FragsMixedRejectedOnJumbo.bpfman
+++ b/e2e/scripts/TestXDP_FragsMixedRejectedOnJumbo.bpfman
@@ -1,0 +1,50 @@
+# -*- mode: bpfman -*-
+#
+# Given: a frags program attached natively to a jumbo-MTU interface
+#
+# When: a non-frags program is attached to the same interface
+#
+# Then: the rebuild would downgrade the dispatcher to non-frags, which
+# cannot attach natively to the jumbo interface, so the attach is
+# rejected with ERANGE and the original frags dispatcher survives
+# unchanged -- the rebuild is atomic.
+
+guard veth <- net netns-veth-pair
+defer net release $veth
+
+let netns = "/var/run/netns/${veth.a.ns}"
+
+# Raise both ends to a jumbo MTU that native XDP cannot take without
+# frags support.
+guard _ <- net exec $veth.a ip link set dev $veth.a.link mtu 8901
+guard _ <- net exec $veth.b ip link set dev $veth.b.link mtu 8901
+
+guard fragsLoaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
+let fragsProg = $fragsLoaded.programs[0]
+let fragsPid = $fragsProg.record.program_id
+defer bpfman program unload $fragsPid
+guard fragsLink <- bpfman link attach xdp $fragsProg $veth.a.link --priority 50 --netns $netns
+defer bpfman link detach $fragsLink
+
+guard disp1 <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+assert $disp1.is_xdp_frags
+
+# A non-frags program cannot join a frags dispatcher on a jumbo
+# interface: the downgraded dispatcher fails its native attach. Assert
+# the failure is specifically ERANGE, not merely that it failed -- a
+# failure for any other reason would pass a bare not-ok check.
+guard plainLoaded <- bpfman program load file testdata/bpf/xdp_pass.bpf.o --programs xdp:pass
+let plainProg = $plainLoaded.programs[0]
+let plainPid = $plainProg.record.program_id
+defer bpfman program unload $plainPid
+let rejected <- bpfman link attach xdp $plainProg $veth.a.link --priority 60 --netns $netns
+assert not $rejected.ok
+assert contains $rejected.stderr "numerical result out of range"
+
+# The original frags dispatcher survives the failed rebuild: still
+# frags-aware, still holding only the frags program.
+guard disp2 <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+assert $disp2.is_xdp_frags
+let members = $disp2 |> jq ".members | length"
+assert $members == 1
+assert $disp2.members[0].program_name == "frags_pass"

--- a/e2e/scripts/TestXDP_FragsMixedRejectedOnJumbo.bpfman
+++ b/e2e/scripts/TestXDP_FragsMixedRejectedOnJumbo.bpfman
@@ -22,6 +22,7 @@ guard _ <- net exec $veth.b ip link set dev $veth.b.link mtu 8901
 guard fragsLoaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
 let fragsProg = $fragsLoaded.programs[0]
 let fragsPid = $fragsProg.record.program_id
+assert $fragsProg.record.has_xdp_frags
 defer bpfman program unload $fragsPid
 guard fragsLink <- bpfman link attach xdp $fragsProg $veth.a.link --priority 50 --netns $netns
 defer bpfman link detach $fragsLink
@@ -36,6 +37,7 @@ assert $disp1.is_xdp_frags
 guard plainLoaded <- bpfman program load file testdata/bpf/xdp_pass.bpf.o --programs xdp:pass
 let plainProg = $plainLoaded.programs[0]
 let plainPid = $plainProg.record.program_id
+assert not $plainProg.record.has_xdp_frags
 defer bpfman program unload $plainPid
 let rejected <- bpfman link attach xdp $plainProg $veth.a.link --priority 60 --netns $netns
 assert not $rejected.ok

--- a/e2e/scripts/TestXDP_FragsNativeJumboAttach.bpfman
+++ b/e2e/scripts/TestXDP_FragsNativeJumboAttach.bpfman
@@ -1,0 +1,48 @@
+# -*- mode: bpfman -*-
+#
+# Given: an xdp.frags program and a netns veth pair raised to a jumbo
+# MTU (8901), which exceeds the per-page XDP buffer limit, so a
+# non-frags XDP program cannot attach in native mode
+#
+# When: the frags program is attached through bpfman
+#
+# Then: because every dispatcher member is frags-capable, bpfman loads
+# the dispatcher with BPF_F_XDP_HAS_FRAGS and the attach lands in native
+# (driver) mode (ip xdp.mode == 1). dispatcher get reports is_xdp_frags.
+# Without frags support the native attach fails with ERANGE, since this
+# branch has no generic-mode fallback.
+
+guard veth <- net netns-veth-pair
+defer net release $veth
+
+let netns = "/var/run/netns/${veth.a.ns}"
+
+# Raise both ends to the jumbo MTU.
+guard _ <- net exec $veth.a ip link set dev $veth.a.link mtu 8901
+guard _ <- net exec $veth.b ip link set dev $veth.b.link mtu 8901
+
+guard loaded <- bpfman program load file testdata/bpf/xdp_frags_pass.bpf.o --programs xdp:frags_pass
+let prog = $loaded.programs[0]
+let pid = $prog.record.program_id
+assert $prog.record.has_xdp_frags
+defer bpfman program unload $pid
+
+# Native attach to the jumbo interface succeeds only because the
+# dispatcher is loaded frags-aware.
+guard link <- bpfman link attach xdp $prog $veth.a.link --priority 50 --netns $netns
+defer bpfman link detach $link
+assert $link.status.kernel_seen
+
+# Kernel proof: the dispatcher is attached in native (driver) mode, not
+# generic. Mode 1 is XDP_FLAGS_DRV_MODE; 2 would be XDP_FLAGS_SKB_MODE.
+guard xdpShow <- net exec $veth.a ip -j -d link show dev $veth.a.link
+let xdpMode = $xdpShow.stdout |> jq "fromjson | .[0].xdp.mode"
+print "xdp mode on ${veth.a.link}: ${xdpMode} (1=native, 2=generic)"
+assert $xdpMode == 1
+
+# The dispatcher was loaded with BPF_F_XDP_HAS_FRAGS, and the member
+# records its frags capability.
+guard disp <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
+assert $disp.is_xdp_frags
+assert $disp.members[0].program_name == "frags_pass"
+assert $disp.members[0].has_xdp_frags

--- a/e2e/scripts/TestXDP_FragsNativeJumboAttach.bpfman
+++ b/e2e/scripts/TestXDP_FragsNativeJumboAttach.bpfman
@@ -46,3 +46,9 @@ guard disp <- bpfman dispatcher get xdp $veth.a.nsid $veth.a.ifindex
 assert $disp.is_xdp_frags
 assert $disp.members[0].program_name == "frags_pass"
 assert $disp.members[0].has_xdp_frags
+
+# dispatcher list carries the same frags summary, so frags dispatchers
+# can be found without a per-dispatcher get.
+guard dispList <- bpfman dispatcher list
+let listFrags = $dispList |> jq "[.dispatchers[] | select(.key.nsid == ${veth.a.nsid} and .key.ifindex == ${veth.a.ifindex})][0].is_xdp_frags"
+assert $listFrags

--- a/e2e/scripts/TestXDP_LoadAndGet.bpfman
+++ b/e2e/scripts/TestXDP_LoadAndGet.bpfman
@@ -50,6 +50,7 @@ assert $prog matches exhaustive {
         program_id:     $pid
         license:        "Dual BSD/GPL"
         gpl_compatible: true
+        has_xdp_frags:  false
         created_at:     not-empty
         updated_at:     null
         load: matches exhaustive {
@@ -152,6 +153,7 @@ assert $got matches exhaustive {
         program_id:     $prog.record.program_id
         license:        $prog.record.license
         gpl_compatible: $prog.record.gpl_compatible
+        has_xdp_frags:  $prog.record.has_xdp_frags
         created_at:     $prog.record.created_at
         updated_at:     null
         load: matches exhaustive {

--- a/manager/action/action.go
+++ b/manager/action/action.go
@@ -386,6 +386,9 @@ type RebuildXDPDispatcher struct {
 	// Metadata holds user-supplied key/value link labels to persist on
 	// the new extension's link record.
 	Metadata map[string]string
+
+	// HasXDPFrags reports whether the new XDP extension is frags-capable.
+	HasXDPFrags bool
 }
 
 func (RebuildXDPDispatcher) isAction() {}

--- a/manager/attach_xdp.go
+++ b/manager/attach_xdp.go
@@ -59,6 +59,7 @@ func (m *Manager) attachXDP(ctx context.Context, spec bpfman.XDPAttachSpec) (bpf
 				Priority:    priority,
 				ProceedOn:   proceedOnMask,
 				Metadata:    spec.Metadata(),
+				HasXDPFrags: prog.HasXDPFrags,
 			}
 		},
 	})

--- a/manager/executor.go
+++ b/manager/executor.go
@@ -110,9 +110,19 @@ func (e *executor) ExecuteResult(ctx context.Context, a action.Action) (any, err
 		return nil, e.bpffs.RemoveDispatcherRevDir(a.Path)
 
 	case action.RebuildXDPDispatcher:
-		return e.rebuildXDPDispatcher(ctx, a.ProgramID,
+		newSlot := rebuildSlot{
+			ProgPinPath: a.ProgPinPath,
+			ProgramName: a.ProgramName,
+			Priority:    a.Priority,
+			ProceedOn:   a.ProceedOn,
+			ProgramID:   a.ProgramID,
+			Ifname:      a.Ifname,
+			Metadata:    a.Metadata,
+			HasXDPFrags: a.HasXDPFrags,
+		}
+		return e.rebuildXDPDispatcher(ctx,
 			xdpRebuildOps{ifindex: a.Ifindex, ifname: a.Ifname, netnsPath: a.NetnsPath},
-			a.ProgPinPath, a.ProgramName, a.Priority, a.ProceedOn, a.Metadata)
+			newSlot)
 
 	case action.RebuildTCDispatcher:
 		return e.rebuildTCDispatcher(ctx, a.ProgramID,

--- a/manager/executor_dispatcher.go
+++ b/manager/executor_dispatcher.go
@@ -89,15 +89,17 @@ func dispatcherMembers(slots []rebuildSlot, attached []attachedExt) []platform.D
 }
 
 func xdpFragsModeForSlots(slots []rebuildSlot) dispatcher.XDPFragsMode {
-	for _, slot := range slots {
-		if !slot.HasXDPFrags {
-			return dispatcher.XDPFragsDisabled
-		}
+	frags := make([]bool, len(slots))
+
+	for i, slot := range slots {
+		frags[i] = slot.HasXDPFrags
 	}
-	if len(slots) == 0 {
-		return dispatcher.XDPFragsDisabled
+
+	if dispatcher.FragsEligible(frags) {
+		return dispatcher.XDPFragsEnabled
 	}
-	return dispatcher.XDPFragsEnabled
+
+	return dispatcher.XDPFragsDisabled
 }
 
 // rebuildXDPDispatcher performs a full XDP dispatcher rebuild.

--- a/manager/executor_dispatcher.go
+++ b/manager/executor_dispatcher.go
@@ -88,18 +88,16 @@ func dispatcherMembers(slots []rebuildSlot, attached []attachedExt) []platform.D
 	return members
 }
 
-func xdpFragsModeForSlots(slots []rebuildSlot) dispatcher.XDPFragsMode {
+// xdpFragsForSlots reports whether an XDP dispatcher built from these
+// rebuild slots should be loaded frags-aware, applying the shared
+// dispatcher.FragsEligible rule over each slot's member.
+func xdpFragsForSlots(slots []rebuildSlot) bool {
 	frags := make([]bool, len(slots))
-
 	for i, slot := range slots {
 		frags[i] = slot.HasXDPFrags
 	}
 
-	if dispatcher.FragsEligible(frags) {
-		return dispatcher.XDPFragsEnabled
-	}
-
-	return dispatcher.XDPFragsDisabled
+	return dispatcher.FragsEligible(frags)
 }
 
 // rebuildXDPDispatcher performs a full XDP dispatcher rebuild.
@@ -155,7 +153,7 @@ func (e *executor) rebuildXDPDispatcher(
 	sortRebuildSlots(allSlots)
 
 	// Compute .rodata config.
-	cfg, err := dispatcher.NewXDPConfig(len(allSlots), xdpFragsModeForSlots(allSlots))
+	cfg, err := dispatcher.NewXDPConfig(len(allSlots), xdpFragsForSlots(allSlots))
 	if err != nil {
 		return extensionResult{}, fmt.Errorf("create XDP dispatcher config: %w", err)
 	}
@@ -716,7 +714,7 @@ func (e *executor) rebuildXDPForDetach(
 ) error {
 	key := snap.Key
 
-	cfg, err := dispatcher.NewXDPConfig(len(slots), xdpFragsModeForSlots(slots))
+	cfg, err := dispatcher.NewXDPConfig(len(slots), xdpFragsForSlots(slots))
 	if err != nil {
 		return fmt.Errorf("create XDP dispatcher config for detach rebuild: %w", err)
 	}

--- a/manager/executor_dispatcher.go
+++ b/manager/executor_dispatcher.go
@@ -33,6 +33,7 @@ type rebuildSlot struct {
 	ProgramID      kernel.ProgramID  // managed program's kernel ID
 	Ifname         string            // interface name from detail record
 	Metadata       map[string]string // user link labels; new slot from spec, existing slots preserved from the snapshot
+	HasXDPFrags    bool
 }
 
 // xdpRebuildOps returns the type-specific operations for XDP
@@ -81,9 +82,22 @@ func dispatcherMembers(slots []rebuildSlot, attached []attachedExt) []platform.D
 			ProceedOn:      slot.ProceedOn,
 			Ifname:         slot.Ifname,
 			Metadata:       slot.Metadata,
+			HasXDPFrags:    slot.HasXDPFrags,
 		}
 	}
 	return members
+}
+
+func xdpFragsModeForSlots(slots []rebuildSlot) dispatcher.XDPFragsMode {
+	for _, slot := range slots {
+		if !slot.HasXDPFrags {
+			return dispatcher.XDPFragsDisabled
+		}
+	}
+	if len(slots) == 0 {
+		return dispatcher.XDPFragsDisabled
+	}
+	return dispatcher.XDPFragsEnabled
 }
 
 // rebuildXDPDispatcher performs a full XDP dispatcher rebuild.
@@ -92,24 +106,9 @@ func dispatcherMembers(slots []rebuildSlot, attached []attachedExt) []platform.D
 // The managedProgramID identifies the user program being attached.
 func (e *executor) rebuildXDPDispatcher(
 	ctx context.Context,
-	managedProgramID kernel.ProgramID,
 	ops xdpRebuildOps,
-	progPinPath bpfman.ProgPinPath,
-	programName string,
-	priority int,
-	proceedOn uint32,
-	metadata map[string]string,
+	newSlot rebuildSlot,
 ) (extensionResult, error) {
-	newSlot := rebuildSlot{
-		ProgPinPath: progPinPath,
-		ProgramName: programName,
-		Priority:    priority,
-		ProceedOn:   proceedOn,
-		ProgramID:   managedProgramID,
-		Ifname:      ops.ifname,
-		Metadata:    metadata,
-	}
-
 	nsid, err := netns.NSID(ops.netnsPath)
 	if err != nil {
 		return extensionResult{}, fmt.Errorf("get nsid: %w", err)
@@ -141,6 +140,7 @@ func (e *executor) rebuildXDPDispatcher(
 			ProgramID:      m.ProgramID,
 			Ifname:         m.Ifname,
 			Metadata:       m.Metadata,
+			HasXDPFrags:    m.HasXDPFrags,
 		})
 	}
 	allSlots = append(allSlots, newSlot)
@@ -153,7 +153,7 @@ func (e *executor) rebuildXDPDispatcher(
 	sortRebuildSlots(allSlots)
 
 	// Compute .rodata config.
-	cfg, err := dispatcher.NewXDPConfig(len(allSlots))
+	cfg, err := dispatcher.NewXDPConfig(len(allSlots), xdpFragsModeForSlots(allSlots))
 	if err != nil {
 		return extensionResult{}, fmt.Errorf("create XDP dispatcher config: %w", err)
 	}
@@ -319,7 +319,7 @@ func (e *executor) rebuildXDPDispatcher(
 	newExtLinkRecord := completed.Members[newSlotPosition]
 	newExtRecord := bpfman.LinkRecord{
 		ID:           newExtLinkRecord.LinkID,
-		ProgramID:    managedProgramID,
+		ProgramID:    newSlot.ProgramID,
 		KernelLinkID: newExtLinkRecord.KernelLinkID,
 		Kind:         bpfman.LinkKindXDP,
 		PinPath:      bpfman.NewLinkPath(newExt.pinPath),
@@ -687,6 +687,7 @@ func (e *executor) rebuildDispatcherForDetach(ctx context.Context, key dispatche
 			ExistingLinkID: &linkID,
 			ProgramID:      m.ProgramID,
 			Ifname:         m.Ifname,
+			HasXDPFrags:    m.HasXDPFrags,
 		}
 	}
 	sortRebuildSlots(rebuildSlots)
@@ -713,7 +714,7 @@ func (e *executor) rebuildXDPForDetach(
 ) error {
 	key := snap.Key
 
-	cfg, err := dispatcher.NewXDPConfig(len(slots))
+	cfg, err := dispatcher.NewXDPConfig(len(slots), xdpFragsModeForSlots(slots))
 	if err != nil {
 		return fmt.Errorf("create XDP dispatcher config for detach rebuild: %w", err)
 	}

--- a/manager/load.go
+++ b/manager/load.go
@@ -79,6 +79,7 @@ func buildProgramRecord(
 			WithAttachFunc(spec.AttachFunc()),
 		License:       loaded.License,
 		GPLCompatible: bpfman.IsGPLCompatible(loaded.License),
+		HasXDPFrags:   loaded.HasXDPFrags,
 		Handles: bpfman.ProgramHandles{
 			PinPath:    loaded.PinPath,
 			MapsDir:    loaded.MapsDir,

--- a/platform/dispatcher_types.go
+++ b/platform/dispatcher_types.go
@@ -56,6 +56,10 @@ type DispatcherMember struct {
 	// Metadata is the caller-supplied key/value metadata recorded with
 	// the link.
 	Metadata map[string]string `json:"metadata"`
+
+	// HasXDPFrags reports whether this XDP member was loaded from a
+	// frags-capable program spec. It is false for non-XDP members.
+	HasXDPFrags bool `json:"has_xdp_frags"`
 }
 
 // DispatcherMemberSpec describes an extension program that should be
@@ -111,6 +115,10 @@ type DispatcherMemberSpec struct {
 	// Metadata is the caller-supplied key/value metadata to record
 	// with the link.
 	Metadata map[string]string `json:"metadata"`
+
+	// HasXDPFrags reports whether this XDP member was loaded from a
+	// frags-capable program spec. It is false for non-XDP members.
+	HasXDPFrags bool `json:"has_xdp_frags"`
 }
 
 // DispatcherRuntime holds the kernel-assigned identifiers for the
@@ -168,6 +176,10 @@ type DispatcherSnapshot struct {
 	// Members are the extension programs currently attached to the
 	// dispatcher, in slot order (ascending Position).
 	Members []DispatcherMember `json:"members"`
+
+	// IsXDPFrags reports whether this XDP dispatcher was loaded with
+	// BPF_F_XDP_HAS_FRAGS. It is false for non-XDP dispatchers.
+	IsXDPFrags bool `json:"is_xdp_frags"`
 }
 
 // DispatcherSnapshotSpec is the requested replacement state for a dispatcher.

--- a/platform/dispatcher_types.go
+++ b/platform/dispatcher_types.go
@@ -117,7 +117,11 @@ type DispatcherMemberSpec struct {
 	Metadata map[string]string `json:"metadata"`
 
 	// HasXDPFrags reports whether this XDP member was loaded from a
-	// frags-capable program spec. It is false for non-XDP members.
+	// frags-capable program spec; false for non-XDP members. It is not
+	// persisted per-member: managed_programs.has_xdp_frags (the program
+	// record) is the source of truth, and the store re-derives the member
+	// flag from it on read via a join. On the spec this is load-transient
+	// input to the frags-eligibility decision, not a durable field.
 	HasXDPFrags bool `json:"has_xdp_frags"`
 }
 

--- a/platform/dispatcher_types.go
+++ b/platform/dispatcher_types.go
@@ -224,6 +224,12 @@ type DispatcherSummary struct {
 	// MemberCount is the number of extension members attached to the
 	// dispatcher.
 	MemberCount int `json:"member_count"`
+
+	// IsXDPFrags reports whether the dispatcher is loaded frags-aware
+	// (BPF_F_XDP_HAS_FRAGS). Always false for a non-XDP dispatcher.
+	// Mirrors DispatcherSnapshot.IsXDPFrags so `dispatcher list` can be
+	// filtered for frags dispatchers without a per-dispatcher get.
+	IsXDPFrags bool `json:"is_xdp_frags"`
 }
 
 // DispatcherListResult wraps dispatcher list output for consistent

--- a/platform/ebpf/attach_xdp.go
+++ b/platform/ebpf/attach_xdp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
 
 	"github.com/bpfman/bpfman"
 	"github.com/bpfman/bpfman/dispatcher"
@@ -140,6 +141,13 @@ func (k *kernelAdapter) LoadAndPinXDPDispatcher(ctx context.Context, cfg dispatc
 	collSpec, err := dispatcher.LoadXDPDispatcher(cfg)
 	if err != nil {
 		return 0, fmt.Errorf("load XDP dispatcher spec: %w", err)
+	}
+	if cfg.IsXDPFrags == 1 {
+		progSpec, ok := collSpec.Programs["xdp_dispatcher"]
+		if !ok {
+			return 0, fmt.Errorf("xdp_dispatcher program not found in collection spec")
+		}
+		progSpec.Flags |= unix.BPF_F_XDP_HAS_FRAGS
 	}
 
 	coll, err := ebpf.NewCollection(collSpec)

--- a/platform/ebpf/features.go
+++ b/platform/ebpf/features.go
@@ -44,14 +44,15 @@ func haveXDPFrags() bool {
 			// the negative.
 			xdpFragsSupported = false
 		default:
-			// The probe failed for a reason unrelated to
-			// the flag -- a kernel that lacks frags
-			// returns EINVAL. Assume supported rather
-			// than caching a false negative that would
-			// silently strip frags from every program for
-			// the rest of the process; if the kernel
-			// really lacks frags the real load is still
-			// rejected.
+			// A non-EINVAL failure is unrelated to frags support: a
+			// kernel that lacks frags rejects the flag with EINVAL
+			// (handled above), so this is a transient or
+			// environmental failure (EPERM without CAP_BPF, ENOMEM).
+			// Assume supported rather than caching a false negative
+			// that would strip frags from every program for the
+			// process lifetime. Such failures hit the real program
+			// load equally, so this cannot silently turn a frags
+			// load into a non-frags one.
 			xdpFragsSupported = true
 		}
 	})

--- a/platform/ebpf/features.go
+++ b/platform/ebpf/features.go
@@ -1,0 +1,75 @@
+package ebpf
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	xdpFragsOnce      sync.Once
+	xdpFragsSupported bool
+)
+
+// haveXDPFrags reports whether the running kernel accepts
+// BPF_F_XDP_HAS_FRAGS at program load. The flag was added in Linux 5.18;
+// on older kernels BPF_PROG_LOAD rejects the unknown prog_flags bit with
+// EINVAL. cilium/ebpf has no feature probe for program flags, so this
+// probes directly, once, by loading a trivial XDP program with the flag
+// set and caching the outcome. A load probe rather than a version check
+// so it stays correct across backports.
+func haveXDPFrags() bool {
+	xdpFragsOnce.Do(func() {
+		prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+			Name:    "probe_xdp_frags",
+			Type:    ebpf.XDP,
+			Flags:   unix.BPF_F_XDP_HAS_FRAGS,
+			License: "GPL",
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 2), // XDP_PASS
+				asm.Return(),
+			},
+		})
+
+		switch {
+		case err == nil:
+			prog.Close()
+			xdpFragsSupported = true
+		case errors.Is(err, unix.EINVAL):
+			// The kernel rejected the flag itself: frags
+			// is genuinely unsupported (pre-5.18). Cache
+			// the negative.
+			xdpFragsSupported = false
+		default:
+			// The probe failed for a reason unrelated to
+			// the flag -- a kernel that lacks frags
+			// returns EINVAL. Assume supported rather
+			// than caching a false negative that would
+			// silently strip frags from every program for
+			// the rest of the process; if the kernel
+			// really lacks frags the real load is still
+			// rejected.
+			xdpFragsSupported = true
+		}
+	})
+
+	return xdpFragsSupported
+}
+
+// resolveXDPFrags returns the program flags to load with and whether the
+// program is frags-capable, given the flags the spec declares (the loader
+// sets BPF_F_XDP_HAS_FRAGS from an xdp.frags section) and whether the
+// running kernel supports the flag. On a kernel without frags support the
+// flag is stripped so the program loads as non-frags rather than being
+// rejected at load. This is the pure decision behind the probe; Load
+// feeds haveXDPFrags() in as kernelHasFrags.
+func resolveXDPFrags(specFlags uint32, kernelHasFrags bool) (flags uint32, hasFrags bool) {
+	hasFrags = specFlags&unix.BPF_F_XDP_HAS_FRAGS != 0
+	if hasFrags && !kernelHasFrags {
+		return specFlags &^ unix.BPF_F_XDP_HAS_FRAGS, false
+	}
+	return specFlags, hasFrags
+}

--- a/platform/ebpf/features_test.go
+++ b/platform/ebpf/features_test.go
@@ -1,0 +1,41 @@
+package ebpf
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestResolveXDPFrags(t *testing.T) {
+	t.Parallel()
+
+	const frags = uint32(unix.BPF_F_XDP_HAS_FRAGS)
+	const other = uint32(1 << 4) // an unrelated prog_flags bit, must be preserved
+
+	tests := []struct {
+		name           string
+		specFlags      uint32
+		kernelHasFrags bool
+		wantFlags      uint32
+		wantHasFrags   bool
+	}{
+		{"non-frags program, kernel supports frags", other, true, other, false},
+		{"non-frags program, kernel lacks frags", other, false, other, false},
+		{"frags program, kernel supports frags", frags | other, true, frags | other, true},
+		{"frags program, kernel lacks frags -> stripped", frags | other, false, other, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotFlags, gotHasFrags := resolveXDPFrags(tt.specFlags, tt.kernelHasFrags)
+			if gotFlags != tt.wantFlags {
+				t.Errorf("flags = %#x, want %#x", gotFlags, tt.wantFlags)
+			}
+			if gotHasFrags != tt.wantHasFrags {
+				t.Errorf("hasFrags = %v, want %v", gotHasFrags, tt.wantHasFrags)
+			}
+		})
+	}
+}

--- a/platform/ebpf/load.go
+++ b/platform/ebpf/load.go
@@ -105,7 +105,14 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 		return bpfman.LoadOutput{}, fmt.Errorf("program %q not found in collection spec; available programs: %v", spec.ProgramName(), available)
 	}
 	license := progSpec.License
-	hasXDPFrags := progSpec.Flags&unix.BPF_F_XDP_HAS_FRAGS != 0
+
+	// The loader sets BPF_F_XDP_HAS_FRAGS from an xdp.frags section. On a
+	// kernel that predates it (< 5.18) BPF_PROG_LOAD rejects the unknown
+	// flag, so resolveXDPFrags strips it and loads the program as
+	// non-frags -- mirroring libxdp, which loads the dispatcher without
+	// the flag when the kernel lacks it.
+	var hasXDPFrags bool
+	progSpec.Flags, hasXDPFrags = resolveXDPFrags(progSpec.Flags, haveXDPFrags())
 
 	// Determine program type: prefer user-specified type, fall back to ELF inference.
 	// The user's CLI specification (e.g., --programs kretprobe:func) takes precedence

--- a/platform/ebpf/load.go
+++ b/platform/ebpf/load.go
@@ -110,9 +110,13 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 	// kernel that predates it (< 5.18) BPF_PROG_LOAD rejects the unknown
 	// flag, so resolveXDPFrags strips it and loads the program as
 	// non-frags -- mirroring libxdp, which loads the dispatcher without
-	// the flag when the kernel lacks it.
+	// the flag when the kernel lacks it. Only an xdp.frags program carries
+	// the flag, so gate the one-shot kernel probe on it: a non-XDP or
+	// plain-XDP load never triggers haveXDPFrags().
 	var hasXDPFrags bool
-	progSpec.Flags, hasXDPFrags = resolveXDPFrags(progSpec.Flags, haveXDPFrags())
+	if progSpec.Flags&unix.BPF_F_XDP_HAS_FRAGS != 0 {
+		progSpec.Flags, hasXDPFrags = resolveXDPFrags(progSpec.Flags, haveXDPFrags())
+	}
 
 	// Determine program type: prefer user-specified type, fall back to ELF inference.
 	// The user's CLI specification (e.g., --programs kretprobe:func) takes precedence

--- a/platform/ebpf/load.go
+++ b/platform/ebpf/load.go
@@ -105,6 +105,7 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 		return bpfman.LoadOutput{}, fmt.Errorf("program %q not found in collection spec; available programs: %v", spec.ProgramName(), available)
 	}
 	license := progSpec.License
+	hasXDPFrags := progSpec.Flags&unix.BPF_F_XDP_HAS_FRAGS != 0
 
 	// Determine program type: prefer user-specified type, fall back to ELF inference.
 	// The user's CLI specification (e.g., --programs kretprobe:func) takes precedence
@@ -427,6 +428,7 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 		License:        license,
 		InferredType:   programType,
 		SharedMapNames: sharedMapNames,
+		HasXDPFrags:    hasXDPFrags,
 	}, nil
 }
 

--- a/platform/ebpf/test_dispatcher.go
+++ b/platform/ebpf/test_dispatcher.go
@@ -30,7 +30,7 @@ func loadTestDispatcher(programType bpfman.ProgramType) (*ebpf.Program, func(), 
 	)
 	switch programType {
 	case bpfman.ProgramTypeXDP:
-		cfg, cfgErr := dispatcher.NewXDPConfig(1)
+		cfg, cfgErr := dispatcher.NewXDPConfig(1, dispatcher.XDPFragsDisabled)
 		if cfgErr != nil {
 			return nil, nil, fmt.Errorf("create test XDP dispatcher config: %w", cfgErr)
 		}

--- a/platform/ebpf/test_dispatcher.go
+++ b/platform/ebpf/test_dispatcher.go
@@ -30,7 +30,7 @@ func loadTestDispatcher(programType bpfman.ProgramType) (*ebpf.Program, func(), 
 	)
 	switch programType {
 	case bpfman.ProgramTypeXDP:
-		cfg, cfgErr := dispatcher.NewXDPConfig(1, dispatcher.XDPFragsDisabled)
+		cfg, cfgErr := dispatcher.NewXDPConfig(1, false)
 		if cfgErr != nil {
 			return nil, nil, fmt.Errorf("create test XDP dispatcher config: %w", cfgErr)
 		}

--- a/platform/store/sqlite/dispatchers.go
+++ b/platform/store/sqlite/dispatchers.go
@@ -69,7 +69,13 @@ func (s *sqliteStore) prepareDispatcherStatements(ctx context.Context) error {
 		       AND t.direction = CASE d.type
 		           WHEN 'tc-ingress' THEN 'ingress'
 		           WHEN 'tc-egress' THEN 'egress'
-		           ELSE '' END) AS member_count
+		           ELSE '' END) AS member_count,
+		    (SELECT json_group_array(p.has_xdp_frags)
+		     FROM link_xdp_details x
+		     JOIN links l ON x.id = l.id
+		     JOIN managed_programs p ON l.kernel_prog_id = p.program_id
+		     WHERE x.nsid = d.nsid AND x.ifindex = d.ifindex
+		       AND d.type = 'xdp') AS member_frags
 		FROM dispatchers d`
 
 	s.stmtListDispatcherSummaries, err = s.db.PrepareContext(ctx, listDispatcherSummariesSQL)
@@ -188,6 +194,23 @@ func scanDispatcherRuntime(programID kernel.ProgramID, nullLinkID sql.NullInt64,
 	return rt
 }
 
+// xdpDispatcherFrags reports whether an XDP dispatcher with these members
+// is frags-aware, applying the shared dispatcher.FragsEligible rule.
+// Always false for a non-XDP dispatcher, since TC members are never
+// frags-capable.
+func xdpDispatcherFrags(key dispatcher.Key, members []platform.DispatcherMember) bool {
+	if key.Type != dispatcher.DispatcherTypeXDP {
+		return false
+	}
+
+	frags := make([]bool, len(members))
+	for i, m := range members {
+		frags[i] = m.HasXDPFrags
+	}
+
+	return dispatcher.FragsEligible(frags)
+}
+
 // GetDispatcherSnapshot retrieves a complete snapshot of a dispatcher
 // and all its extension members.
 func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.Key) (platform.DispatcherSnapshot, error) {
@@ -218,7 +241,6 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 		Revision: revision,
 		Runtime:  scanDispatcherRuntime(programID, nullLinkID, priority, filterHandle, netnsPath),
 	}
-	allXDPFrags := key.Type == dispatcher.DispatcherTypeXDP
 
 	// Fetch members from the appropriate detail table.
 	var rows *sql.Rows
@@ -247,9 +269,7 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 			return platform.DispatcherSnapshot{}, fmt.Errorf("scan dispatcher member: %w", err)
 		}
 		m.HasXDPFrags = hasXDPFrags != 0
-		if !m.HasXDPFrags {
-			allXDPFrags = false
-		}
+
 		if kernelLinkID.Valid {
 			id := kernel.LinkID(kernelLinkID.Int64)
 			m.KernelLinkID = &id
@@ -278,20 +298,21 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 
 		snap.Members = append(snap.Members, m)
 	}
+
 	if err := rows.Err(); err != nil {
 		return platform.DispatcherSnapshot{}, fmt.Errorf("iterate dispatcher members: %w", err)
 	}
-	if key.Type == dispatcher.DispatcherTypeXDP && len(snap.Members) > 0 {
-		snap.IsXDPFrags = allXDPFrags
-	}
+
+	snap.IsXDPFrags = xdpDispatcherFrags(key, snap.Members)
 
 	s.logger.Debug("sql", "stmt", "GetDispatcherSnapshot", "args", []any{key}, "duration_ms", msec(time.Since(start)), "members", len(snap.Members))
 	return snap, nil
 }
 
 // ListDispatcherSummaries returns lightweight summaries of all
-// dispatchers with member counts. Uses a correlated subquery to
-// count members without joining detail tables.
+// dispatchers with member counts. Uses correlated subqueries to count
+// members and gather their frags flags without joining detail tables at
+// the top level, so the whole listing is one consistent snapshot.
 func (s *sqliteStore) ListDispatcherSummaries(ctx context.Context) ([]platform.DispatcherSummary, error) {
 	start := time.Now()
 
@@ -312,8 +333,9 @@ func (s *sqliteStore) ListDispatcherSummaries(ctx context.Context) ([]platform.D
 		var priority sql.NullInt64
 		var filterHandle sql.NullInt64
 		var netnsPath string
+		var memberFragsJSON string
 		if err := rows.Scan(&dispTypeStr, &summary.Key.Nsid, &summary.Key.Ifindex,
-			&summary.Revision, &programID, &nullLinkID, &priority, &filterHandle, &netnsPath, &summary.MemberCount); err != nil {
+			&summary.Revision, &programID, &nullLinkID, &priority, &filterHandle, &netnsPath, &summary.MemberCount, &memberFragsJSON); err != nil {
 			s.logger.Debug("sql", "stmt", "ListDispatcherSummaries", "duration_ms", msec(time.Since(start)), "error", err)
 			return nil, fmt.Errorf("scan dispatcher summary: %w", err)
 		}
@@ -323,7 +345,23 @@ func (s *sqliteStore) ListDispatcherSummaries(ctx context.Context) ([]platform.D
 			return nil, fmt.Errorf("invalid dispatcher type in DB: %w", err)
 		}
 
+		// member_frags is a JSON array of each XDP member's has_xdp_frags
+		// flag ('[]' for non-XDP dispatchers), gathered in the same
+		// statement so the frags verdict shares one snapshot with the
+		// rest of the row. SQL only gathers; the frags rule stays in
+		// dispatcher.FragsEligible, the same rule the snapshot uses.
+		var memberFrags []int
+		if err := json.Unmarshal([]byte(memberFragsJSON), &memberFrags); err != nil {
+			return nil, fmt.Errorf("parse dispatcher member frags: %w", err)
+		}
+
+		frags := make([]bool, len(memberFrags))
+		for i, v := range memberFrags {
+			frags[i] = v != 0
+		}
+
 		summary.Key.Type = parsed
+		summary.IsXDPFrags = dispatcher.FragsEligible(frags)
 		summary.Runtime = scanDispatcherRuntime(programID, nullLinkID, priority, filterHandle, netnsPath)
 		result = append(result, summary)
 	}
@@ -468,15 +506,8 @@ func (s *sqliteStore) replaceDispatcherSnapshot(ctx context.Context, snap platfo
 		}
 		completed.Members = append(completed.Members, m)
 	}
-	if snap.Key.Type == dispatcher.DispatcherTypeXDP && len(completed.Members) > 0 {
-		completed.IsXDPFrags = true
-		for _, m := range completed.Members {
-			if !m.HasXDPFrags {
-				completed.IsXDPFrags = false
-				break
-			}
-		}
-	}
+
+	completed.IsXDPFrags = xdpDispatcherFrags(snap.Key, completed.Members)
 
 	s.logger.Debug("sql", "stmt", "ReplaceDispatcherSnapshot", "args", []any{snap.Key, snap.Revision}, "duration_ms", msec(time.Since(start)), "members", len(snap.Members))
 	return completed, nil

--- a/platform/store/sqlite/dispatchers.go
+++ b/platform/store/sqlite/dispatchers.go
@@ -32,7 +32,7 @@ func (s *sqliteStore) prepareDispatcherStatements(ctx context.Context) error {
 
 	const getXDPMembersSQL = `
 		SELECT d.position, d.priority, p.program_name, d.proceed_on,
-		       p.pin_path, l.id, l.kernel_link_id, l.kernel_prog_id, l.pin_path, d.interface, l.metadata_json
+		       p.pin_path, l.id, l.kernel_link_id, l.kernel_prog_id, l.pin_path, d.interface, l.metadata_json, p.has_xdp_frags
 		FROM link_xdp_details d
 		JOIN links l ON d.id = l.id
 		JOIN managed_programs p ON l.kernel_prog_id = p.program_id
@@ -46,7 +46,7 @@ func (s *sqliteStore) prepareDispatcherStatements(ctx context.Context) error {
 
 	const getTCMembersSQL = `
 		SELECT d.position, d.priority, p.program_name, d.proceed_on,
-		       p.pin_path, l.id, l.kernel_link_id, l.kernel_prog_id, l.pin_path, d.interface, l.metadata_json
+		       p.pin_path, l.id, l.kernel_link_id, l.kernel_prog_id, l.pin_path, d.interface, l.metadata_json, 0
 		FROM link_tc_details d
 		JOIN links l ON d.id = l.id
 		JOIN managed_programs p ON l.kernel_prog_id = p.program_id
@@ -218,6 +218,7 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 		Revision: revision,
 		Runtime:  scanDispatcherRuntime(programID, nullLinkID, priority, filterHandle, netnsPath),
 	}
+	allXDPFrags := key.Type == dispatcher.DispatcherTypeXDP
 
 	// Fetch members from the appropriate detail table.
 	var rows *sql.Rows
@@ -240,9 +241,14 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 		var kernelLinkID sql.NullInt64
 		var linkPinPath sql.NullString
 		var metadataJSON sql.NullString
+		var hasXDPFrags int
 		if err := rows.Scan(&m.Position, &m.Priority, &m.ProgramName, &proceedOnJSON,
-			&m.ProgPinPath, &m.LinkID, &kernelLinkID, &m.ProgramID, &linkPinPath, &m.Ifname, &metadataJSON); err != nil {
+			&m.ProgPinPath, &m.LinkID, &kernelLinkID, &m.ProgramID, &linkPinPath, &m.Ifname, &metadataJSON, &hasXDPFrags); err != nil {
 			return platform.DispatcherSnapshot{}, fmt.Errorf("scan dispatcher member: %w", err)
+		}
+		m.HasXDPFrags = hasXDPFrags != 0
+		if !m.HasXDPFrags {
+			allXDPFrags = false
 		}
 		if kernelLinkID.Valid {
 			id := kernel.LinkID(kernelLinkID.Int64)
@@ -274,6 +280,9 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 	}
 	if err := rows.Err(); err != nil {
 		return platform.DispatcherSnapshot{}, fmt.Errorf("iterate dispatcher members: %w", err)
+	}
+	if key.Type == dispatcher.DispatcherTypeXDP && len(snap.Members) > 0 {
+		snap.IsXDPFrags = allXDPFrags
 	}
 
 	s.logger.Debug("sql", "stmt", "GetDispatcherSnapshot", "args", []any{key}, "duration_ms", msec(time.Since(start)), "members", len(snap.Members))
@@ -434,6 +443,7 @@ func (s *sqliteStore) replaceDispatcherSnapshot(ctx context.Context, snap platfo
 			ProceedOn:    spec.ProceedOn,
 			Ifname:       spec.Ifname,
 			Metadata:     spec.Metadata,
+			HasXDPFrags:  spec.HasXDPFrags,
 		}
 
 		// Insert detail row.
@@ -457,6 +467,15 @@ func (s *sqliteStore) replaceDispatcherSnapshot(ctx context.Context, snap platfo
 			}
 		}
 		completed.Members = append(completed.Members, m)
+	}
+	if snap.Key.Type == dispatcher.DispatcherTypeXDP && len(completed.Members) > 0 {
+		completed.IsXDPFrags = true
+		for _, m := range completed.Members {
+			if !m.HasXDPFrags {
+				completed.IsXDPFrags = false
+				break
+			}
+		}
 	}
 
 	s.logger.Debug("sql", "stmt", "ReplaceDispatcherSnapshot", "args", []any{snap.Key, snap.Revision}, "duration_ms", msec(time.Since(start)), "members", len(snap.Members))

--- a/platform/store/sqlite/dispatchers.go
+++ b/platform/store/sqlite/dispatchers.go
@@ -70,6 +70,11 @@ func (s *sqliteStore) prepareDispatcherStatements(ctx context.Context) error {
 		           WHEN 'tc-ingress' THEN 'ingress'
 		           WHEN 'tc-egress' THEN 'egress'
 		           ELSE '' END) AS member_count,
+		    -- member_frags reaches has_xdp_frags via managed_programs, while
+		    -- member_count counts link_xdp_details directly. They enumerate the
+		    -- same members only because FK enforcement (foreign_keys=1)
+		    -- guarantees every link row has a program row; without it an orphan
+		    -- link would be counted but dropped here, skewing the frags verdict.
 		    (SELECT json_group_array(p.has_xdp_frags)
 		     FROM link_xdp_details x
 		     JOIN links l ON x.id = l.id
@@ -268,8 +273,8 @@ func (s *sqliteStore) GetDispatcherSnapshot(ctx context.Context, key dispatcher.
 			&m.ProgPinPath, &m.LinkID, &kernelLinkID, &m.ProgramID, &linkPinPath, &m.Ifname, &metadataJSON, &hasXDPFrags); err != nil {
 			return platform.DispatcherSnapshot{}, fmt.Errorf("scan dispatcher member: %w", err)
 		}
-		m.HasXDPFrags = hasXDPFrags != 0
 
+		m.HasXDPFrags = hasXDPFrags != 0
 		if kernelLinkID.Valid {
 			id := kernel.LinkID(kernelLinkID.Int64)
 			m.KernelLinkID = &id

--- a/platform/store/sqlite/dispatchers_snapshot_test.go
+++ b/platform/store/sqlite/dispatchers_snapshot_test.go
@@ -115,6 +115,88 @@ func setupXDPSnapshot(t *testing.T, ctx context.Context, store platform.Store) p
 	}
 }
 
+func TestXDPSnapshotAggregatesFragsCapability(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlite.NewInMemory(context.Background(), testLogger())
+	require.NoError(t, err)
+	defer store.Close()
+
+	ctx := context.Background()
+	prog1ID := kernel.ProgramID(1001)
+	prog2ID := kernel.ProgramID(1002)
+	prog1 := testXDPProgram("xdp_frags_1")
+	prog1.HasXDPFrags = true
+	prog2 := testXDPProgram("xdp_frags_2")
+	prog2.HasXDPFrags = true
+	require.NoError(t, store.Save(ctx, prog1ID, prog1))
+	require.NoError(t, store.Save(ctx, prog2ID, prog2))
+
+	member1KernelLinkID := kernel.LinkID(701)
+	member2KernelLinkID := kernel.LinkID(702)
+	snap := platform.DispatcherSnapshotSpec{
+		Key:      xdpKey(),
+		Revision: 1,
+		Runtime: platform.DispatcherRuntime{
+			ProgramID:    500,
+			KernelLinkID: ptr(kernel.LinkID(501)),
+		},
+		Members: []platform.DispatcherMemberSpec{
+			{
+				ProgramID:    prog1ID,
+				ProgramName:  "xdp_frags_1",
+				ProgPinPath:  "/sys/fs/bpf/xdp_frags_1",
+				KernelLinkID: &member1KernelLinkID,
+				LinkPinPath:  "/sys/fs/bpf/dispatch/r1/link0",
+				Position:     0,
+				Priority:     50,
+				ProceedOn:    0x04,
+				Ifname:       "eth0",
+				HasXDPFrags:  true,
+			},
+			{
+				ProgramID:    prog2ID,
+				ProgramName:  "xdp_frags_2",
+				ProgPinPath:  "/sys/fs/bpf/xdp_frags_2",
+				KernelLinkID: &member2KernelLinkID,
+				LinkPinPath:  "/sys/fs/bpf/dispatch/r1/link1",
+				Position:     1,
+				Priority:     100,
+				ProceedOn:    0x04,
+				Ifname:       "eth0",
+				HasXDPFrags:  true,
+			},
+		},
+	}
+
+	completed, err := store.ReplaceDispatcherSnapshot(ctx, snap)
+	require.NoError(t, err)
+	require.True(t, completed.IsXDPFrags)
+
+	got, err := store.GetDispatcherSnapshot(ctx, xdpKey())
+	require.NoError(t, err)
+	require.True(t, got.IsXDPFrags)
+	require.True(t, got.Members[0].HasXDPFrags)
+	require.True(t, got.Members[1].HasXDPFrags)
+
+	prog2.HasXDPFrags = false
+	require.NoError(t, store.Save(ctx, prog2ID, prog2))
+	snap.Revision = 2
+	snap.Runtime.ProgramID = 501
+	snap.Runtime.KernelLinkID = ptr(kernel.LinkID(502))
+	snap.Members[1].HasXDPFrags = false
+
+	completed, err = store.ReplaceDispatcherSnapshot(ctx, snap)
+	require.NoError(t, err)
+	require.False(t, completed.IsXDPFrags)
+
+	got, err = store.GetDispatcherSnapshot(ctx, xdpKey())
+	require.NoError(t, err)
+	require.False(t, got.IsXDPFrags)
+	require.True(t, got.Members[0].HasXDPFrags)
+	require.False(t, got.Members[1].HasXDPFrags)
+}
+
 func TestSnapshotStore_ReplaceAndGet_XDP(t *testing.T) {
 	t.Parallel()
 

--- a/platform/store/sqlite/migrations/00003_add_has_xdp_frags.sql
+++ b/platform/store/sqlite/migrations/00003_add_has_xdp_frags.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE managed_programs
+    ADD COLUMN has_xdp_frags INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE managed_programs
+    DROP COLUMN has_xdp_frags;

--- a/platform/store/sqlite/programs.go
+++ b/platform/store/sqlite/programs.go
@@ -47,6 +47,7 @@ type scannedProgram struct {
 	license, metadataJSON                            sql.NullString
 	mapSetID                                         sql.NullInt64
 	gplCompatible                                    int
+	hasXDPFrags                                      int
 	createdAtStr                                     string
 	updatedAtStr                                     sql.NullString
 }
@@ -141,6 +142,7 @@ func buildProgramRecord(sp *scannedProgram) (bpfman.ProgramRecord, error) {
 			WithAttachFunc(attachFuncVal),
 		License:       licenseVal,
 		GPLCompatible: sp.gplCompatible != 0,
+		HasXDPFrags:   sp.hasXDPFrags != 0,
 		Handles: bpfman.ProgramHandles{
 			PinPath:    bpfman.ProgPinPath(sp.pinPath),
 			MapsDir:    bpfman.MapDir(mapPinPathVal),
@@ -181,6 +183,7 @@ func (s *sqliteStore) scanProgram(row *sql.Row, programID kernel.ProgramID) (bpf
 		&sp.description,
 		&sp.license,
 		&sp.gplCompatible,
+		&sp.hasXDPFrags,
 		&sp.createdAtStr,
 		&sp.updatedAtStr,
 		&sp.metadataJSON,
@@ -297,6 +300,10 @@ func (s *sqliteStore) Save(ctx context.Context, programID kernel.ProgramID, meta
 	if metadata.GPLCompatible {
 		gplCompatibleInt = 1
 	}
+	var hasXDPFragsInt int
+	if metadata.HasXDPFrags {
+		hasXDPFragsInt = 1
+	}
 
 	start := time.Now()
 	result, err := s.stmtSaveProgram.ExecContext(ctx,
@@ -314,6 +321,7 @@ func (s *sqliteStore) Save(ctx context.Context, programID kernel.ProgramID, meta
 		description,
 		license,
 		gplCompatibleInt,
+		hasXDPFragsInt,
 		metadataJSON,
 		metadata.CreatedAt.UTC().Format(time.RFC3339),
 		updatedAtNullable,
@@ -541,6 +549,7 @@ func (s *sqliteStore) scanProgramFromRows(rows *sql.Rows) (kernel.ProgramID, bpf
 		&sp.description,
 		&sp.license,
 		&sp.gplCompatible,
+		&sp.hasXDPFrags,
 		&sp.createdAtStr,
 		&sp.updatedAtStr,
 		&sp.metadataJSON,

--- a/platform/store/sqlite/sqlite_test.go
+++ b/platform/store/sqlite/sqlite_test.go
@@ -222,6 +222,30 @@ func TestMetadata_StoredAsJSON(t *testing.T) {
 	assert.Error(t, err, "expected error after delete")
 }
 
+func TestProgramHasXDPFrags_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlite.NewInMemory(context.Background(), testLogger())
+	require.NoError(t, err, "failed to create store")
+	defer store.Close()
+
+	ctx := context.Background()
+	programID := kernel.ProgramID(42)
+	prog := testProgram()
+	prog.HasXDPFrags = true
+
+	require.NoError(t, store.Save(ctx, programID, prog), "Save failed")
+
+	got, err := store.Get(ctx, programID)
+	require.NoError(t, err, "Get failed")
+	require.True(t, got.HasXDPFrags)
+
+	list, err := store.List(ctx)
+	require.NoError(t, err, "List failed")
+	require.Len(t, list, 1)
+	require.True(t, list[programID].HasXDPFrags)
+}
+
 func TestProgramName_DuplicatesAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/platform/store/sqlite/stmts.go
+++ b/platform/store/sqlite/stmts.go
@@ -12,7 +12,7 @@ func (s *sqliteStore) prepareProgramStatements(ctx context.Context) error {
 	const sqlGetProgram = `
 		SELECT m.program_name, m.program_type, m.object_path, m.source_path, m.pin_path, m.attach_func,
 		       m.global_data, m.map_set_id, ms.pin_path, m.image_source, m.owner, m.description,
-		       m.license, m.gpl_compatible, m.created_at, m.updated_at, m.metadata_json
+		       m.license, m.gpl_compatible, m.has_xdp_frags, m.created_at, m.updated_at, m.metadata_json
 		FROM managed_programs m
 		JOIN map_sets ms ON ms.id = m.map_set_id
 		WHERE m.program_id = ?`
@@ -36,8 +36,8 @@ func (s *sqliteStore) prepareProgramStatements(ctx context.Context) error {
 	const sqlSaveProgram = `
 		INSERT INTO managed_programs
 		(program_id, program_name, program_type, object_path, source_path, pin_path, attach_func,
-		 global_data, map_set_id, image_source, owner, description, license, gpl_compatible, metadata_json, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 global_data, map_set_id, image_source, owner, description, license, gpl_compatible, has_xdp_frags, metadata_json, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(program_id) DO UPDATE SET
 		  program_name = excluded.program_name,
 		  program_type = excluded.program_type,
@@ -52,6 +52,7 @@ func (s *sqliteStore) prepareProgramStatements(ctx context.Context) error {
 		  description = excluded.description,
 		  license = excluded.license,
 		  gpl_compatible = excluded.gpl_compatible,
+		  has_xdp_frags = excluded.has_xdp_frags,
 		  metadata_json = excluded.metadata_json,
 		  updated_at = excluded.updated_at`
 	if s.stmtSaveProgram, err = s.db.PrepareContext(ctx, sqlSaveProgram); err != nil {
@@ -66,7 +67,7 @@ func (s *sqliteStore) prepareProgramStatements(ctx context.Context) error {
 	const sqlListPrograms = `
 		SELECT m.program_id, m.program_name, m.program_type, m.object_path, m.source_path, m.pin_path, m.attach_func,
 		       m.global_data, m.map_set_id, ms.pin_path, m.image_source, m.owner, m.description,
-		       m.license, m.gpl_compatible, m.created_at, m.updated_at, m.metadata_json
+		       m.license, m.gpl_compatible, m.has_xdp_frags, m.created_at, m.updated_at, m.metadata_json
 		FROM managed_programs m
 		JOIN map_sets ms ON ms.id = m.map_set_id`
 	if s.stmtListPrograms, err = s.db.PrepareContext(ctx, sqlListPrograms); err != nil {

--- a/program.go
+++ b/program.go
@@ -196,6 +196,10 @@ type ProgramRecord struct {
 	// because it is a property of the loaded program, not the load request.
 	GPLCompatible bool `json:"gpl_compatible"`
 
+	// HasXDPFrags reports whether the program was loaded from bytecode whose
+	// program spec carried BPF_F_XDP_HAS_FRAGS.
+	HasXDPFrags bool `json:"has_xdp_frags"`
+
 	// Handles holds the stable filesystem handles used for lifecycle operations.
 	Handles ProgramHandles `json:"handles"`
 
@@ -375,6 +379,10 @@ type LoadOutput struct {
 
 	// SharedMapNames is the list of PinByName map names, for reference counting.
 	SharedMapNames []string
+
+	// HasXDPFrags reports whether the loaded program's spec carried
+	// BPF_F_XDP_HAS_FRAGS.
+	HasXDPFrags bool
 }
 
 // IsGPLCompatible checks if a license string is GPL compatible.


### PR DESCRIPTION
This adds XDP frags support so an XDP program compiled with a `SEC("xdp.frags")` section can attach natively to an interface with a large MTU, where a non-frags program is otherwise rejected with `ERANGE`.

The core is a single eligibility rule, `dispatcher.FragsEligible`: an XDP dispatcher is loaded with `BPF_F_XDP_HAS_FRAGS` only when it is non-empty and every member program is frags-capable, mirroring libxdp's all-or-nothing policy. The flag is a property of the dispatcher as a whole rather than a per-freplace-member flag, and a non-frags member exposed to fragmented packets can silently misbehave, so a mixed set downgrades the dispatcher to non-frags. That downgraded dispatcher then attaches fine on a normal MTU and is refused with `ERANGE` on a jumbo one, leaving the previous frags dispatcher intact via atomic rollback.

A one-shot kernel probe (`haveXDPFrags`) degrades gracefully on kernels older than 5.18, which reject the unknown flag at load: the flag is stripped and the program loads as non-frags rather than failing. Each program's frags capability is persisted (`has_xdp_frags`, migration `00003`) and reported through `dispatcher get` and `dispatcher list` as `is_xdp_frags`, plus per member.


## Test plan

`make bpfman-compile`, `make lint-go`, the unit tests, and the `.bpfman` e2e suite all pass. Frags-specific e2e cover native jumbo attach (driver mode confirmed via `ip -d link`), the mixed-member downgrade, and the jumbo rejection with atomic rollback.