### PR TITLE
Add a nested Fedora VM e2e harness and deterministic link-detach teardown

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   check-vendor:
     name: Check go.mod and vendor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -38,7 +38,7 @@ jobs:
 
   check-fmt:
     name: Check Go formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -54,7 +54,7 @@ jobs:
 
   check-goimports:
     name: Check Go imports
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -70,7 +70,7 @@ jobs:
 
   check-vet:
     name: Check go vet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: docker/setup-buildx-action@v4
@@ -78,7 +78,7 @@ jobs:
 
   check-gofix:
     name: Check go fix modernisers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: docker/setup-buildx-action@v4
@@ -86,7 +86,7 @@ jobs:
 
   check-bpfman-shell-fmt:
     name: Check .bpfman formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: docker/setup-buildx-action@v4
@@ -100,7 +100,7 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: docker/setup-buildx-action@v4
@@ -137,7 +137,7 @@ jobs:
   # the magic keeps the workflow honest about what it actually does.
   nix:
     name: Nix lint and build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -201,7 +201,7 @@ jobs:
     name: CI complete
     needs: [check-vendor, check-fmt, check-goimports, check-vet, check-gofix, check-bpfman-shell-fmt, build, tests, nested-vm-e2e, lint, nix, test-bpfman-ns-qemu]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -111,6 +111,9 @@ jobs:
   tests:
     uses: ./.github/workflows/go-test.yaml
 
+  nested-vm-e2e:
+    uses: ./.github/workflows/nested-vm-e2e.yml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -196,7 +199,7 @@ jobs:
 
   ci-complete:
     name: CI complete
-    needs: [check-vendor, check-fmt, check-goimports, check-vet, check-gofix, check-bpfman-shell-fmt, build, tests, lint, nix, test-bpfman-ns-qemu]
+    needs: [check-vendor, check-fmt, check-goimports, check-vet, check-gofix, check-bpfman-shell-fmt, build, tests, nested-vm-e2e, lint, nix, test-bpfman-ns-qemu]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -46,7 +46,7 @@ jobs:
         race: [1, 0]
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -96,7 +96,7 @@ jobs:
         arch: [amd64, arm64]
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -138,7 +138,7 @@ jobs:
         race: [1, 0]
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -198,7 +198,7 @@ jobs:
           - {bytecode_source: image, race: 1}
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/nested-vm-e2e.yml
+++ b/.github/workflows/nested-vm-e2e.yml
@@ -1,0 +1,131 @@
+name: e2e (nested Fedora VM, LSM)
+
+# Run the e2e suite -- the gRPC lifecycle tests and the
+# whole .bpfman script corpus -- under a kernel with bpf in the
+# active LSM list.
+#
+# Hosted runners boot without bpf-LSM (/sys/kernel/security/lsm lacks
+# bpf) and cannot be rebooted mid-job, so the lsm tests otherwise
+# skip. hack/fedora-vm.sh boots a Fedora cloud VM (stock Fedora
+# kernels ship bpf-LSM active), shares the checkout into the guest
+# over virtiofs, and runs hack/nested-vm-e2e.sh inside. The guest builds
+# with Fedora's native BPF toolchain, so nothing beyond the VM
+# tooling is installed on the runner.
+#
+# Two caches keep the steady-state run short: the harness caches the
+# base image and a provisioned disk (dependencies pre-installed,
+# keyed on hack/install-fedora-deps.sh content) under
+# ~/.cache/bpfman-fedora-vm, and the guest Go build cache persists in
+# .gocache on the share.
+#
+# It has no triggers of its own: the CI workflow calls it as a job,
+# so it runs on pull requests and on pushes to main and inherits
+# CI's concurrency group.
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  nested-vm-e2e:
+    name: e2e (nested Fedora VM, LSM)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install VM tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils genisoimage libseccomp-dev libcap-ng-dev
+
+      - name: Cache virtiofsd binary
+        uses: actions/cache@v4
+        with:
+          path: ~/virtiofsd-bin
+          key: virtiofsd-1.13.2
+
+      - name: Build virtiofsd
+        run: |
+          # The harness needs virtiofsd's --translate-uid/--translate-gid,
+          # added in 1.13; noble packages 1.10, so build from crates.io
+          # with the runner's Rust toolchain (cached across runs).
+          if [[ ! -x ~/virtiofsd-bin/bin/virtiofsd ]]; then
+            cargo install virtiofsd --version 1.13.2 --root ~/virtiofsd-bin
+          fi
+          sudo ln -sf ~/virtiofsd-bin/bin/virtiofsd /usr/local/bin/virtiofsd
+          virtiofsd --version
+
+      - name: Open up KVM and unprivileged user namespaces
+        run: |
+          # Standard x64 Linux runners expose /dev/kvm but root-only.
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -la /dev/kvm
+          # Ubuntu 24.04 confines unprivileged user namespaces behind
+          # AppArmor; unprivileged virtiofsd sandboxes itself in one.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          # virtiofsd pins an O_PATH fd per inode the guest touches
+          # (repo + vendor + Go cache); the runner's default file
+          # table is small enough to exhaust, and the guest sees the
+          # host's ENFILE verbatim through FUSE.
+          sudo sysctl -w fs.file-max=4194304
+          ulimit -Hn
+
+      - name: Sanity -- the bare runner has no bpf-LSM (that is what the VM fixes)
+        run: |
+          echo -n "host lsm: "; cat /sys/kernel/security/lsm; echo
+          ! grep -qw bpf /sys/kernel/security/lsm
+
+      - name: Cache base image and provisioned disk
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bpfman-fedora-vm
+          key: fedora-vm-${{ hashFiles('hack/fedora-vm.sh', 'hack/install-fedora-deps.sh') }}
+          restore-keys: fedora-vm-
+
+      - name: Cache guest Go build cache
+        uses: actions/cache@v4
+        with:
+          path: .gocache
+          key: lsm-gocache-${{ github.sha }}
+          restore-keys: lsm-gocache-
+
+      # Three separate steps, each its own VM boot against the cached
+      # provisioned disk, so the stages are visible as they complete.
+      - name: Provision the Fedora VM disk
+        env:
+          SERIAL_LOG: /tmp/guest-serial.log
+        run: hack/fedora-vm.sh --provision hack/install-fedora-deps.sh
+
+      # prlimit is per-step: each run script is a fresh shell, and
+      # virtiofsd (started by the harness) inherits the raised hard
+      # limit from it.
+      - name: Build the e2e artefacts in the VM
+        env:
+          VIRTFS_FAST: "1"
+          SERIAL_LOG: /tmp/guest-serial.log
+        run: |
+          sudo prlimit --pid $$ --nofile=1048576:1048576
+          hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run 'hack/nested-vm-e2e.sh build'
+
+      - name: Run the e2e tests in the VM
+        env:
+          VIRTFS_FAST: "1"
+          SERIAL_LOG: /tmp/guest-serial.log
+        run: |
+          sudo prlimit --pid $$ --nofile=1048576:1048576
+          hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run 'hack/nested-vm-e2e.sh test'
+
+      - name: Upload guest serial log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: guest-serial-log
+          path: /tmp/guest-serial.log
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ cargo-vendor-filterer
 
 /ci-e2e-bundle/
 .cache/
+
+# Go build cache persisted across hack/fedora-vm.sh runs.
+/.gocache/

--- a/e2e/lib.bpfman
+++ b/e2e/lib.bpfman
@@ -154,6 +154,19 @@ def await_uprobe_detach_quiescent(mapID events counterFilter) {
     retry "waiting for uprobe detach quiescence" unless $after == $before
 }
 
+# Wait until a just-detached network program (xdp/tc/tcx, plain or
+# dispatcher-backed) stops counting packets on its interface. One
+# ping from `ns` to `addr` is the probe: while the program still
+# observes the hook the counter moves, so retry until it holds.
+def await_net_detach_quiescent(ns addr mapID counterFilter) {
+    guard beforeDump <- bpftool map dump id $mapID -j
+    let before = $beforeDump.stdout |> jq $counterFilter
+    guard _ <- net exec $ns ping -c 1 -W 1 $addr
+    guard afterDump <- bpftool map dump id $mapID -j
+    let after = $afterDump.stdout |> jq $counterFilter
+    retry "waiting for network detach quiescence" unless $after == $before
+}
+
 # Asserts the store records exactly `want` dispatchers on the given
 # (nsid, ifindex), across all dispatcher types. List-derived
 # assertions must scope to keys the script owns: scripts run in

--- a/e2e/scripts/TestMultiProgMixed_LoadAttachDetachUnload.bpfman
+++ b/e2e/scripts/TestMultiProgMixed_LoadAttachDetachUnload.bpfman
@@ -6,8 +6,8 @@
 # When: the stimulus is fired across waves with the programs detached at
 # staggered points
 #
-# Then: each program ends with the exact event count implied by the
-# waves it survived
+# Then: each program's counter advances only during the waves its link
+# stayed attached
 #
 # Three program types -- tracepoint, kprobe, kretprobe -- in one
 # .bpf.o, all driven by a single stimulus per wave: a write to the
@@ -24,15 +24,9 @@
 # The tracepoint program filters on the leased slot index; the probes
 # attach to a slot-private symbol, so the symbol itself is their
 # isolation boundary. Three waves with staggered detach (krp first,
-# then kp) leave:
-#
-#   tp  counts waves 1+2+3 = 3 * N
-#   kp  counts waves 1+2   = 2 * N
-#   krp counts wave 1      = 1 * N
-#
-# Between detach and the next wave a brief sleep lets the perf-link RCU
-# grace period close; perf-link applies to the kp/krp pair, while
-# tracepoint detach is effectively synchronous.
+# then kp): each wave asserts a delta between snapshots for the
+# still-attached programs, and each detached program's counter is
+# asserted frozen across all subsequent activity.
 
 import ../lib.bpfman
 
@@ -69,41 +63,77 @@ guard link_krp <- bpfman link attach kprobe $krp $fn.name
 
 let counter_filter = "fromjson | .[0].formatted.value | tonumber"
 
+# The kernel unhooks a detached program asynchronously, so each
+# detach is followed by a quiescence poll before the next wave; the
+# poll's probe fires feed the still-attached programs, so the wave
+# assertions are deltas between snapshots taken around each poll
+# rather than fixed whole-run totals.
+
 # --- Wave 1: tp, kp, krp all attached ---
 guard _ <- kfunc fire $fn $n
 
+guard w1_tp <- bpftool map dump id $mapID_tp -j
+guard w1_kp <- bpftool map dump id $mapID_kp -j
+guard w1_krp <- bpftool map dump id $mapID_krp -j
+let snap1_tp = $w1_tp.stdout |> jq $counter_filter
+let snap1_kp = $w1_kp.stdout |> jq $counter_filter
+let snap1_krp = $w1_krp.stdout |> jq $counter_filter
+print "wave1 tp=${snap1_tp} kp=${snap1_kp} krp=${snap1_krp}"
+assert $snap1_tp == ($n * $weight_tp)
+assert $snap1_kp == ($n * $weight_kp)
+assert $snap1_krp == ($n * $weight_krp)
+
 # Detach krp first.
 bpfman link detach $link_krp
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_kfunc_detach_quiescent $fn $mapID_krp 1 $counter_filter
+}
+guard q2_tp <- bpftool map dump id $mapID_tp -j
+guard q2_kp <- bpftool map dump id $mapID_kp -j
+guard q2_krp <- bpftool map dump id $mapID_krp -j
+let snap2_tp = $q2_tp.stdout |> jq $counter_filter
+let snap2_kp = $q2_kp.stdout |> jq $counter_filter
+let snap2_krp = $q2_krp.stdout |> jq $counter_filter
 
-# --- Wave 2: tp, kp attached; krp detached ---
+# --- Wave 2: tp, kp attached; krp detached and quiescent ---
 guard _ <- kfunc fire $fn $n
+
+guard w2_tp <- bpftool map dump id $mapID_tp -j
+guard w2_kp <- bpftool map dump id $mapID_kp -j
+guard w2_krp <- bpftool map dump id $mapID_krp -j
+let snap3_tp = $w2_tp.stdout |> jq $counter_filter
+let snap3_kp = $w2_kp.stdout |> jq $counter_filter
+let snap3_krp = $w2_krp.stdout |> jq $counter_filter
+print "wave2 dtp=${snap3_tp} dkp=${snap3_kp} krp=${snap3_krp} want_krp=${snap2_krp}"
+assert ($snap3_tp - $snap2_tp) == ($n * $weight_tp)
+assert ($snap3_kp - $snap2_kp) == ($n * $weight_kp)
+assert $snap3_krp == $snap2_krp
 
 bpfman link detach $link_kp
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_kfunc_detach_quiescent $fn $mapID_kp 1 $counter_filter
+}
+guard q3_tp <- bpftool map dump id $mapID_tp -j
+guard q3_kp <- bpftool map dump id $mapID_kp -j
+guard q3_krp <- bpftool map dump id $mapID_krp -j
+let snap4_tp = $q3_tp.stdout |> jq $counter_filter
+let snap4_kp = $q3_kp.stdout |> jq $counter_filter
+let snap4_krp = $q3_krp.stdout |> jq $counter_filter
+assert $snap4_krp == $snap3_krp
 
-# --- Wave 3: only tp attached ---
+# --- Wave 3: only tp attached; kp, krp quiescent ---
 guard _ <- kfunc fire $fn $n
 
-guard dump_tp <- bpftool map dump id $mapID_tp -j
-guard dump_kp <- bpftool map dump id $mapID_kp -j
-guard dump_krp <- bpftool map dump id $mapID_krp -j
-
-let count_tp = $dump_tp.stdout |> jq $counter_filter
-let count_kp = $dump_kp.stdout |> jq $counter_filter
-let count_krp = $dump_krp.stdout |> jq $counter_filter
-
-let want_tp = (3 * $n) * $weight_tp
-let want_kp = (2 * $n) * $weight_kp
-let want_krp = (1 * $n) * $weight_krp
-
-print "tp:  got=${count_tp}  want=${want_tp}"
-print "kp:  got=${count_kp}  want=${want_kp}"
-print "krp: got=${count_krp} want=${want_krp}"
-
-assert $count_tp == $want_tp
-assert $count_kp == $want_kp
-assert $count_krp == $want_krp
+guard w3_tp <- bpftool map dump id $mapID_tp -j
+guard w3_kp <- bpftool map dump id $mapID_kp -j
+guard w3_krp <- bpftool map dump id $mapID_krp -j
+let final_tp = $w3_tp.stdout |> jq $counter_filter
+let final_kp = $w3_kp.stdout |> jq $counter_filter
+let final_krp = $w3_krp.stdout |> jq $counter_filter
+print "wave3 dtp=${final_tp} kp=${final_kp} want_kp=${snap4_kp} krp=${final_krp} want_krp=${snap4_krp}"
+assert ($final_tp - $snap4_tp) == ($n * $weight_tp)
+assert $final_kp == $snap4_kp
+assert $final_krp == $snap4_krp
 
 # tp is still attached on the happy path; detach explicitly
 # before the deferred program-unloads fire.

--- a/e2e/scripts/TestMultiProgTracepoint_LoadAttachDetachUnload.bpfman
+++ b/e2e/scripts/TestMultiProgTracepoint_LoadAttachDetachUnload.bpfman
@@ -46,45 +46,76 @@ guard link_c <- bpfman link attach tracepoint $c bpfman_e2e/bpfman_e2e_ping
 
 let counter_filter = "fromjson | .[0].formatted.value | tonumber"
 
+# The kernel unhooks a detached program asynchronously, so each
+# detach is followed by a quiescence poll before the next wave; the
+# poll's probe fires feed the still-attached programs, so the wave
+# assertions are deltas between snapshots taken around each poll
+# rather than fixed whole-run totals.
+
 # --- Wave 1: a, b, c all attached ---
 guard _ <- kfunc fire $fn $n
 
-# Detach c. Sleep briefly so the perf-link RCU GP completes before the
-# next wave fires, otherwise some of wave 2's events could still hit
-# c's program.
+guard w1_a <- bpftool map dump id $mapID_a -j
+guard w1_b <- bpftool map dump id $mapID_b -j
+guard w1_c <- bpftool map dump id $mapID_c -j
+let snap1_a = $w1_a.stdout |> jq $counter_filter
+let snap1_b = $w1_b.stdout |> jq $counter_filter
+let snap1_c = $w1_c.stdout |> jq $counter_filter
+print "wave1 a=${snap1_a} b=${snap1_b} c=${snap1_c}"
+assert $snap1_a == ($n * $weight_a)
+assert $snap1_b == ($n * $weight_b)
+assert $snap1_c == ($n * $weight_c)
+
 bpfman link detach $link_c
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_kfunc_detach_quiescent $fn $mapID_c 1 $counter_filter
+}
+guard q2_a <- bpftool map dump id $mapID_a -j
+guard q2_b <- bpftool map dump id $mapID_b -j
+guard q2_c <- bpftool map dump id $mapID_c -j
+let snap2_a = $q2_a.stdout |> jq $counter_filter
+let snap2_b = $q2_b.stdout |> jq $counter_filter
+let snap2_c = $q2_c.stdout |> jq $counter_filter
 
-# --- Wave 2: a, b attached; c detached ---
+# --- Wave 2: a, b attached; c detached and quiescent ---
 guard _ <- kfunc fire $fn $n
 
-# Detach b.
+guard w2_a <- bpftool map dump id $mapID_a -j
+guard w2_b <- bpftool map dump id $mapID_b -j
+guard w2_c <- bpftool map dump id $mapID_c -j
+let snap3_a = $w2_a.stdout |> jq $counter_filter
+let snap3_b = $w2_b.stdout |> jq $counter_filter
+let snap3_c = $w2_c.stdout |> jq $counter_filter
+print "wave2 da=${snap3_a} db=${snap3_b} c=${snap3_c} want_c=${snap2_c}"
+assert ($snap3_a - $snap2_a) == ($n * $weight_a)
+assert ($snap3_b - $snap2_b) == ($n * $weight_b)
+assert $snap3_c == $snap2_c
+
 bpfman link detach $link_b
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_kfunc_detach_quiescent $fn $mapID_b 1 $counter_filter
+}
+guard q3_a <- bpftool map dump id $mapID_a -j
+guard q3_b <- bpftool map dump id $mapID_b -j
+guard q3_c <- bpftool map dump id $mapID_c -j
+let snap4_a = $q3_a.stdout |> jq $counter_filter
+let snap4_b = $q3_b.stdout |> jq $counter_filter
+let snap4_c = $q3_c.stdout |> jq $counter_filter
+assert $snap4_c == $snap3_c
 
-# --- Wave 3: only a attached ---
+# --- Wave 3: only a attached; b, c quiescent ---
 guard _ <- kfunc fire $fn $n
 
-# Read counters and assert exactness.
-guard dump_a <- bpftool map dump id $mapID_a -j
-guard dump_b <- bpftool map dump id $mapID_b -j
-guard dump_c <- bpftool map dump id $mapID_c -j
-
-let count_a = $dump_a.stdout |> jq $counter_filter
-let count_b = $dump_b.stdout |> jq $counter_filter
-let count_c = $dump_c.stdout |> jq $counter_filter
-
-let want_a = (3 * $n) * $weight_a
-let want_b = (2 * $n) * $weight_b
-let want_c = (1 * $n) * $weight_c
-
-print "a: got=${count_a} want=${want_a}"
-print "b: got=${count_b} want=${want_b}"
-print "c: got=${count_c} want=${want_c}"
-
-assert $count_a == $want_a
-assert $count_b == $want_b
-assert $count_c == $want_c
+guard w3_a <- bpftool map dump id $mapID_a -j
+guard w3_b <- bpftool map dump id $mapID_b -j
+guard w3_c <- bpftool map dump id $mapID_c -j
+let final_a = $w3_a.stdout |> jq $counter_filter
+let final_b = $w3_b.stdout |> jq $counter_filter
+let final_c = $w3_c.stdout |> jq $counter_filter
+print "wave3 da=${final_a} b=${final_b} want_b=${snap4_b} c=${final_c} want_c=${snap4_c}"
+assert ($final_a - $snap4_a) == ($n * $weight_a)
+assert $final_b == $snap4_b
+assert $final_c == $snap4_c
 
 # link_a is still attached on the happy path; detach it explicitly
 # before the deferred program-unloads fire (an attached program

--- a/e2e/scripts/TestMultiProgUprobe_LoadAttachDetachUnload.bpfman
+++ b/e2e/scripts/TestMultiProgUprobe_LoadAttachDetachUnload.bpfman
@@ -41,40 +41,76 @@ guard link_c <- bpfman link attach uprobe $c $target.path -f $target.symbol
 
 let counter_filter = "fromjson | .[0].formatted.value | tonumber"
 
+# The kernel unhooks a detached program asynchronously, so each
+# detach is followed by a quiescence poll before the next wave; the
+# poll's probe fires feed the still-attached programs, so the wave
+# assertions are deltas between snapshots taken around each poll
+# rather than fixed whole-run totals.
+
 # --- Wave 1: a, b, c all attached ---
 guard _ <- uprobe fire $n
 
-bpfman link detach $link_c
-sleep 0.1
+guard w1_a <- bpftool map dump id $mapID_a -j
+guard w1_b <- bpftool map dump id $mapID_b -j
+guard w1_c <- bpftool map dump id $mapID_c -j
+let snap1_a = $w1_a.stdout |> jq $counter_filter
+let snap1_b = $w1_b.stdout |> jq $counter_filter
+let snap1_c = $w1_c.stdout |> jq $counter_filter
+print "wave1 a=${snap1_a} b=${snap1_b} c=${snap1_c}"
+assert $snap1_a == ($n * $weight_a)
+assert $snap1_b == ($n * $weight_b)
+assert $snap1_c == ($n * $weight_c)
 
-# --- Wave 2: a, b attached; c detached ---
+bpfman link detach $link_c
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID_c 1 $counter_filter
+}
+guard q2_a <- bpftool map dump id $mapID_a -j
+guard q2_b <- bpftool map dump id $mapID_b -j
+guard q2_c <- bpftool map dump id $mapID_c -j
+let snap2_a = $q2_a.stdout |> jq $counter_filter
+let snap2_b = $q2_b.stdout |> jq $counter_filter
+let snap2_c = $q2_c.stdout |> jq $counter_filter
+
+# --- Wave 2: a, b attached; c detached and quiescent ---
 guard _ <- uprobe fire $n
+
+guard w2_a <- bpftool map dump id $mapID_a -j
+guard w2_b <- bpftool map dump id $mapID_b -j
+guard w2_c <- bpftool map dump id $mapID_c -j
+let snap3_a = $w2_a.stdout |> jq $counter_filter
+let snap3_b = $w2_b.stdout |> jq $counter_filter
+let snap3_c = $w2_c.stdout |> jq $counter_filter
+print "wave2 da=${snap3_a} db=${snap3_b} c=${snap3_c} want_c=${snap2_c}"
+assert ($snap3_a - $snap2_a) == ($n * $weight_a)
+assert ($snap3_b - $snap2_b) == ($n * $weight_b)
+assert $snap3_c == $snap2_c
 
 bpfman link detach $link_b
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID_b 1 $counter_filter
+}
+guard q3_a <- bpftool map dump id $mapID_a -j
+guard q3_b <- bpftool map dump id $mapID_b -j
+guard q3_c <- bpftool map dump id $mapID_c -j
+let snap4_a = $q3_a.stdout |> jq $counter_filter
+let snap4_b = $q3_b.stdout |> jq $counter_filter
+let snap4_c = $q3_c.stdout |> jq $counter_filter
+assert $snap4_c == $snap3_c
 
-# --- Wave 3: only a attached ---
+# --- Wave 3: only a attached; b, c quiescent ---
 guard _ <- uprobe fire $n
 
-guard dump_a <- bpftool map dump id $mapID_a -j
-guard dump_b <- bpftool map dump id $mapID_b -j
-guard dump_c <- bpftool map dump id $mapID_c -j
-
-let count_a = $dump_a.stdout |> jq $counter_filter
-let count_b = $dump_b.stdout |> jq $counter_filter
-let count_c = $dump_c.stdout |> jq $counter_filter
-
-let want_a = (3 * $n) * $weight_a
-let want_b = (2 * $n) * $weight_b
-let want_c = (1 * $n) * $weight_c
-
-print "a: got=${count_a} want=${want_a}"
-print "b: got=${count_b} want=${want_b}"
-print "c: got=${count_c} want=${want_c}"
-
-assert $count_a == $want_a
-assert $count_b == $want_b
-assert $count_c == $want_c
+guard w3_a <- bpftool map dump id $mapID_a -j
+guard w3_b <- bpftool map dump id $mapID_b -j
+guard w3_c <- bpftool map dump id $mapID_c -j
+let final_a = $w3_a.stdout |> jq $counter_filter
+let final_b = $w3_b.stdout |> jq $counter_filter
+let final_c = $w3_c.stdout |> jq $counter_filter
+print "wave3 da=${final_a} b=${final_b} want_b=${snap4_b} c=${final_c} want_c=${snap4_c}"
+assert ($final_a - $snap4_a) == ($n * $weight_a)
+assert $final_b == $snap4_b
+assert $final_c == $snap4_c
 
 # link_a is still attached on the happy path; detach it explicitly
 # before the deferred program-unloads fire.

--- a/e2e/scripts/TestMultiProgUretprobe_LoadAttachDetachUnload.bpfman
+++ b/e2e/scripts/TestMultiProgUretprobe_LoadAttachDetachUnload.bpfman
@@ -41,40 +41,76 @@ guard link_c <- bpfman link attach uprobe $c $target.path -f $target.symbol
 
 let counter_filter = "fromjson | .[0].formatted.value | tonumber"
 
+# The kernel unhooks a detached program asynchronously, so each
+# detach is followed by a quiescence poll before the next wave; the
+# poll's probe fires feed the still-attached programs, so the wave
+# assertions are deltas between snapshots taken around each poll
+# rather than fixed whole-run totals.
+
 # --- Wave 1: a, b, c all attached ---
 guard _ <- uprobe fire $n
 
-bpfman link detach $link_c
-sleep 0.1
+guard w1_a <- bpftool map dump id $mapID_a -j
+guard w1_b <- bpftool map dump id $mapID_b -j
+guard w1_c <- bpftool map dump id $mapID_c -j
+let snap1_a = $w1_a.stdout |> jq $counter_filter
+let snap1_b = $w1_b.stdout |> jq $counter_filter
+let snap1_c = $w1_c.stdout |> jq $counter_filter
+print "wave1 a=${snap1_a} b=${snap1_b} c=${snap1_c}"
+assert $snap1_a == ($n * $weight_a)
+assert $snap1_b == ($n * $weight_b)
+assert $snap1_c == ($n * $weight_c)
 
-# --- Wave 2: a, b attached; c detached ---
+bpfman link detach $link_c
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID_c 1 $counter_filter
+}
+guard q2_a <- bpftool map dump id $mapID_a -j
+guard q2_b <- bpftool map dump id $mapID_b -j
+guard q2_c <- bpftool map dump id $mapID_c -j
+let snap2_a = $q2_a.stdout |> jq $counter_filter
+let snap2_b = $q2_b.stdout |> jq $counter_filter
+let snap2_c = $q2_c.stdout |> jq $counter_filter
+
+# --- Wave 2: a, b attached; c detached and quiescent ---
 guard _ <- uprobe fire $n
+
+guard w2_a <- bpftool map dump id $mapID_a -j
+guard w2_b <- bpftool map dump id $mapID_b -j
+guard w2_c <- bpftool map dump id $mapID_c -j
+let snap3_a = $w2_a.stdout |> jq $counter_filter
+let snap3_b = $w2_b.stdout |> jq $counter_filter
+let snap3_c = $w2_c.stdout |> jq $counter_filter
+print "wave2 da=${snap3_a} db=${snap3_b} c=${snap3_c} want_c=${snap2_c}"
+assert ($snap3_a - $snap2_a) == ($n * $weight_a)
+assert ($snap3_b - $snap2_b) == ($n * $weight_b)
+assert $snap3_c == $snap2_c
 
 bpfman link detach $link_b
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID_b 1 $counter_filter
+}
+guard q3_a <- bpftool map dump id $mapID_a -j
+guard q3_b <- bpftool map dump id $mapID_b -j
+guard q3_c <- bpftool map dump id $mapID_c -j
+let snap4_a = $q3_a.stdout |> jq $counter_filter
+let snap4_b = $q3_b.stdout |> jq $counter_filter
+let snap4_c = $q3_c.stdout |> jq $counter_filter
+assert $snap4_c == $snap3_c
 
-# --- Wave 3: only a attached ---
+# --- Wave 3: only a attached; b, c quiescent ---
 guard _ <- uprobe fire $n
 
-guard dump_a <- bpftool map dump id $mapID_a -j
-guard dump_b <- bpftool map dump id $mapID_b -j
-guard dump_c <- bpftool map dump id $mapID_c -j
-
-let count_a = $dump_a.stdout |> jq $counter_filter
-let count_b = $dump_b.stdout |> jq $counter_filter
-let count_c = $dump_c.stdout |> jq $counter_filter
-
-let want_a = (3 * $n) * $weight_a
-let want_b = (2 * $n) * $weight_b
-let want_c = (1 * $n) * $weight_c
-
-print "a: got=${count_a} want=${want_a}"
-print "b: got=${count_b} want=${want_b}"
-print "c: got=${count_c} want=${want_c}"
-
-assert $count_a == $want_a
-assert $count_b == $want_b
-assert $count_c == $want_c
+guard w3_a <- bpftool map dump id $mapID_a -j
+guard w3_b <- bpftool map dump id $mapID_b -j
+guard w3_c <- bpftool map dump id $mapID_c -j
+let final_a = $w3_a.stdout |> jq $counter_filter
+let final_b = $w3_b.stdout |> jq $counter_filter
+let final_c = $w3_c.stdout |> jq $counter_filter
+print "wave3 da=${final_a} b=${final_b} want_b=${snap4_b} c=${final_c} want_c=${snap4_c}"
+assert ($final_a - $snap4_a) == ($n * $weight_a)
+assert $final_b == $snap4_b
+assert $final_c == $snap4_c
 
 # link_a is still attached on the happy path; detach it explicitly
 # before the deferred program-unloads fire.

--- a/e2e/scripts/TestPublishedImage_AppExampleXDP.bpfman
+++ b/e2e/scripts/TestPublishedImage_AppExampleXDP.bpfman
@@ -52,7 +52,12 @@ assert $delta >= 5
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- net exec $pair ping -c 5 -i 0.05 -W 1 $pair.host_addr

--- a/e2e/scripts/TestPublishedImage_KprobeExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_KprobeExample.bpfman
@@ -53,7 +53,12 @@ assert $delta >= $events
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_kfunc_detach_quiescent $fn $mapID 1 $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- kfunc fire $fn $events

--- a/e2e/scripts/TestPublishedImage_TCExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_TCExample.bpfman
@@ -54,7 +54,12 @@ assert $delta >= 5
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- net exec $pair ping -c 5 -i 0.05 -W 1 $pair.host_addr

--- a/e2e/scripts/TestPublishedImage_TCXExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_TCXExample.bpfman
@@ -54,7 +54,12 @@ assert $delta >= 5
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- net exec $pair ping -c 5 -i 0.05 -W 1 $pair.host_addr

--- a/e2e/scripts/TestPublishedImage_TracepointExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_TracepointExample.bpfman
@@ -51,7 +51,19 @@ assert $delta >= $events
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline. No lib helper
+# fires this script's kill(2) stimulus, so the poll body mirrors the
+# await_*_detach_quiescent shape inline.
+poll timeout 2s every 50ms {
+    guard quiesceBefore <- bpftool map dump id $mapID -j
+    let qBefore = $quiesceBefore.stdout |> jq $sumFilter
+    guard _ <- exec sh -c 'i=0; trap "" USR1; while [ $i -lt "$1" ]; do kill -USR1 $$; i=$((i + 1)); done' sh 1
+    guard quiesceAfter <- bpftool map dump id $mapID -j
+    let qAfter = $quiesceAfter.stdout |> jq $sumFilter
+    retry "waiting for tracepoint detach quiescence" unless $qAfter == $qBefore
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- exec sh -c 'i=0; trap "" USR1; while [ $i -lt "$1" ]; do kill -USR1 $$; i=$((i + 1)); done' sh $events

--- a/e2e/scripts/TestPublishedImage_UprobeExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_UprobeExample.bpfman
@@ -53,7 +53,12 @@ assert $delta >= $events
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID 1 $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- uprobe fire $events

--- a/e2e/scripts/TestPublishedImage_UretprobeExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_UretprobeExample.bpfman
@@ -54,7 +54,12 @@ assert $delta >= $events
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID 1 $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- uprobe fire $events

--- a/e2e/scripts/TestPublishedImage_XDPExample.bpfman
+++ b/e2e/scripts/TestPublishedImage_XDPExample.bpfman
@@ -52,7 +52,12 @@ assert $delta >= 5
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+# The kernel unhooks a detached program asynchronously; wait for the
+# counter to quiesce before taking the frozen baseline.
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
+
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter
 guard _ <- net exec $pair ping -c 5 -i 0.05 -W 1 $pair.host_addr

--- a/e2e/scripts/TestTCX_DuplicateAttachRejected.bpfman
+++ b/e2e/scripts/TestTCX_DuplicateAttachRejected.bpfman
@@ -39,8 +39,12 @@ guard listed <- bpfman link list -o json
 assert ($listed |> jq "[.links[] | select(.id == ${link.record.id})] | length") == 1
 assert ($listed |> jq "[.links[] | select(.program_id == ${prog.record.program_id})] | length") == 1
 
-guard klinks <- bpftool link list -j
-assert ($klinks.stdout |> jq "fromjson | [ .[] | select(.id == ${link.record.kernel_link_id}) ] | length") == 1
+# linkinfo reads the kernel link by id via the bpf() syscall,
+# avoiding both bpftool enumeration (racy against concurrent
+# teardown elsewhere in the parallel corpus) and bpftool's show-id
+# exit-code quirk.
+guard klink <- linkinfo id $link.record.kernel_link_id
+assert $klink.id == $link.record.kernel_link_id
 
 # The kernel listing proves the link object exists; the counter
 # proves it is still on the packet path. Lower bound; ARP/control

--- a/e2e/scripts/TestTCX_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTCX_LinkRoundTrip.bpfman
@@ -71,9 +71,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/e2e/scripts/TestTCX_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTCX_NetnsVethPairLinkRoundTrip.bpfman
@@ -74,9 +74,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair.b $pair.a.addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/e2e/scripts/TestTC_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTC_LinkRoundTrip.bpfman
@@ -79,9 +79,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/e2e/scripts/TestTC_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTC_NetnsVethPairLinkRoundTrip.bpfman
@@ -80,9 +80,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair.b $pair.a.addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/e2e/scripts/TestUprobe_GoSymbolTraffic.bpfman
+++ b/e2e/scripts/TestUprobe_GoSymbolTraffic.bpfman
@@ -50,9 +50,9 @@ assert $count == $want
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-# Let any async detach teardown settle before establishing
-# the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID 1 $counter_filter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $counter_filter

--- a/e2e/scripts/TestUprobe_LibraryNameCacheTraffic.bpfman
+++ b/e2e/scripts/TestUprobe_LibraryNameCacheTraffic.bpfman
@@ -54,24 +54,25 @@ if path-exists "/etc/ld.so.cache" {
     # Decide whether the behavioural phase can hold: it can only if
     # the libc this process maps is the one bare-name resolution
     # lands on. Read the mapped libc path from this process's maps,
-    # then ask whether the cache lists that exact file. If it does,
-    # the linker resolved this binary's libc through the cache, so a
-    # bare libc target resolves to the same file and firing counts.
-    # If it does not (a store-private libc the global cache omits) or
-    # there is no mapped libc (a static binary), the fire cannot
-    # count and the script skips, keying on the cache rather than
-    # naming any distribution.
-    guard mapped <- exec sh -c "awk '/\\/libc[.-]/ && /\\.so/ {print \$6; exit}' /proc/${target.pid}/maps"
+    # then ask whether the cache names that same file. Compare by
+    # file identity, not by string: on a usr-merged host the cache
+    # says /lib64/libc.so.6 whilst maps reports the resolved
+    # /usr/lib64/libc.so.6, and those are one file. If the cache
+    # names a different file (a store-private libc the global cache
+    # omits) or there is no mapped libc (a static binary), the fire
+    # cannot count and the script skips, keying on the cache rather
+    # than naming any distribution.
+    guard mapped <- exec sh -c "awk '/\\/libc[.-]/ && /\\.so/ {print \$6; exit}' /proc/${target.pid}/maps | tr -d '[:space:]'"
     let mapped_libc = $mapped.stdout
     print "cache-tier: process maps libc at ${mapped_libc}"
 
-    guard incache <- exec sh -c "test -n '${mapped_libc}' && grep -qaF -- '${mapped_libc}' /etc/ld.so.cache && echo yes || echo no"
+    guard incache <- exec sh -c "if [ -z '${mapped_libc}' ]; then echo no; else r=no; for c in \$(grep -aoE '/[A-Za-z0-9_.+-]+(/[A-Za-z0-9_.+-]+)*/libc\\.so\\.6' /etc/ld.so.cache | sort -u); do if [ \"\$c\" -ef '${mapped_libc}' ]; then r=yes; fi; done; echo \$r; fi | tr -d '[:space:]'"
 
     let mapID = $prog |> jq '[.status.maps[] | select(.name == "up_count") | .id][0]'
     let counter_filter = "fromjson | .[0].formatted.value | tonumber"
 
     if $incache.stdout != yes {
-        print "cache-tier: mapped libc is not listed in /etc/ld.so.cache (store-private or static binary); cache resolves a different file. Skipping traffic assertion (structural proof stands; an FHS layout exercises traffic)."
+        print "cache-tier: /etc/ld.so.cache does not name the mapped libc (store-private or static binary); cache resolves a different file. Skipping traffic assertion (structural proof stands; an FHS layout exercises traffic)."
     } else {
         guard dumpBefore <- bpftool map dump id $mapID -j
         let before = $dumpBefore.stdout |> jq $counter_filter

--- a/e2e/scripts/TestUprobe_OffsetOnlyTraffic.bpfman
+++ b/e2e/scripts/TestUprobe_OffsetOnlyTraffic.bpfman
@@ -72,7 +72,9 @@ assert $delta == $want
 bpfman link detach $link
 assert fail bpfman link get $linkID
 
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_uprobe_detach_quiescent $mapID 1 $counter_filter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $counter_filter

--- a/e2e/scripts/TestXDP_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestXDP_LinkRoundTrip.bpfman
@@ -71,9 +71,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair $pair.host_addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/e2e/scripts/TestXDP_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestXDP_NetnsVethPairLinkRoundTrip.bpfman
@@ -72,9 +72,9 @@ assert fail bpfman link get $linkID
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID
 
-# Let any in-flight pre-detach packet accounting settle before
-# establishing the detached baseline.
-sleep 0.1
+poll timeout 2s every 50ms {
+    await_net_detach_quiescent $pair.b $pair.a.addr $mapID $sumFilter
+}
 
 guard dumpDetached <- bpftool map dump id $mapID -j
 let detached = $dumpDetached.stdout |> jq $sumFilter

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,14 @@
             # SQLite CLI for inspecting the store database.
             sqlite
             sqlite.dev
+
+            # Shared-directory daemon for the nested Fedora VM
+            # harness (hack/fedora-vm.sh). Needs 1.13+ for
+            # --translate-uid; distro packages can lag (Ubuntu
+            # noble ships 1.10), so supply it from nixpkgs. qemu
+            # itself still comes from the host via
+            # hack/fedora-vm-host-deps.sh.
+            virtiofsd
           ];
 
           shellHook = ''

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,107 @@
+# The nested Fedora VM test harness
+
+Some e2e tests need a kernel with `bpf` in the active LSM list
+(`/sys/kernel/security/lsm`). GitHub-hosted runners boot without it
+and cannot be rebooted mid-job, and many developer machines lack it
+too. The harness in this directory runs the whole e2e suite inside a
+throwaway Fedora VM -- stock Fedora kernels ship bpf-LSM active --
+with the repository shared into the guest over virtiofs, so the guest
+builds and tests your working tree directly.
+
+Four scripts cooperate; each documents its full interface in its
+header.
+
+| Script | Role |
+|---|---|
+| `fedora-vm-host-deps.sh` | One-off host setup: installs qemu for x86_64 and aarch64 guests with the aarch64 UEFI firmware, virtiofsd 1.13+, genisoimage and friends (dnf on Fedora, apt on Ubuntu/Debian with a crates.io build of virtiofsd where the packaged one is too old). |
+| `fedora-vm.sh` | The harness: boots a fresh Fedora cloud VM, shares host directories over virtiofs (`docker -v` style), runs a command in the guest over ssh, exits with its status. |
+| `install-fedora-deps.sh` | Guest provisioning: installs the Fedora build/test toolchain. Run once per content-change via `--provision`, baked into a cached disk. |
+| `nested-vm-e2e.sh` | The in-guest driver: builds, runs the unit tests, the gRPC e2e suite and the `.bpfman` script corpus. Also runs directly on any Fedora box. |
+
+## Quick start
+
+```
+hack/fedora-vm-host-deps.sh        # once per host
+hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run hack/nested-vm-e2e.sh
+```
+
+The first run downloads the Fedora cloud image (cached in
+`~/.cache/bpfman-fedora-vm`), boots it, runs the provisioning script
+in the guest and keeps the resulting disk, keyed on the provisioning
+script's content -- it rebuilds itself whenever
+`install-fedora-deps.sh` changes. Subsequent runs boot the provisioned
+disk, build incrementally against the `.gocache` persisted on the
+share, and complete in a few minutes; a quick `--run` command
+round-trips in about 45 seconds.
+
+## Other useful shapes
+
+```
+# Interactive shell in the guest (repository shared at its host path).
+# At a terminal this boots you into the guest; with stdin redirected
+# it just prepares the cached disk and exits, which is how CI
+# provisions as a step of its own.
+hack/fedora-vm.sh --provision hack/install-fedora-deps.sh
+
+# One-off command; exit status propagates.
+hack/fedora-vm.sh --run 'uname -r && cat /sys/kernel/security/lsm'
+
+# Share extra host directories, read-only where wanted.
+hack/fedora-vm.sh -v /path/on/host:/path/in/guest:ro --run '...'
+
+# Only build and unit-test, or only run the e2e stages.
+hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run 'hack/nested-vm-e2e.sh build'
+hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run 'hack/nested-vm-e2e.sh test'
+```
+
+Environment knobs (see the `fedora-vm.sh` header for the full list):
+`VIRTFS_FAST=1` enables writeback virtiofs caching, recommended for
+build workloads; `VM_CPUS` (default: host `nproc`) and `VM_MEMORY`
+(default 4G) size the guest; `VM_ARCH=aarch64` on an x86_64 host (or
+vice versa) runs a TCG-emulated cross-architecture smoke test;
+`SERIAL_LOG=<file>` captures the guest console for debugging a boot
+that never reaches ssh; `VM_FIRMWARE=<file>` overrides the aarch64
+UEFI image, which is otherwise probed from the usual distribution
+paths; `VIRTIOFSD=<path>` points the harness at a specific virtiofsd,
+which is otherwise probed from PATH, `~/.local/bin` and
+`/usr/libexec` for one supporting `--translate-uid`.
+
+Guests forward ssh from `SSH_PORT` (2222), so only one VM at a time
+uses the default. If you keep an interactive shell open and start a
+second run, the second fails with `Could not set up host forwarding
+rule`; give it `SSH_PORT=2223`.
+
+## What survives a poweroff
+
+Only the shared directories. The guest disk is a fresh qcow2 overlay
+per boot, layered over the cached provisioned disk, and it is
+discarded when the VM stops -- so anything you install by hand in the
+guest is gone next time. Add it to the `rpms` array in
+`install-fedora-deps.sh` instead, which re-keys the provisioned disk
+and gives it to CI too.
+
+Your working tree is a share, so edits in the guest are edits on your
+host, and the Go build cache is kept on the share as well: a login
+shell in the guest gets `GOCACHE` pointed at `.gocache` in the
+repository, the same cache `nested-vm-e2e.sh` uses, so builds you type
+at the guest prompt stay incremental across boots.
+
+## How the share stays writable
+
+Unprivileged virtiofsd sandboxes itself in a user namespace that maps
+only the invoking user's uid and gid, and switches credentials to the
+caller's guest identity on inode-creating operations -- so without
+help, any other guest identity (including root under sudo, which the
+e2e needs) fails with EINVAL. The harness squashes every guest uid/gid
+to the invoking user's own via `--translate-uid`/`--translate-gid`,
+which is why virtiofsd 1.13+ is required. Everything the guest creates
+on the share lands owned by you.
+
+## CI
+
+`.github/workflows/nested-vm-e2e.yml` runs the same three stages
+(provision, build, test) as separate steps on a hosted runner, with
+the base image, provisioned disk and guest Go cache persisted via
+`actions/cache`. It has no triggers of its own: the `CI` workflow
+calls it as a job, so it runs on pull requests and on pushes to main
+and counts towards `ci-complete`.

--- a/hack/fedora-vm-host-deps.sh
+++ b/hack/fedora-vm-host-deps.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Install the host-side tooling hack/fedora-vm.sh needs: qemu for both
+# x86_64 and aarch64 guests plus the aarch64 UEFI firmware (the virt
+# machine has no default firmware), virtiofsd (the Rust daemon, 1.13+
+# for --translate-uid/--translate-gid), genisoimage, qemu-img, ssh,
+# ssh-keygen and curl. /dev/kvm must be present and accessible; on most
+# distros that means membership of the kvm group or a udev rule.
+#
+# Fedora installs everything from dnf. Ubuntu/Debian installs qemu and
+# genisoimage from apt, but noble packages virtiofsd 1.10, which
+# predates the uid/gid translation the harness depends on, so a new
+# enough virtiofsd is built from crates.io into ~/.local when nothing
+# capable is reachable (this needs cargo, libseccomp-dev and
+# libcap-ng-dev, which are installed alongside). Nothing is linked
+# onto PATH: the harness probes ~/.local/bin and /usr/libexec (where
+# the Fedora and Debian packages put the binary) itself, so this
+# script writes only through the package manager and under your home.
+# Other distros get the requirements list; a Nix host takes the tools
+# from a devshell providing qemu and virtiofsd.
+#
+# Usage: hack/fedora-vm-host-deps.sh
+#   Re-run safely; package installs are idempotent.
+
+set -euo pipefail
+
+sudo_cmd=
+if [ "$(id -u)" -ne 0 ]; then
+    sudo_cmd=sudo
+fi
+
+# resolve_virtiofsd prints the path of a virtiofsd that supports
+# --translate-uid/--translate-gid (1.13+): $VIRTIOFSD when set (an
+# explicit override never falls through -- it must itself be capable),
+# otherwise the first capable candidate among PATH, the cargo install
+# target this script uses, and the libexec directory the Fedora and
+# Debian packages install into, off PATH. Capability decides, not
+# position: noble's packaged /usr/libexec/virtiofsd is 1.10 and must
+# lose to a good build elsewhere. Keep in sync with the copy in
+# hack/fedora-vm.sh.
+resolve_virtiofsd() {
+    if [[ -n "${VIRTIOFSD:-}" ]]; then
+        if "$VIRTIOFSD" --help 2>/dev/null | grep -q -- --translate-uid; then
+            echo "$VIRTIOFSD"
+            return 0
+        fi
+        echo "error: VIRTIOFSD=$VIRTIOFSD does not support --translate-uid (need virtiofsd 1.13+)" >&2
+        return 1
+    fi
+
+    local candidate
+    for candidate in "$(command -v virtiofsd || true)" "$HOME/.local/bin/virtiofsd" /usr/libexec/virtiofsd; do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if "$candidate" --help 2>/dev/null | grep -q -- --translate-uid; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "error: no virtiofsd with --translate-uid (1.13+) on PATH, in ~/.local/bin or /usr/libexec; run hack/fedora-vm-host-deps.sh or set VIRTIOFSD" >&2
+    return 1
+}
+
+if command -v dnf >/dev/null; then
+    # edk2-aarch64 supplies the UEFI image an aarch64 guest boots from;
+    # the virt machine has no default firmware. It is noarch, so an
+    # x86_64 host installs it too and can smoke-test VM_ARCH=aarch64.
+    $sudo_cmd dnf install -y qemu-system-x86 qemu-system-aarch64 qemu-img virtiofsd genisoimage openssh-clients curl edk2-aarch64
+elif command -v apt-get >/dev/null; then
+    $sudo_cmd apt-get update
+    $sudo_cmd apt-get install -y --no-install-recommends \
+        qemu-system-x86 qemu-system-arm qemu-efi-aarch64 qemu-utils \
+        genisoimage openssh-client curl libseccomp-dev libcap-ng-dev
+    # Noble's packaged virtiofsd (/usr/libexec, off PATH) is 1.10,
+    # which predates --translate-uid; build 1.13 from crates.io into
+    # ~/.local when nothing capable is reachable. The harness probes
+    # ~/.local/bin itself, so the build needs no linking onto PATH.
+    if ! resolve_virtiofsd >/dev/null 2>&1; then
+        if ! command -v cargo >/dev/null; then
+            echo "error: packaged virtiofsd is missing or predates --translate-uid," >&2
+            echo "       and cargo is not available to build 1.13 from crates.io." >&2
+            echo "       Install rustup/cargo and re-run." >&2
+            exit 1
+        fi
+        cargo install virtiofsd --version 1.13.2 --root "$HOME/.local"
+    fi
+else
+    echo "error: no supported package manager (dnf, apt-get) found." >&2
+    echo "       Provide these tools yourself: qemu-system-x86_64," >&2
+    echo "       qemu-system-aarch64 with an aarch64 UEFI image, qemu-img," >&2
+    echo "       virtiofsd 1.13+ (the Rust daemon), genisoimage, ssh," >&2
+    echo "       ssh-keygen, curl. On a Nix host use a devshell providing" >&2
+    echo "       qemu and virtiofsd." >&2
+    exit 1
+fi
+
+virtiofsd_path=$(resolve_virtiofsd) || exit 1
+
+[ -e /dev/kvm ] || echo "warning: /dev/kvm absent; the harness will fall back to TCG (slow)" >&2
+echo "Host tooling for hack/fedora-vm.sh is in place (virtiofsd: $virtiofsd_path)."

--- a/hack/fedora-vm.sh
+++ b/hack/fedora-vm.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+#
+# Run a command inside a throwaway Fedora VM with host directories
+# shared over virtiofs (docker -v style), then exit with the command's
+# status. Each run gets a fresh qcow2 overlay off the base image, so no
+# state carries between runs.
+#
+# Why a VM: attaching a BPF_PROG_TYPE_LSM program needs "bpf" in the
+# active LSM list (/sys/kernel/security/lsm). Many hosts and all
+# GitHub-hosted runners boot without it; a Fedora guest has it, and
+# building/testing inside Fedora gives the native BPF toolchain
+# (clang/libbpf-devel/bpftool) with no cross-distro workarounds.
+#
+# Host requirements: qemu-system-<arch> (x86_64 and aarch64), virtiofsd
+# (the Rust daemon), genisoimage, ssh, ssh-keygen, qemu-img, curl, and
+# /dev/kvm. The guest arch follows the host by default so KVM applies;
+# VM_ARCH crosses over to TCG for smoke tests. See usage() below, or
+# --help, for options and environment knobs.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Run a command inside a throwaway Fedora VM with host directories
+shared over virtiofs (docker -v style), then exit with the command's
+status.
+
+Usage:
+  hack/fedora-vm.sh [options] [--run "<command>"]
+
+Options:
+  -v HOST[:GUEST[:ro]]  Share HOST at GUEST (default GUEST=HOST) over
+                        virtiofs; read-write unless :ro. Repeatable.
+                        With no -v, the repository root is shared.
+  -w GUESTDIR           Working directory for --run (default: the first
+                        read-write volume's guest path).
+  --image PATH          Base Fedora cloud image (a fresh per-run overlay
+                        is created from it; the base is never modified).
+  --provision "<cmd>"   Run <cmd> in the guest once and cache the
+                        resulting disk (keyed on the command, or on the
+                        script's content when <cmd> names a file);
+                        later runs boot from the cached disk directly.
+                        With no --run, boot the cached disk into an
+                        interactive shell at a terminal, or just
+                        prepare it and exit when stdin is not a tty
+                        (how CI provisions as a step of its own).
+  --run "<command>"     Run the command in the guest and exit with its
+                        status. Without it, boots interactively.
+
+Environment:
+  FEDORA_IMAGE_URL  base image URL fetched when --image is omitted
+  VM_ARCH           guest arch (default: host arch; cross-arch = TCG)
+  VM_FIRMWARE       aarch64 UEFI image (default: probed from the
+                    usual distribution paths)
+  VM_CACHE_DIR      base-image cache dir
+  VM_MEMORY (4G), VM_CPUS (nproc), SSH_PORT (2222), BOOT_TIMEOUT (300)
+  VIRTFS_FAST       1 = cache=always,writeback (near-native, default);
+                    0 = cache=auto (coherent host<->guest)
+  SERIAL_LOG        capture the guest serial console to this file
+EOF
+}
+
+# Guest architecture: defaults to the host's (KVM requires the two to
+# match). VM_ARCH=aarch64 on an x86_64 host (or vice versa) runs under
+# TCG emulation -- an order of magnitude slower, useful only for
+# smoke-testing the other architecture's bring-up. Cross-arch TCG has
+# no host CPU to mirror, so it gets qemu's fullest emulated CPU.
+: "${VM_ARCH:=$(uname -m)}"
+arch=$VM_ARCH
+cpu=host
+x86_cpu=host,migratable=no,+invtsc
+if [[ "$arch" != "$(uname -m)" ]]; then
+    cpu=max
+    x86_cpu=max
+    echo "warning: VM_ARCH=$arch != host $(uname -m); using TCG emulation (slow)" >&2
+fi
+# shellcheck disable=SC2054  # commas are qemu option syntax, not element separators
+case "$arch" in
+    x86_64)
+        qemu_bin=qemu-system-x86_64
+        arch_args=(-machine q35,accel=kvm:tcg -cpu "$x86_cpu"
+                   -rtc base=utc,clock=host,driftfix=slew
+                   -global kvm-pit.lost_tick_policy=discard)
+        ;;
+    aarch64)
+        qemu_bin=qemu-system-aarch64
+        # The virt machine has no default firmware, and distributions
+        # disagree on both the name and the location of the edk2 build:
+        # Fedora installs QEMU_EFI.fd under /usr/share/edk2/aarch64,
+        # Debian ships AAVMF_CODE.fd, and some qemu builds bundle
+        # edk2-aarch64-code.fd beside the binary. Only that last one is
+        # on qemu's own firmware search path, so probe for a real file
+        # instead of passing a bare name and hoping.
+        : "${VM_FIRMWARE:=}"
+        if [[ -z "$VM_FIRMWARE" ]]; then
+            qemu_share=$(dirname "$(command -v qemu-system-aarch64 || echo /nonexistent/bin/qemu)")/../share
+            for fw in /usr/share/edk2/aarch64/QEMU_EFI.fd \
+                      /usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd \
+                      /usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
+                      /usr/share/AAVMF/AAVMF_CODE.fd \
+                      "$qemu_share/qemu/edk2-aarch64-code.fd"; do
+                if [[ -f "$fw" ]]; then VM_FIRMWARE=$fw; break; fi
+            done
+        fi
+        [[ -n "$VM_FIRMWARE" ]] || { echo "error: no aarch64 UEFI firmware found; install edk2-aarch64 (Fedora) or qemu-efi-aarch64 (Debian/Ubuntu), or set VM_FIRMWARE" >&2; exit 1; }
+        arch_args=(-machine virt,accel=kvm:tcg,gic-version=max -cpu "$cpu"
+                   -bios "$VM_FIRMWARE")
+        ;;
+    *) echo "error: unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+: "${FEDORA_IMAGE_URL:=https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/${arch}/images/Fedora-Cloud-Base-Generic-44-1.7.${arch}.qcow2}"
+: "${VM_CACHE_DIR:=${XDG_CACHE_HOME:-$HOME/.cache}/bpfman-fedora-vm}"
+: "${VM_MEMORY:=4G}"
+: "${VM_CPUS:=$(nproc)}"
+: "${SSH_PORT:=2222}"
+: "${BOOT_TIMEOUT:=300}"
+: "${VIRTFS_FAST:=0}"
+: "${SERIAL_LOG:=}"
+
+image=""
+run_cmd=""
+workdir=""
+provision_cmd=""
+declare -a vol_specs=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v) vol_specs+=("$2"); shift 2 ;;
+        -w) workdir="$2"; shift 2 ;;
+        --image) image="$2"; shift 2 ;;
+        --provision) provision_cmd="$2"; shift 2 ;;
+        --run) run_cmd="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+# Default share: the repository.
+[[ ${#vol_specs[@]} -eq 0 ]] && vol_specs+=("$repo")
+
+for tool in "$qemu_bin" virtiofsd genisoimage ssh ssh-keygen qemu-img curl; do
+    command -v "$tool" >/dev/null || { echo "error: '$tool' not on PATH" >&2; exit 1; }
+done
+[[ -e /dev/kvm ]] || echo "warning: /dev/kvm absent; qemu will use TCG (slow)" >&2
+
+# Resolve the base image (explicit --image, else a cached download).
+if [[ -n "$image" ]]; then
+    base_image=$image
+    [[ -f "$base_image" ]] || { echo "error: --image '$base_image' does not exist" >&2; exit 1; }
+else
+    mkdir -p "$VM_CACHE_DIR"
+    base_image="$VM_CACHE_DIR/$(basename "$FEDORA_IMAGE_URL")"
+    if [[ ! -f "$base_image" ]]; then
+        echo "==> downloading $(basename "$base_image")"
+        # The archive server drops long transfers; -C - resumes the
+        # .part across attempts (and across harness reruns). The
+        # progress meter is tty-only: in CI it floods the log and
+        # defeats live log streaming.
+        curl_progress=()
+        [[ -t 2 ]] || curl_progress=(--no-progress-meter)
+        for attempt in 1 2 3 4 5; do
+            curl -fSL -C - --retry 3 "${curl_progress[@]}" -o "$base_image.part" "$FEDORA_IMAGE_URL" && break
+            [[ "$attempt" == 5 ]] && { echo "error: download failed after $attempt attempts" >&2; exit 1; }
+            echo "==> download interrupted; resuming ($attempt/5)" >&2
+            sleep 3
+        done
+        mv "$base_image.part" "$base_image"
+    fi
+fi
+
+# Parse volume specs into parallel arrays. Each: host, guest, mount opts.
+declare -a v_host=() v_guest=() v_mode=()
+for spec in "${vol_specs[@]}"; do
+    IFS=: read -r host guest mode <<< "$spec"
+    host=$(cd "$host" 2>/dev/null && pwd) || { echo "error: -v host '$host' is not a directory" >&2; exit 1; }
+    v_host+=("$host")
+    v_guest+=("${guest:-$host}")
+    v_mode+=("${mode:-rw}")
+done
+# Default working directory: the first read-write volume's guest path.
+if [[ -z "$workdir" ]]; then
+    for i in "${!v_mode[@]}"; do [[ "${v_mode[$i]}" == rw ]] && { workdir="${v_guest[$i]}"; break; }; done
+fi
+
+work=$(mktemp -d)
+declare -a virtiofsd_pids=()
+qemu_pid=
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+    [[ -n "$qemu_pid" ]] && kill "$qemu_pid" 2>/dev/null || true
+    for p in "${virtiofsd_pids[@]}"; do kill "$p" 2>/dev/null || true; done
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Transient SSH key for this run only; never touches the host's ~/.ssh.
+ssh-keygen -q -t ed25519 -N '' -f "$work/id" -C bpfman-fedora-vm
+pubkey=$(cat "$work/id.pub")
+
+# virtiofsd cache profile.
+if [[ "$VIRTFS_FAST" == 1 ]]; then
+    vfs_cache=(--cache=always --writeback --thread-pool-size=128)
+else
+    vfs_cache=(--cache=auto --thread-pool-size=64)
+fi
+
+# Unprivileged virtiofsd sandboxes itself in a user namespace that maps
+# only our own uid and gid. On inode-creating operations (create, mkdir,
+# symlink) it switches credentials to the caller's guest uid/gid, and
+# setresuid/setresgid to an id unmapped in that namespace fails with
+# EINVAL -- so any guest identity other than exactly $(id -u):$(id -g)
+# (a default cloud-init user gets its own fresh group; anything under
+# sudo is 0:0) cannot create files on the share. Squash every guest
+# uid/gid to our own instead: the credential switch becomes a no-op and
+# everything created on the share lands as us on the host.
+vfs_translate=(--translate-uid "squash-guest:0:$(id -u):4294967295"
+               --translate-gid "squash-guest:0:$(id -g):4294967295")
+
+# Build cloud-init mount/mkdir lines and qemu wiring per volume.
+mount_lines=""
+mkdir_lines=""
+declare -a qemu_fs_args=()
+for i in "${!v_host[@]}"; do
+    tag="vol$i"
+    opts="rw"; [[ "${v_mode[$i]}" == ro ]] && opts="ro"
+    qemu_fs_args+=(-chardev "socket,id=$tag,path=$work/$tag.sock"
+                   -device "vhost-user-fs-pci,queue-size=1024,chardev=$tag,tag=$tag")
+    mount_lines+="  - [ \"$tag\", \"${v_guest[$i]}\", \"virtiofs\", \"$opts,_netdev,nofail\", \"0\", \"0\" ]"$'\n'
+    mkdir_lines+="  - mkdir -p ${v_guest[$i]}"$'\n'
+done
+
+# virtiofsd serves exactly one vhost-user connection and then exits, so
+# the daemons must be (re)started for every VM boot, not once per run.
+start_virtiofsd() {
+    virtiofsd_pids=()
+    for i in "${!v_host[@]}"; do
+        rm -f "$work/vol$i.sock"
+        virtiofsd --socket-path="$work/vol$i.sock" --shared-dir="${v_host[$i]}" \
+            --announce-submounts "${vfs_cache[@]}" "${vfs_translate[@]}" >>"$work/vol$i.log" 2>&1 &
+        virtiofsd_pids+=("$!")
+    done
+    for _ in $(seq 1 50); do
+        local ok=1
+        for i in "${!v_host[@]}"; do [[ -S "$work/vol$i.sock" ]] || ok=0; done
+        [[ "$ok" == 1 ]] && return 0
+        sleep 0.1
+    done
+    for i in "${!v_host[@]}"; do
+        echo "--- virtiofsd vol$i (${v_host[$i]}) log tail ---" >&2
+        tail -5 "$work/vol$i.log" >&2 || true
+    done
+    fail "virtiofsd sockets never appeared"
+}
+
+# cloud-init: a uid-matched passwordless-sudo user with our transient key
+# in its (guest-local) ~/.ssh, the shared dirs mounted, /tmp on tmpfs,
+# and SELinux permissive (enough for virtiofs writes; no reboot needed).
+# A fresh instance-id each run makes cloud-init re-apply its
+# per-instance config (user, ssh key, mounts, runcmd) when booting a
+# provisioned disk left over from an earlier run.
+cat > "$work/meta-data" <<EOF
+instance-id: bpfman-fedora-vm-$(date +%s)-$$
+local-hostname: bpfman-fedora-vm
+EOF
+cat > "$work/user-data" <<EOF
+#cloud-config
+users:
+  - name: ${USER}
+    uid: $(id -u)
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${pubkey}
+mounts:
+${mount_lines}  - [ "tmpfs", "/tmp", "tmpfs", "size=8G,mode=1777", "0", "0" ]
+runcmd:
+  - setenforce 0 || true
+  # Parallel Go test linking over the virtiofs share exhausts the
+  # guest's default system-wide file table (ENFILE).
+  - sysctl -w fs.file-max=2097152 || true
+${mkdir_lines}  - [ chown, "${USER}:", "/home/${USER}" ]
+  - systemctl enable --now sshd || systemctl enable --now ssh
+EOF
+genisoimage -quiet -output "$work/seed.iso" -volid cidata -joliet -rock \
+    "$work/user-data" "$work/meta-data"
+
+# Boot plumbing. vhost-user-fs needs shared guest memory (memfd + numa).
+serial=(-serial null)
+[[ -n "$SERIAL_LOG" ]] && serial=(-serial "file:$SERIAL_LOG")
+
+ssh_opts=(-p "$SSH_PORT" -i "$work/id"
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+    -o LogLevel=ERROR -o ConnectTimeout=5 -o IdentitiesOnly=yes)
+# shellcheck disable=SC2029  # arguments are meant to run in the guest
+guest() { ssh "${ssh_opts[@]}" "${USER}@127.0.0.1" "$@"; }
+fail() { echo "$1" >&2; [[ -n "$SERIAL_LOG" ]] && { echo "--- serial (tail) ---" >&2; tail -30 "$SERIAL_LOG" >&2; }; exit 1; }
+
+start_vm() { # $1: boot disk (qcow2)
+    start_virtiofsd
+    "$qemu_bin" \
+        "${arch_args[@]}" \
+        -smp "$VM_CPUS" -m "$VM_MEMORY" \
+        -object "memory-backend-memfd,id=mem,size=$VM_MEMORY,share=on" \
+        -numa node,memdev=mem \
+        "${qemu_fs_args[@]}" \
+        -drive "file=$1,if=virtio,format=qcow2" \
+        -drive "file=$work/seed.iso,if=virtio,media=cdrom,format=raw" \
+        -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22" \
+        -device virtio-net-pci,netdev=net0 \
+        -device virtio-rng-pci \
+        -display none -nographic -monitor none "${serial[@]}" &
+    qemu_pid=$!
+}
+
+wait_ready() {
+    echo "==> waiting for guest ssh (up to ${BOOT_TIMEOUT}s)"
+    local deadline=$((SECONDS + BOOT_TIMEOUT))
+    until guest true 2>/dev/null; do
+        kill -0 "$qemu_pid" 2>/dev/null || fail "qemu exited before ssh came up"
+        [[ "$SECONDS" -lt "$deadline" ]] || fail "timed out waiting for guest ssh"
+        sleep 3
+    done
+    # sshd may come up before cloud-init's runcmd (setenforce, mkdirs)
+    # has run; wait for cloud-init so the guest is fully configured.
+    echo "==> waiting for cloud-init to finish"
+    guest 'cloud-init status --wait >/dev/null 2>&1' || true
+}
+
+stop_vm() {
+    guest 'sudo poweroff' 2>/dev/null || true
+    for _ in $(seq 1 30); do kill -0 "$qemu_pid" 2>/dev/null || break; sleep 1; done
+    kill "$qemu_pid" 2>/dev/null || true
+    qemu_pid=
+}
+
+# One-off provisioning: on a cache miss, boot the pristine base, run the
+# command, power off, and keep the disk. Later runs overlay off the
+# cached provisioned disk and skip provisioning entirely.
+boot_base=$base_image
+if [[ -n "$provision_cmd" ]]; then
+    if [[ -f "$provision_cmd" ]]; then
+        prov_key=$(sha256sum < "$provision_cmd" | cut -c1-12)
+    else
+        prov_key=$(printf '%s' "$provision_cmd" | sha256sum | cut -c1-12)
+    fi
+    provisioned="$VM_CACHE_DIR/$(basename "$base_image" .qcow2)-prov-$prov_key.qcow2"
+    if [[ ! -f "$provisioned" ]]; then
+        echo "==> provisioning (one-off): ${provision_cmd}"
+        prov_disk="$work/provision.qcow2"
+        qemu-img create -q -f qcow2 -F qcow2 -b "$base_image" "$prov_disk" >/dev/null
+        qemu-img resize -q "$prov_disk" 20G >/dev/null
+        start_vm "$prov_disk"
+        wait_ready
+        # shellcheck disable=SC2029  # workdir/provision_cmd expand into the guest command
+        guest "cd $(printf '%q' "${workdir:-/}") && ${provision_cmd}" || fail "provisioning failed"
+        stop_vm
+        mkdir -p "$VM_CACHE_DIR"
+        mv "$prov_disk" "$provisioned"
+    fi
+    boot_base=$provisioned
+
+    # With --provision and no --run, preparing the cached disk is the
+    # job when nobody is watching -- CI runs exactly this as a step of
+    # its own and expects it to finish, not to boot. At a terminal the
+    # same command means "give me a shell on the disk you just built",
+    # so fall through to the interactive boot below.
+    if [[ -z "$run_cmd" && ! -t 0 ]]; then
+        echo "==> provisioned disk ready: ${provisioned}"
+        exit 0
+    fi
+fi
+
+# Fresh per-run qcow2 overlay; grow it for build room (a provisioned
+# disk is already grown).
+overlay="$work/disk.qcow2"
+qemu-img create -q -f qcow2 -F qcow2 -b "$boot_base" "$overlay" >/dev/null
+[[ "$boot_base" == "$base_image" ]] && qemu-img resize -q "$overlay" 20G >/dev/null
+
+start_vm "$overlay"
+wait_ready
+
+if [[ -z "$run_cmd" ]]; then
+    echo "==> interactive shell (workdir ${workdir:-/}); 'sudo poweroff' to exit"
+    status=0
+    ssh -t "${ssh_opts[@]}" "${USER}@127.0.0.1" "cd $(printf '%q' "${workdir:-/}") 2>/dev/null; exec bash -l" || status=$?
+    # Let qemu finish powering off before the EXIT trap kills it and
+    # pulls virtiofsd out from under it; otherwise it scribbles vhost
+    # teardown errors over the terminal, some of them after the prompt
+    # has already come back. Ending the session is not a failure: ssh
+    # reports 255 when the guest drops the connection at poweroff, and
+    # the connection itself was proven good before the shell started.
+    stop_vm
+    [[ "$status" == 255 ]] && status=0
+    exit "$status"
+fi
+
+echo "==> running in guest (${workdir:-/}): ${run_cmd}"
+status=0
+# shellcheck disable=SC2029  # workdir/run_cmd are meant to expand into the guest command
+guest "cd $(printf '%q' "${workdir:-/}") && ${run_cmd}" || status=$?
+echo "==> command exit status: ${status}; powering off guest"
+stop_vm
+exit "$status"

--- a/hack/fedora-vm.sh
+++ b/hack/fedora-vm.sh
@@ -11,11 +11,13 @@
 # building/testing inside Fedora gives the native BPF toolchain
 # (clang/libbpf-devel/bpftool) with no cross-distro workarounds.
 #
-# Host requirements: qemu-system-<arch> (x86_64 and aarch64), virtiofsd
-# (the Rust daemon), genisoimage, ssh, ssh-keygen, qemu-img, curl, and
-# /dev/kvm. The guest arch follows the host by default so KVM applies;
-# VM_ARCH crosses over to TCG for smoke tests. See usage() below, or
-# --help, for options and environment knobs.
+# Host requirements (hack/fedora-vm-host-deps.sh installs them on
+# Fedora and Ubuntu/Debian hosts): qemu-system-<arch> (x86_64 and
+# aarch64), virtiofsd 1.13+ (the Rust daemon), genisoimage, ssh,
+# ssh-keygen, qemu-img, curl, and /dev/kvm. The guest arch follows the
+# host by default so KVM applies; VM_ARCH crosses over to TCG for
+# smoke tests. See usage() below, or --help, for options and
+# environment knobs.
 
 set -euo pipefail
 
@@ -52,6 +54,9 @@ Environment:
   VM_ARCH           guest arch (default: host arch; cross-arch = TCG)
   VM_FIRMWARE       aarch64 UEFI image (default: probed from the
                     usual distribution paths)
+  VIRTIOFSD         virtiofsd binary (default: probed from PATH,
+                    ~/.local/bin and /usr/libexec for one that
+                    supports --translate-uid)
   VM_CACHE_DIR      base-image cache dir
   VM_MEMORY (4G), VM_CPUS (nproc), SSH_PORT (2222), BOOT_TIMEOUT (300)
   VIRTFS_FAST       1 = cache=always,writeback (near-native, default);
@@ -141,9 +146,43 @@ repo=$(cd "$(dirname "$0")/.." && pwd)
 # Default share: the repository.
 [[ ${#vol_specs[@]} -eq 0 ]] && vol_specs+=("$repo")
 
-for tool in "$qemu_bin" virtiofsd genisoimage ssh ssh-keygen qemu-img curl; do
+for tool in "$qemu_bin" genisoimage ssh ssh-keygen qemu-img curl; do
     command -v "$tool" >/dev/null || { echo "error: '$tool' not on PATH" >&2; exit 1; }
 done
+
+# resolve_virtiofsd prints the path of a virtiofsd that supports
+# --translate-uid/--translate-gid (1.13+): $VIRTIOFSD when set (an
+# explicit override never falls through -- it must itself be capable),
+# otherwise the first capable candidate among PATH, the cargo install
+# target hack/fedora-vm-host-deps.sh uses, and the libexec directory
+# the Fedora and Debian packages install into, off PATH. Capability
+# decides, not position: noble's packaged /usr/libexec/virtiofsd is
+# 1.10 and must lose to a good build elsewhere. Keep in sync with the
+# copy in hack/fedora-vm-host-deps.sh.
+resolve_virtiofsd() {
+    if [[ -n "${VIRTIOFSD:-}" ]]; then
+        if "$VIRTIOFSD" --help 2>/dev/null | grep -q -- --translate-uid; then
+            echo "$VIRTIOFSD"
+            return 0
+        fi
+        echo "error: VIRTIOFSD=$VIRTIOFSD does not support --translate-uid (need virtiofsd 1.13+)" >&2
+        return 1
+    fi
+
+    local candidate
+    for candidate in "$(command -v virtiofsd || true)" "$HOME/.local/bin/virtiofsd" /usr/libexec/virtiofsd; do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if "$candidate" --help 2>/dev/null | grep -q -- --translate-uid; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "error: no virtiofsd with --translate-uid (1.13+) on PATH, in ~/.local/bin or /usr/libexec; run hack/fedora-vm-host-deps.sh or set VIRTIOFSD" >&2
+    return 1
+}
+
+virtiofsd_bin=$(resolve_virtiofsd) || exit 1
 [[ -e /dev/kvm ]] || echo "warning: /dev/kvm absent; qemu will use TCG (slow)" >&2
 
 # Resolve the base image (explicit --image, else a cached download).
@@ -238,7 +277,7 @@ start_virtiofsd() {
     virtiofsd_pids=()
     for i in "${!v_host[@]}"; do
         rm -f "$work/vol$i.sock"
-        virtiofsd --socket-path="$work/vol$i.sock" --shared-dir="${v_host[$i]}" \
+        "$virtiofsd_bin" --socket-path="$work/vol$i.sock" --shared-dir="${v_host[$i]}" \
             --announce-submounts "${vfs_cache[@]}" "${vfs_translate[@]}" >>"$work/vol$i.log" 2>&1 &
         virtiofsd_pids+=("$!")
     done

--- a/hack/install-fedora-deps.sh
+++ b/hack/install-fedora-deps.sh
@@ -114,7 +114,11 @@ if [ "$(id -u)" -ne 0 ]; then
     sudo_cmd=sudo
 fi
 
-$sudo_cmd dnf install -y "${rpms[@]}" "$@"
+# rpm fsyncs as it unpacks, which dominates install time on virtual
+# disks. eatmydata no-ops the fsyncs for just this transaction;
+# durability is irrelevant for an install we would simply rerun.
+$sudo_cmd dnf install -y libeatmydata
+$sudo_cmd eatmydata dnf install -y "${rpms[@]}" "$@"
 
 cat <<'EOF'
 

--- a/hack/install-fedora-deps.sh
+++ b/hack/install-fedora-deps.sh
@@ -99,6 +99,13 @@ rpms=(
     sqlite-devel
 )
 
+# Fast path: skip dnf (and its metadata refresh) when everything is
+# already present -- e.g. on a disk provisioned by hack/fedora-vm.sh.
+if [ "$#" -eq 0 ] && rpm -q "${rpms[@]}" >/dev/null 2>&1; then
+    echo "Fedora dependencies already installed."
+    exit 0
+fi
+
 # Skip sudo when already root (e.g. inside a container during
 # `docker build`); use sudo on a regular host where the user
 # typically isn't root.

--- a/hack/install-fedora-deps.sh
+++ b/hack/install-fedora-deps.sh
@@ -99,6 +99,18 @@ rpms=(
     sqlite-devel
 )
 
+# In the throwaway VM from hack/fedora-vm.sh, only the shared
+# directories outlive a poweroff: the guest disk is a per-boot overlay.
+# Go's default cache sits in the guest home, off the share, so a build
+# typed at the interactive prompt starts cold every boot. Point a login
+# shell at the .gocache on the share, where hack/nested-vm-e2e.sh
+# already puts it, and interactive builds go incremental too. Guarded
+# on the guest hostname: run on a real host or in `docker build`, this
+# script must leave your own Go cache alone.
+if [ "$(cat /etc/hostname 2>/dev/null)" = bpfman-fedora-vm ] && ! grep -qs GOCACHE "$HOME/.bashrc"; then
+    printf 'export GOCACHE=%s/.gocache\n' "$PWD" >> "$HOME/.bashrc"
+fi
+
 # Fast path: skip dnf (and its metadata refresh) when everything is
 # already present -- e.g. on a disk provisioned by hack/fedora-vm.sh.
 if [ "$#" -eq 0 ] && rpm -q "${rpms[@]}" >/dev/null 2>&1; then

--- a/hack/nested-vm-e2e.sh
+++ b/hack/nested-vm-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Build and run the e2e suite on a Fedora system whose kernel has
+# "bpf" in the active LSM list (the environment BPF_PROG_TYPE_LSM
+# tests will need; the corpus runs the same either way). Idempotent:
+# installs build deps, builds, loads the e2e kmod, then runs the
+# gRPC e2e suite and the .bpfman script corpus.
+#
+# Meant to be handed to hack/fedora-vm.sh (which supplies exactly such a
+# Fedora guest); --provision caches a disk with the deps pre-installed:
+#
+#   hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run hack/nested-vm-e2e.sh
+#
+# but it also runs directly on any Fedora box with bpf-LSM active
+# (stock Fedora kernels ship it on by default).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Persist the Go build cache on the repository (the virtiofs share under
+# hack/fedora-vm.sh) so a rerun in a fresh VM compiles incrementally
+# instead of from cold. Harmless on a normal filesystem.
+export GOCACHE="$PWD/.gocache"
+
+if ! grep -qw bpf /sys/kernel/security/lsm; then
+    echo "error: bpf is not in the active LSM list ($(cat /sys/kernel/security/lsm))." >&2
+    echo "       BPF_PROG_TYPE_LSM programs cannot attach here." >&2
+    echo "       Use a kernel with bpf-LSM (stock Fedora) or boot with lsm=...,bpf." >&2
+    exit 1
+fi
+
+# An optional stage argument narrows the run so CI can surface build
+# and test as separate steps (each in its own VM boot): "build"
+# compiles the binaries, test binaries and kmod, then runs the unit
+# tests; "test" loads the kmod and runs the e2e tests, expecting a
+# prior build on the share; no argument does both.
+stage="${1:-all}"
+case "$stage" in
+    all|build|test) ;;
+    *) echo "usage: $0 [build|test]" >&2; exit 2 ;;
+esac
+
+hack/install-fedora-deps.sh
+
+if [[ "$stage" != test ]]; then
+    make bpfman-compile
+    make build-e2e-grpc build-e2e-scripts
+    make e2e-kmod-build
+    make test
+fi
+
+if [[ "$stage" != build ]]; then
+    # The full gRPC e2e suite (its kfunc-backed tests gate
+    # on the kmod loaded here) and the whole .bpfman script corpus
+    # (the default !external selector still applies).
+    make e2e-kmod-reload
+    make test-e2e-grpc STRESS_COUNT=1
+    make test-e2e-scripts STRESS_COUNT=5
+fi

--- a/platform/ebpf/pin.go
+++ b/platform/ebpf/pin.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
 
 	"github.com/bpfman/bpfman"
 	"github.com/bpfman/bpfman/kernel"
@@ -168,9 +170,10 @@ func (k *kernelAdapter) Unpin(pinDir string) (int, error) {
 	return count, nil
 }
 
-// DetachLink tears down a previously-attached link in three
+// DetachLink tears down a previously-attached link in four
 // stages: explicit kernel-side Detach() where supported, removal
-// of the bpffs pin, then Close of the live *link.Link FD.
+// of the bpffs pin, Close of the live *link.Link FD, then a
+// bounded wait for the kernel link object to disappear.
 //
 // Stage 1 (Detach): for link types that implement the kernel's
 // bpf_link_ops.detach callback -- XDP, TCX, cgroup, netfilter,
@@ -191,11 +194,15 @@ func (k *kernelAdapter) Unpin(pinDir string) (int, error) {
 // Stage 3 (Close): drops the last user reference to the link
 // FD; the kernel reclaims the link object.
 //
-// For Detach-supporting types the program is already provably
-// offline by the time we reach Close. For non-supporting types
-// the test surface still observes async kernel teardown lag
-// (see waitForDetachComplete in e2e/helpers.go) -- there is no
-// userspace primitive to make perf-event teardown synchronous.
+// Stage 4 (wait): for Detach-supporting types the program is
+// already provably offline by the time we reach Close. For
+// non-supporting types the kernel releases the link via deferred
+// work and RCU grace periods, and under CPU contention the
+// program keeps firing on its hook well after Close returns.
+// There is no userspace primitive to make that teardown
+// synchronous, so we poll the kernel link ID (bounded) until the
+// object is gone, giving detach the contract callers expect:
+// returned means no longer invoked.
 func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkPath) error {
 	pin := linkPinPath.String()
 	k.logger.Debug("detaching link by removing pin", "link_pin_path", pin)
@@ -227,8 +234,17 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 		// as ENOENT.
 		k.logger.Warn("LoadPinnedLink failed", "link_pin_path", pin, "err", err)
 	}
+	var syncDetached bool
+	var kernelLinkID link.ID
 	if detachLnk != nil {
-		if err := detachLnk.Detach(); err != nil && !errors.Is(err, ebpf.ErrNotSupported) {
+		// Capture the kernel link ID while we still hold an FD;
+		// stage 4 needs it to observe the object's release.
+		if info, err := detachLnk.Info(); err == nil {
+			kernelLinkID = info.ID
+		}
+		if err := detachLnk.Detach(); err == nil {
+			syncDetached = true
+		} else if !errors.Is(err, ebpf.ErrNotSupported) {
 			k.logger.Warn("link Detach failed", "link_pin_path", pin, "err", err)
 			// continue: cleanup must still happen
 		}
@@ -265,7 +281,49 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 	// but attach calls MkdirAll before pinning, so it recovers
 	// if the directory disappears underneath it.
 	os.Remove(filepath.Dir(pin))
+
+	// Stage 4: only the async-teardown types need the wait; a
+	// successful Detach already disconnected the program.
+	if !syncDetached && kernelLinkID != 0 {
+		k.waitKernelLinkGone(ctx, kernelLinkID, pin)
+	}
 	return nil
+}
+
+// waitKernelLinkGone polls until the kernel link object with the
+// given ID has been released, bounded so a wedged reference can
+// never hang teardown. The ID exposes three states: alive (an FD
+// comes back), dying (EAGAIN: the refcount already hit zero but
+// the deferred release has not run -- the program can still fire
+// on its hook), and gone (ENOENT: the ID has left the table).
+// Only the third terminates the wait; treating EAGAIN as gone
+// returns into the very window this wait exists to outlive.
+func (k *kernelAdapter) waitKernelLinkGone(ctx context.Context, id link.ID, pin string) {
+	const deadline = 3 * time.Second
+	backoff := time.Millisecond
+	start := time.Now()
+	for {
+		l, err := link.NewFromID(id)
+		if err != nil && !errors.Is(err, unix.EAGAIN) {
+			return
+		}
+		if err == nil {
+			_ = l.Close()
+		}
+
+		if time.Since(start) >= deadline {
+			k.logger.Warn("kernel link still present after detach wait", "link_pin_path", pin, "kernel_link_id", id, "waited", deadline)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 50*time.Millisecond {
+			backoff *= 2
+		}
+	}
 }
 
 // pinWithRetry creates the parent directory and invokes pin. If the


### PR DESCRIPTION
This PR does three things: it makes `bpfman link detach` deterministic for link types the kernel releases asynchronously, it runs the whole e2e suite inside a nested Fedora VM in CI so that bpf-LSM tests become runnable, and it makes that VM a general-purpose developer tool you can drive from the command line.

## Deterministic detach

For link types with no kernel-side detach operation (perf-event and tracing links: kprobe, uprobe, tracepoint, fentry/fexit, LSM) the kernel tears the link down asynchronously after the pin is removed and the last FD closed, so a program can keep firing on its hook after `bpfman link detach` returns. Under CPU contention on a 4-vCPU runner that window stretched far enough for an e2e counter to record all fifty post-detach probe fires. `DetachLink` now captures the kernel link ID and polls `BPF_LINK_GET_FD_BY_ID` until the object is gone, distinguishing alive (an FD comes back), dying (`EAGAIN`: refcount zero, deferred release pending) and gone (`ENOENT`); the wait is bounded and skipped entirely for types whose kernel `Detach()` already disconnected the program synchronously.

Even a fully released link ID cannot prove the program is off its hook -- the trampoline unlink drains behind RCU grace periods with no userspace-visible completion -- so the script corpus stops trusting teardown timing altogether. The fixed `sleep 0.1` settles after detach become quiescence polls that fire the script's own probe and retry until the detached program's counter stops moving; the multi-prog wave scripts convert their fixed whole-run totals into snapshot deltas around each poll (a strictly stronger assertion); and the TCX duplicate-attach script reads kernel truth through the `linkinfo` builtin, which looks the link up by id via the `bpf()` syscall and is immune to the enumeration race against links dying elsewhere in the parallel corpus.

## A nested VM in CI

GitHub-hosted runners boot without `bpf` in the active LSM list and cannot be rebooted mid-job, so nothing that needs a bpf-LSM kernel can run on them. The new `nested-vm-e2e.yml` workflow boots a Fedora guest -- stock Fedora kernels ship bpf-LSM active -- and runs the build, the unit tests, the full gRPC e2e suite and the whole `.bpfman` script corpus inside it. Nothing here is LSM-specific; the VM simply provides the kernel the lsm tests in #1676 need, so once that PR rebases onto this one its `TestLsm_` scripts run with no further wiring.

The workflow has no triggers of its own: `CI` calls it as a job, so it runs on pull requests and pushes to main and counts towards `ci-complete`. Provision, build and test run as separate steps, each booting a cached provisioned disk. On the runner it builds virtiofsd 1.13.2 from crates.io (noble packages 1.10, which predates `--translate-uid`), opens `/dev/kvm`, lifts Ubuntu 24.04's AppArmor confinement of unprivileged user namespaces and raises file limits. A steady-state run restores the base image, the provisioned disk and the guest Go build cache from `actions/cache` and completes in about six minutes.

## The VM as a developer tool

The harness underneath, `hack/fedora-vm.sh`, is not CI-shaped -- it is a general way to run anything in a throwaway Fedora guest with your working tree shared in at its host path:

```
hack/fedora-vm-host-deps.sh        # host tooling, once (Fedora and Ubuntu/Debian)

# Interactive shell in the guest.
hack/fedora-vm.sh --provision hack/install-fedora-deps.sh

# The CI run, locally.
hack/fedora-vm.sh --provision hack/install-fedora-deps.sh --run hack/nested-vm-e2e.sh

# One-off command; exit status propagates.
hack/fedora-vm.sh --run 'uname -r && cat /sys/kernel/security/lsm'

# Share extra host directories, docker -v style.
hack/fedora-vm.sh -v /path/on/host:/path/in/guest:ro --run '...'
```

The guest disk is a per-boot overlay, so only the shares persist: packages you want permanently belong in `install-fedora-deps.sh`, whose content keys the provisioned disk so it rebuilds itself on change, and `GOCACHE` lives on the share so builds typed at the guest prompt stay incremental across boots. Shares are writable by any guest identity, including root under sudo, because virtiofsd squashes guest uids/gids to the invoking user via `--translate-uid`/`--translate-gid` -- the reason virtiofsd 1.13+ is required. The harness locates the daemon itself, probing PATH, `~/.local/bin` and `/usr/libexec` for a binary that supports the option (`VIRTIOFSD=<path>` overrides), so neither it nor the installer ever symlinks anything onto PATH. The harness also runs on aarch64 hosts (probing the UEFI firmware locations distributions disagree on), and `VM_ARCH` gives a TCG-emulated cross-architecture smoke test. The remaining knobs (`VIRTFS_FAST`, `VM_CPUS`, `VM_MEMORY`, `VM_FIRMWARE`, `SERIAL_LOG`, `SSH_PORT`) and the full details are documented in `hack/README.md`.

## Testing

Native host (bpf-LSM kernel): the full script corpus at `STRESS_COUNT=5`, 590/590 subtests passing. Nested VM: the complete driver -- build, unit tests, gRPC e2e suite, corpus at five iterations -- green end to end, and the workflow ran repeatedly green on the development branch, including four concurrent runs to recreate runner contention. The detach fix is falsified both ways: with the kernel-link wait disabled the after-detach flake reproduces in CI (counter exactly doubled); with the wait plus the quiescence polls it has not been observed since. The aarch64 path is exercised on a Fedora 44 Asahi host: all three CI stages run green in the nested guest, 605 subtests passing, the 55 skips being the `external`-labelled image scripts the default selector excludes.

