### PR TITLE
Drop in-process link tracking 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -841,7 +841,7 @@ $(BIN_DIR)/e2e.test: $(DISPATCHER_BPF_EMBEDS) $(E2E_BPF_OBJECTS) | $(BIN_DIR)
 .PHONY: test-e2e
 test-e2e: $(BIN_DIR)/e2e.test
 	$(Q)$(MAKE) e2e-kmod-reload
-	sudo BPFMAN_E2E_BYTECODE_DIR=$(abspath e2e) $(call forward-env,BPFMAN_E2E_ISOLATED_RUNTIME BPFMAN_E2E_POLICY_RULE_PREF BPFMAN_LOG) $(BIN_DIR)/e2e.test -test.v -test.failfast -test.count=$(STRESS_COUNT) $(if $(filter-out 0,$(PARALLEL)),-test.parallel $(PARALLEL)) $(if $(TEST),-test.run $(TEST))
+	sudo BPFMAN_E2E_BYTECODE_DIR=$(abspath e2e) $(call forward-env,BPFMAN_E2E_ISOLATED_RUNTIME BPFMAN_E2E_POLICY_RULE_PREF BPFMAN_LOG) $(BIN_DIR)/e2e.test -test.v -test.failfast -test.count=$(STRESS_COUNT) $(if $(filter-out 0,$(PARALLEL)),-test.parallel $(PARALLEL)) $(if $(TEST),-test.run "$(TEST)")
 
 # Parallel gRPC e2e: stands up a real `bpfman serve` subprocess and
 # fans goroutines through load/get/attach/detach/unload over the
@@ -904,7 +904,7 @@ run-e2e-grpc:
 	    BPFMAN_E2E_BYTECODE_DIR=$(E2E_GRPC_BYTECODE_DIR) \
 	    $(call forward-env,$(E2E_GRPC_FORWARD_VARS)) \
 	    $(E2E_GRPC_TEST_BIN) -test.v -test.failfast \
-	    -test.count=$(STRESS_COUNT) $(if $(TEST),-test.run $(TEST))
+	    -test.count=$(STRESS_COUNT) $(if $(TEST),-test.run "$(TEST)")
 
 .PHONY: test-e2e-grpc
 test-e2e-grpc: build-e2e-grpc

--- a/e2e/grpc/detach_contract_test.go
+++ b/e2e/grpc/detach_contract_test.go
@@ -1,0 +1,274 @@
+//go:build e2e
+
+// Detach-contract tests: daemon-process properties that only a
+// long-lived `bpfman serve` process can exhibit. The script corpus
+// runs every bpfman command as a short-lived subprocess, so process
+// exit releases any leaked FD before an assertion can observe it;
+// here the daemon outlives every RPC, so reference-lifetime bugs are
+// visible in its /proc/<pid>/fd table and in how long kernel link
+// objects survive.
+//
+// Three properties, one test each:
+//
+//   - The daemon holds no bpf link FDs while a link is attached: the
+//     bpffs pin is the link's only reference and the daemon keeps no
+//     link state.
+//   - When the Detach RPC returns, the kernel link object is already
+//     gone: the daemon's close performed the last reference drop
+//     synchronously inside close(2).
+//   - An out-of-band pin removal releases the link: with no
+//     daemon-held FD, removing the pin drops the last reference and
+//     the kernel frees the link, rather than leaving a zombie
+//     attached and firing until the daemon exits.
+package grpcparallel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+
+	pb "github.com/bpfman/bpfman/server/pb"
+)
+
+// loadAndAttachKprobe drives Load + Attach for the kmod-target
+// kprobe spec and returns the program and bpfman link IDs. Cleanup
+// (Detach where still needed, then Unload) is registered on t.
+func loadAndAttachKprobe(ctx context.Context, t *testing.T) (progID, linkID uint32) {
+	t.Helper()
+	spec := kprobeSpec()
+
+	loadResp, err := client.Load(ctx, &pb.LoadRequest{
+		Bytecode: &pb.BytecodeLocation{
+			Location: &pb.BytecodeLocation_File{File: testdataPath(spec.object)},
+		},
+		Info: []*pb.LoadInfo{{
+			Name:        spec.progName,
+			ProgramType: spec.enumType,
+			Info:        spec.loadInfo,
+		}},
+		Metadata: map[string]string{"test": "grpc_detach_contract"},
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loadResp.Programs) != 1 || loadResp.Programs[0].KernelInfo == nil {
+		t.Fatalf("Load: want 1 program with KernelInfo, got %+v", loadResp.Programs)
+	}
+	progID = loadResp.Programs[0].KernelInfo.Id
+	t.Cleanup(func() {
+		if _, err := client.Unload(context.Background(), &pb.UnloadRequest{Id: progID}); err != nil {
+			t.Errorf("cleanup Unload %d: %v", progID, err)
+		}
+	})
+
+	attachResp, err := client.Attach(ctx, &pb.AttachRequest{
+		Id:     progID,
+		Attach: spec.attachBuilder(t, 0)(),
+	})
+	if err != nil {
+		t.Fatalf("Attach %d: %v", progID, err)
+	}
+	if attachResp.LinkId == 0 {
+		t.Fatalf("Attach %d: returned zero bpfman link id", progID)
+	}
+	return progID, attachResp.LinkId
+}
+
+// linkPinPath returns the daemon's bpffs pin for a bpfman link ID:
+// {runtime}/fs/links/{id}.
+func linkPinPath(linkID uint32) string {
+	return filepath.Join(daemonRuntimeDir, "fs", "links", strconv.FormatUint(uint64(linkID), 10))
+}
+
+// kernelLinkIDFromPin opens the pin, reads the kernel link ID, and
+// closes the FD again so the test process holds no reference when
+// the caller goes on to detach.
+func kernelLinkIDFromPin(t *testing.T, pin string) link.ID {
+	t.Helper()
+	lnk, err := link.LoadPinnedLink(pin, nil)
+	if err != nil {
+		t.Fatalf("load pinned link %s: %v", pin, err)
+	}
+	info, err := lnk.Info()
+	if err != nil {
+		_ = lnk.Close()
+		t.Fatalf("link info %s: %v", pin, err)
+	}
+	if err := lnk.Close(); err != nil {
+		t.Fatalf("close link %s: %v", pin, err)
+	}
+	return info.ID
+}
+
+// procFDTargets returns the entries of a /proc/<pid>/fd directory
+// whose symlink target contains any of the given tokens.
+func procFDTargets(t *testing.T, fdDir string, tokens ...string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", fdDir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		target, err := os.Readlink(filepath.Join(fdDir, e.Name()))
+		if err != nil {
+			continue // fd closed between ReadDir and Readlink
+		}
+		for _, tok := range tokens {
+			if strings.Contains(target, tok) {
+				out = append(out, target+bpfFDInfo(fdDir, e.Name()))
+				break
+			}
+		}
+	}
+	return out
+}
+
+// bpfFDInfo renders the identifying fdinfo lines (prog_id, map_id,
+// link_id, prog_tag) for one fd so a failing scan names the kernel
+// objects being held, not just their kinds.
+func bpfFDInfo(fdDir, fd string) string {
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(fdDir), "fdinfo", fd))
+	if err != nil {
+		return ""
+	}
+	var ids []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if strings.HasPrefix(line, "prog_id") || strings.HasPrefix(line, "map_id") || strings.HasPrefix(line, "link_id") || strings.HasPrefix(line, "prog_tag") || strings.HasPrefix(line, "map_name") {
+			ids = append(ids, strings.Join(strings.Fields(line), "="))
+		}
+	}
+	if len(ids) == 0 {
+		return ""
+	}
+	return "(" + strings.Join(ids, ",") + ")"
+}
+
+// bpfLinkFDTargets returns the fd targets naming a bpf link anon
+// inode.
+func bpfLinkFDTargets(t *testing.T, fdDir string) []string {
+	t.Helper()
+	return procFDTargets(t, fdDir, "bpf_link", "bpf-link")
+}
+
+// bpfFDTargets returns the fd targets naming any bpf object anon
+// inode: programs, maps, or links. A quiescent daemon must hold
+// none of any kind -- the bpffs pins are the only references.
+func bpfFDTargets(t *testing.T, fdDir string) []string {
+	t.Helper()
+	return procFDTargets(t, fdDir, "bpf_link", "bpf-link", "bpf-prog", "bpf-map")
+}
+
+// TestGRPC_DaemonHoldsNoLinkFDsWhileAttached asserts the daemon's fd
+// table contains no bpf link FDs while a link is attached: the pin
+// is the link's only reference. A daemon that tracks link FDs in
+// memory fails this immediately.
+func TestGRPC_DaemonHoldsNoLinkFDsWhileAttached(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	_, linkID := loadAndAttachKprobe(ctx, t)
+	pin := linkPinPath(linkID)
+	t.Cleanup(func() {
+		if _, err := client.Detach(context.Background(), &pb.DetachRequest{LinkId: linkID}); err != nil {
+			t.Errorf("cleanup Detach %d: %v", linkID, err)
+		}
+	})
+
+	// Validate the fd-table matcher before trusting a zero count:
+	// open the pin in this process and require exactly one new
+	// matching entry to appear. If the kernel's anon-inode name
+	// for links ever changes, this fails loudly instead of letting
+	// the daemon assertion pass vacuously.
+	before := len(bpfLinkFDTargets(t, "/proc/self/fd"))
+	lnk, err := link.LoadPinnedLink(pin, nil)
+	if err != nil {
+		t.Fatalf("load pinned link %s: %v", pin, err)
+	}
+	after := len(bpfLinkFDTargets(t, "/proc/self/fd"))
+	if err := lnk.Close(); err != nil {
+		t.Fatalf("close link: %v", err)
+	}
+	if after != before+1 {
+		t.Fatalf("fd matcher self-check: opening a link changed matching fds %d -> %d, want +1; the anon-inode name assumption is broken", before, after)
+	}
+
+	if fds := bpfLinkFDTargets(t, fmt.Sprintf("/proc/%d/fd", daemonPID)); len(fds) != 0 {
+		t.Fatalf("daemon holds %d bpf link FD(s) while link %d is attached: %v; the bpffs pin must be the link's only reference", len(fds), linkID, fds)
+	}
+}
+
+// TestGRPC_KernelLinkReleasedAtDetachReturn asserts that when the
+// Detach RPC returns, the kernel link object is already unopenable:
+// the daemon's close performed the last reference drop synchronously.
+// A daemon that leaks the link FD keeps the ID openable indefinitely
+// and fails this deterministically.
+func TestGRPC_KernelLinkReleasedAtDetachReturn(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	_, linkID := loadAndAttachKprobe(ctx, t)
+	kid := kernelLinkIDFromPin(t, linkPinPath(linkID))
+
+	if _, err := client.Detach(ctx, &pb.DetachRequest{LinkId: linkID}); err != nil {
+		t.Fatalf("Detach %d: %v", linkID, err)
+	}
+
+	l, err := link.NewFromID(kid)
+	if err == nil {
+		_ = l.Close()
+		t.Fatalf("kernel link %d still openable after Detach returned", kid)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("kernel link %d: want ENOENT after Detach, got: %v", kid, err)
+	}
+}
+
+// TestGRPC_OutOfBandUnpinReleasesLink asserts that removing the pin
+// behind the daemon's back releases the kernel link: with no
+// daemon-held FD, the pin's put drops the last reference and the
+// kernel frees the link via its deferred path. A daemon that tracks
+// link FDs keeps the link alive -- attached and firing, invisible to
+// bpfman's own state -- until the daemon exits, and fails this at
+// the poll deadline.
+func TestGRPC_OutOfBandUnpinReleasesLink(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	_, linkID := loadAndAttachKprobe(ctx, t)
+	pin := linkPinPath(linkID)
+	kid := kernelLinkIDFromPin(t, pin)
+	t.Cleanup(func() {
+		// The pin is gone; Detach must still succeed and clear
+		// the record.
+		if _, err := client.Detach(context.Background(), &pb.DetachRequest{LinkId: linkID}); err != nil {
+			t.Errorf("cleanup Detach %d: %v", linkID, err)
+		}
+	})
+
+	if err := os.Remove(pin); err != nil {
+		t.Fatalf("out-of-band unpin %s: %v", pin, err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		l, err := link.NewFromID(kid)
+		if err == nil {
+			_ = l.Close()
+		} else if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kernel link %d still alive 3s after out-of-band unpin: a held reference is keeping a zombie attached", kid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/e2e/grpc/lifecycle_test.go
+++ b/e2e/grpc/lifecycle_test.go
@@ -136,6 +136,29 @@ func TestParallel_GRPC(t *testing.T) {
 		t.Logf("    reads (Get):                          %6d ops  ~%6.1f/s", totalReads, readRate)
 	})
 
+	// End-state quiescence check, also on the parent so it runs
+	// after every sub-test has finished. Per-lifecycle reference
+	// assertions are impossible while mutations are in flight --
+	// the daemon legitimately holds a link FD inside each attach
+	// and detach -- but leaks accumulate, so once the suite goes
+	// quiet the daemon must hold no bpf object FDs and manage no
+	// programs. A reference leaked by any lifecycle, in any
+	// interleaving, is still visible here.
+	t.Cleanup(func() {
+		if fds := bpfFDTargets(t, fmt.Sprintf("/proc/%d/fd", daemonPID)); len(fds) != 0 {
+			t.Errorf("daemon holds %d bpf object FD(s) after all lifecycles completed: %v", len(fds), fds)
+		}
+		only := true
+		resp, err := client.List(context.Background(), &pb.ListRequest{BpfmanProgramsOnly: &only})
+		if err != nil {
+			t.Errorf("quiescence List: %v", err)
+			return
+		}
+		if n := len(resp.Results); n != 0 {
+			t.Errorf("daemon still manages %d program(s) after all lifecycles completed", n)
+		}
+	})
+
 	for _, spec := range specs {
 		counter := counts[spec.name]
 		t.Run(spec.name, func(t *testing.T) {

--- a/e2e/grpc/main_test.go
+++ b/e2e/grpc/main_test.go
@@ -76,6 +76,14 @@ var (
 	// Per-type specs join their .bpf.o filename to this path to
 	// produce the absolute path the daemon's Load RPC opens.
 	testdataDir string
+
+	// daemonPID is the spawned `bpfman serve` process, and
+	// daemonRuntimeDir its --runtime-dir. The detach-contract
+	// tests read the daemon's /proc/<pid>/fd table and its bpffs
+	// pin layout directly: the daemon outliving every RPC is what
+	// makes reference-lifetime properties observable at all.
+	daemonPID        int
+	daemonRuntimeDir string
 )
 
 func TestMain(m *testing.M) {
@@ -187,6 +195,8 @@ func bootstrap() (func(), error) {
 		cleanupRoot()
 		return nil, fmt.Errorf("start daemon: %w", err)
 	}
+	daemonPID = serverCmd.Process.Pid
+	daemonRuntimeDir = runtimeDir
 
 	cleanupDaemon := func() {
 		_ = syscall.Kill(serverCmd.Process.Pid, syscall.SIGTERM)

--- a/e2e/lib.bpfman
+++ b/e2e/lib.bpfman
@@ -127,6 +127,24 @@ def assert_link_absent(listed linkID) {
     assert $count == 0
 }
 
+# Assert that a link's kernel bpf_link ID is no longer openable at
+# the moment detach returns. The probe is one bpf() syscall with no
+# retry, so it only catches references that outlive the detach
+# command: a pin left behind, or a held FD in a long-lived
+# (daemon-mode) process. It cannot observe the kernel's
+# deferred-release window: script bpfman commands run as short-lived
+# subprocesses, and process exit releases any leaked FD milliseconds
+# before this probe runs, so post-detach firing is guarded by the
+# quiescence polls, not by this assert. The preconditions keep the
+# check honest: `assert fail` passes on any linkinfo error, so
+# without them a link that never recorded a kernel ID would turn the
+# probe into a green no-op.
+def assert_kernel_link_gone(link) {
+    assert not null $link.record.kernel_link_id
+    assert $link.record.kernel_link_id > 0
+    assert fail linkinfo id $link.record.kernel_link_id
+}
+
 # Wait until a just-detached kfunc-backed program stops observing its
 # target. Perf-link teardown is asynchronous, so a fixed sleep after
 # `bpfman link detach` can still race the kernel-side detach path on a

--- a/e2e/lib.bpfman
+++ b/e2e/lib.bpfman
@@ -161,7 +161,13 @@ def await_uprobe_detach_quiescent(mapID events counterFilter) {
 def await_net_detach_quiescent(ns addr mapID counterFilter) {
     guard beforeDump <- bpftool map dump id $mapID -j
     let before = $beforeDump.stdout |> jq $counterFilter
-    guard _ <- net exec $ns ping -c 1 -W 1 $addr
+    # The sub-second -W lets several probe attempts fit the callers'
+    # 2s poll window; -W 1 fitted at most two. The retry message
+    # carries the ping's exit code and stderr so a genuinely broken
+    # data path is named rather than surfacing as an opaque poll
+    # timeout.
+    let probe <- net exec $ns ping -c 1 -W 0.3 $addr
+    retry "waiting for network detach probe (exit ${probe.exit_code}): ${probe.stderr}" unless $probe.ok
     guard afterDump <- bpftool map dump id $mapID -j
     let after = $afterDump.stdout |> jq $counterFilter
     retry "waiting for network detach quiescence" unless $after == $before

--- a/e2e/scripts/TestDispatcher_LifecycleAfterLastDetachTC.bpfman
+++ b/e2e/scripts/TestDispatcher_LifecycleAfterLastDetachTC.bpfman
@@ -22,6 +22,8 @@
 # dispatcher get's success or failure as the proxy -- a dispatcher
 # snapshot exists iff the kernel-side attach point does.
 
+import ../lib.bpfman
+
 guard pair <- net veth-pair
 defer net release $pair
 
@@ -43,6 +45,7 @@ assert $snap1 |> jq ".runtime.filter_handle > 0"
 
 # Phase 2: detach the only member; the dispatcher goes away.
 bpfman link detach $l1
+assert_kernel_link_gone $l1
 assert fail bpfman dispatcher get tc-ingress $pair.host_nsid $pair.host_ifindex
 
 # Phase 3: reattach; a fresh dispatcher is created with a new

--- a/e2e/scripts/TestFentry_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestFentry_LinkRoundTrip.bpfman
@@ -56,6 +56,7 @@ print "kfunc=${fn.name} got=${got} want=${want}"
 assert $got == $want
 
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestFexit_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestFexit_LinkRoundTrip.bpfman
@@ -56,6 +56,7 @@ print "kfunc=${fn.name} got=${got} want=${want}"
 assert $got == $want
 
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestKprobe_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestKprobe_LinkRoundTrip.bpfman
@@ -58,6 +58,7 @@ print "kfunc=${fn.name} got=${got} want=${events}"
 assert $got == $events
 
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestKretprobe_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestKretprobe_LinkRoundTrip.bpfman
@@ -58,6 +58,7 @@ print "kfunc=${fn.name} got=${got} want=${events}"
 assert $got == $events
 
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestMultiProgTracepoint_LoadAttachDetachUnload.bpfman
+++ b/e2e/scripts/TestMultiProgTracepoint_LoadAttachDetachUnload.bpfman
@@ -67,6 +67,7 @@ assert $snap1_b == ($n * $weight_b)
 assert $snap1_c == ($n * $weight_c)
 
 bpfman link detach $link_c
+assert_kernel_link_gone $link_c
 poll timeout 2s every 50ms {
     await_kfunc_detach_quiescent $fn $mapID_c 1 $counter_filter
 }
@@ -92,6 +93,7 @@ assert ($snap3_b - $snap2_b) == ($n * $weight_b)
 assert $snap3_c == $snap2_c
 
 bpfman link detach $link_b
+assert_kernel_link_gone $link_b
 poll timeout 2s every 50ms {
     await_kfunc_detach_quiescent $fn $mapID_b 1 $counter_filter
 }
@@ -121,3 +123,4 @@ assert $final_c == $snap4_c
 # before the deferred program-unloads fire (an attached program
 # refuses to unload).
 bpfman link detach $link_a
+assert_kernel_link_gone $link_a

--- a/e2e/scripts/TestTCX_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTCX_LinkRoundTrip.bpfman
@@ -66,6 +66,7 @@ assert $delta >= 5
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestTCX_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTCX_NetnsVethPairLinkRoundTrip.bpfman
@@ -69,6 +69,7 @@ assert $delta >= 5
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestTC_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTC_LinkRoundTrip.bpfman
@@ -75,6 +75,7 @@ assert $delta >= 5
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
 assert fail bpfman link get $linkID
+assert_kernel_link_gone $link
 
 guard listedAfter <- bpfman link list -o json
 assert_link_absent $listedAfter $linkID

--- a/e2e/scripts/TestTC_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTC_NetnsVethPairLinkRoundTrip.bpfman
@@ -75,6 +75,7 @@ assert $delta >= 5
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestTracepoint_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestTracepoint_LinkRoundTrip.bpfman
@@ -60,6 +60,7 @@ assert $got == $want
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestUprobe_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestUprobe_LinkRoundTrip.bpfman
@@ -66,6 +66,7 @@ assert $count == $want
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestUretprobe_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestUretprobe_LinkRoundTrip.bpfman
@@ -67,6 +67,7 @@ assert $count == $want
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestXDP_LinkRoundTrip.bpfman
+++ b/e2e/scripts/TestXDP_LinkRoundTrip.bpfman
@@ -66,6 +66,7 @@ assert $delta >= 5
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/e2e/scripts/TestXDP_NetnsVethPairLinkRoundTrip.bpfman
+++ b/e2e/scripts/TestXDP_NetnsVethPairLinkRoundTrip.bpfman
@@ -67,6 +67,7 @@ assert $delta >= 5
 
 # Detach, then verify the link is gone from both Get and List.
 bpfman link detach $link
+assert_kernel_link_gone $link
 assert fail bpfman link get $linkID
 
 guard listedAfter <- bpfman link list -o json

--- a/platform/ebpf/attach_tracing.go
+++ b/platform/ebpf/attach_tracing.go
@@ -36,11 +36,9 @@ func (k *kernelAdapter) AttachTracepoint(ctx context.Context, progPinPath bpfman
 
 // finishProbeAttach is the shared tail of the probe-style attaches
 // (tracepoint, kprobe, fentry/fexit). It pins the link when linkPinPath
-// is set, reads its info, and then either hands the live link to the
-// adapter for a later Close or closes it. Probe-style links need an
-// explicit Close after unpinning: pin-removal alone does not run
-// perf_event_free_bpf_prog, so the program stays attached to the
-// perf_event until the link object is Closed.
+// is set, reads its info, and closes our FD: the bpffs pin then holds
+// the link's only reference -- the daemon keeps no link state -- and
+// DetachLink reopens an FD from the pin to make teardown synchronous.
 func (k *kernelAdapter) finishProbeAttach(lnk link.Link, linkPinPath bpfman.LinkPath) (bpfman.AttachOutput, error) {
 	linkPin := linkPinPath.String()
 
@@ -57,10 +55,11 @@ func (k *kernelAdapter) finishProbeAttach(lnk link.Link, linkPinPath bpfman.Link
 		return bpfman.AttachOutput{}, fmt.Errorf("get link info: %w", err)
 	}
 
-	if linkPin != "" {
-		k.trackLink(linkPin, lnk)
-	} else {
-		lnk.Close()
+	// On cilium's tracefs fallback path a failed close leaks the
+	// kprobe_events/uprobe_events entry with no owner left to reap
+	// it, so the error must at least be visible.
+	if err := lnk.Close(); err != nil {
+		k.logger.Warn("close attached link", "link_pin_path", linkPin, "err", err)
 	}
 
 	kernelLinkID := kernel.LinkID(linkInfo.ID)

--- a/platform/ebpf/attach_uprobe.go
+++ b/platform/ebpf/attach_uprobe.go
@@ -158,13 +158,14 @@ func (k *kernelAdapter) doAttachUprobeResolved(progPinPath, path, fnName string,
 		k.logger.Debug("link pinned successfully", "path", linkPinPath)
 	}
 
-	// Hand the live link to the kernelAdapter so DetachLink can
-	// Close it after unpinning. Pin-removal alone does not run
-	// perf_event_free_bpf_prog for probe-style attachments.
-	if linkPinPath != "" {
-		k.trackLink(linkPinPath, lnk)
-	} else {
-		lnk.Close()
+	// Close our FD: the bpffs pin (when present) holds the link's
+	// only reference -- the daemon keeps no link state -- and
+	// DetachLink reopens an FD from the pin to make teardown
+	// synchronous. On cilium's tracefs fallback path a failed close
+	// leaks the uprobe_events entry with no owner left to reap it,
+	// so the error must at least be visible.
+	if err := lnk.Close(); err != nil {
+		k.logger.Warn("close attached link", "link_pin_path", linkPinPath, "err", err)
 	}
 
 	return linkID, ToKernelLink(linkInfo), nil

--- a/platform/ebpf/ebpf.go
+++ b/platform/ebpf/ebpf.go
@@ -6,7 +6,6 @@ import (
 	"iter"
 	"log/slog"
 	"net"
-	"sync"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -20,38 +19,10 @@ import (
 type kernelAdapter struct {
 	logger *slog.Logger
 
-	// liveLinks holds the *link.Link returned by cilium/ebpf at
-	// attach time, keyed by bpffs link pin path. For probe-style
-	// attachments (tracepoint, k(ret)probe, u(ret)probe,
-	// fentry/fexit) where multiple BPF programs share a kernel
-	// hook, pin-removal alone does not run perf_event_free_bpf_prog
-	// for the released link's program. DetachLink removes the pin
-	// and then consumes this map -- the order matters.
-	liveLinks sync.Map
-
 	// testDisp holds lazily-loaded test dispatchers used as
 	// verification targets when loading XDP/TC programs as
 	// Extension type.
 	testDisp testDispatchers
-}
-
-// trackLink remembers a live link so DetachLink can close it. A
-// no-op when linkPinPath is empty (caller owns lnk and must Close).
-func (k *kernelAdapter) trackLink(linkPinPath string, lnk link.Link) {
-	if linkPinPath == "" {
-		return
-	}
-	k.liveLinks.Store(linkPinPath, lnk)
-}
-
-// releaseLink Closes and forgets the live link tracked at
-// linkPinPath, if any. Returns the Close error.
-func (k *kernelAdapter) releaseLink(linkPinPath string) error {
-	v, ok := k.liveLinks.LoadAndDelete(linkPinPath)
-	if !ok {
-		return nil
-	}
-	return v.(link.Link).Close()
 }
 
 // Option configures a kernelAdapter.

--- a/platform/ebpf/ebpf.go
+++ b/platform/ebpf/ebpf.go
@@ -19,11 +19,6 @@ import (
 type kernelAdapter struct {
 	logger *slog.Logger
 
-	// testDisp holds lazily-loaded test dispatchers used as
-	// verification targets when loading XDP/TC programs as
-	// Extension type.
-	testDisp testDispatchers
-
 	// linkWait bounds the kernel-link release wait in DetachLink.
 	linkWait linkWaitParams
 }

--- a/platform/ebpf/ebpf.go
+++ b/platform/ebpf/ebpf.go
@@ -23,6 +23,9 @@ type kernelAdapter struct {
 	// verification targets when loading XDP/TC programs as
 	// Extension type.
 	testDisp testDispatchers
+
+	// linkWait bounds the kernel-link release wait in DetachLink.
+	linkWait linkWaitParams
 }
 
 // Option configures a kernelAdapter.
@@ -38,7 +41,8 @@ func WithLogger(logger *slog.Logger) Option {
 // New creates a new kernel adapter.
 func New(opts ...Option) platform.KernelOperations {
 	k := &kernelAdapter{
-		logger: slog.Default(),
+		logger:   slog.Default(),
+		linkWait: defaultLinkWaitParams(),
 	}
 	for _, opt := range opts {
 		opt(k)

--- a/platform/ebpf/load.go
+++ b/platform/ebpf/load.go
@@ -153,15 +153,14 @@ func (k *kernelAdapter) Load(ctx context.Context, spec bpfman.LoadSpec, bpffs fs
 	// programs are loaded once and reused from their pin on every
 	// dispatcher rebuild, rather than re-reading the ELF file.
 	if programType == bpfman.ProgramTypeXDP || programType == bpfman.ProgramTypeTC {
-		var testProg *ebpf.Program
-		if programType == bpfman.ProgramTypeXDP {
-			testProg, err = k.testDisp.getXDP()
-		} else {
-			testProg, err = k.testDisp.getTC()
-		}
+		testProg, closeTestDisp, err := loadTestDispatcher(programType)
 		if err != nil {
-			return bpfman.LoadOutput{}, fmt.Errorf("get test dispatcher for %s: %w", programType, err)
+			return bpfman.LoadOutput{}, fmt.Errorf("load test dispatcher for %s: %w", programType, err)
 		}
+		// Closed once the extension has loaded: the kernel holds
+		// its own reference on the target while the extension
+		// exists, and the daemon keeps no bpf FDs open.
+		defer closeTestDisp()
 
 		progSpec.Type = ebpf.Extension
 		progSpec.AttachTarget = testProg

--- a/platform/ebpf/pin.go
+++ b/platform/ebpf/pin.go
@@ -267,6 +267,9 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 			if cerr := k.releaseLink(pin); cerr != nil {
 				k.logger.Warn("close tracked link after missing pin", "link_pin_path", pin, "err", cerr)
 			}
+			if !syncDetached && kernelLinkID != 0 {
+				k.waitKernelLinkGone(ctx, kernelLinkID, pin)
+			}
 			return nil
 		}
 		return fmt.Errorf("remove link pin %s: %w", pin, err)

--- a/platform/ebpf/pin.go
+++ b/platform/ebpf/pin.go
@@ -172,58 +172,54 @@ func (k *kernelAdapter) Unpin(pinDir string) (int, error) {
 
 // DetachLink tears down a previously-attached link in four
 // stages: explicit kernel-side Detach() where supported, removal
-// of the bpffs pin, Close of the live *link.Link FD, then a
+// of the bpffs pin, Close of the FD opened from the pin, then a
 // bounded wait for the kernel link object to disappear.
 //
-// Stage 1 (Detach): for link types that implement the kernel's
-// bpf_link_ops.detach callback -- XDP, TCX, cgroup, netfilter,
-// netkit, struct_ops, sockmap -- this synchronously disconnects
-// the program from its hook before we touch the pin or the FD.
+// The invariant the stages rest on: the FD opened in stage 1 is
+// held across the stage-2 pin removal, so the pin's put can never
+// drop the link's last reference -- only our own Close in stage 3
+// can. An FD close frees the link synchronously inside close(2)
+// (bpf_link_put_direct), ID removal and hook detach both complete
+// before Close returns, where every other put path defers to a
+// workqueue. That ordering, not the pin removal itself, is what
+// makes teardown synchronous and gives detach the contract
+// callers expect: returned means no longer invoked.
+//
+// Stage 1 (open + Detach): open an FD from the pin, then, for
+// link types that implement the kernel's bpf_link_ops.detach
+// callback -- XDP, TCX, cgroup, netfilter, netkit, struct_ops,
+// sockmap -- synchronously disconnect the program from its hook.
 // Returns EOPNOTSUPP (wrapped as ebpf.ErrNotSupported) for
 // perf-event / tracing link types (kprobe, uprobe, tracepoint,
-// fentry/fexit), where there is no kernel-side sync detach API.
-// Best-effort: a non-EOPNOTSUPP failure is logged but does not
-// abort cleanup.
+// fentry/fexit), where there is no kernel-side sync detach API;
+// those rely wholly on the invariant above.
 //
-// Stage 2 (Remove): removes the bpffs pin entry. For perf-event
-// link types where Detach() is not supported, this is the step
-// that gets bpf_perf_link_release running synchronously enough
-// for the program to stop firing -- the order Remove-then-Close
-// (rather than the reverse) is load-bearing here.
+// Stage 2 (Remove): removes the bpffs pin entry while the FD is
+// still held.
 //
-// Stage 3 (Close): drops the last user reference to the link
-// FD; the kernel reclaims the link object.
+// Stage 3 (Close): drops what is normally the last reference,
+// tearing the link down synchronously inside close(2).
 //
-// Stage 4 (wait): for Detach-supporting types the program is
-// already provably offline by the time we reach Close. For
-// non-supporting types the kernel releases the link via deferred
-// work and RCU grace periods, and under CPU contention the
-// program keeps firing on its hook well after Close returns.
-// There is no userspace primitive to make that teardown
-// synchronous, so we poll the kernel link ID (bounded) until the
-// object is gone, giving detach the contract callers expect:
-// returned means no longer invoked.
+// Stage 4 (wait): insurance for the one case the invariant does
+// not cover -- an external FD holder (bpftool, an inspection
+// tool) releasing its reference through the deferred put path
+// after our Close. Skipped when stage 1's Detach succeeded (the
+// program is already provably off the hook); otherwise polls the
+// kernel link ID, bounded, until the object is gone.
 func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkPath) error {
 	pin := linkPinPath.String()
 	k.logger.Debug("detaching link by removing pin", "link_pin_path", pin)
 
-	// Stage 1: synchronous kernel-side detach for supported
-	// link types. Prefer the in-process tracked link (saved by
-	// trackLink at attach time) so we don't open a fresh FD;
-	// fall back to LoadPinnedLink when the attach path closed
-	// the original FD after pinning (TCX, XDP, dispatcher
-	// extensions). Either way the resulting *link.Link is
-	// asked to Detach. EOPNOTSUPP comes back for perf-event /
-	// tracing link types where the kernel has no synchronous
+	// Stage 1: open an FD from the pin -- the pin holds the
+	// link's only reference; the daemon keeps no link state --
+	// and attempt the synchronous kernel-side detach for
+	// supported link types. EOPNOTSUPP comes back for perf-event
+	// / tracing link types where the kernel has no synchronous
 	// detach API; those rely on the Remove-then-Close ordering
 	// below.
 	var detachLnk link.Link
-	var detachLnkOpened bool
-	if v, ok := k.liveLinks.Load(pin); ok {
-		detachLnk = v.(link.Link)
-	} else if lnk, err := link.LoadPinnedLink(pin, nil); err == nil {
+	if lnk, err := link.LoadPinnedLink(pin, nil); err == nil {
 		detachLnk = lnk
-		detachLnkOpened = true
 	} else if !errors.Is(err, os.ErrNotExist) {
 		// cilium/ebpf wraps the underlying ENOENT in a string-formatted
 		// error ("load pinned link: no such file or directory"), so the
@@ -232,17 +228,30 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 		// step -- gets logged as a WARN. errors.Is unwraps through fmt's
 		// %w chain and treats both raw PathError and the cilium wrapper
 		// as ENOENT.
-		k.logger.Warn("LoadPinnedLink failed", "link_pin_path", pin, "err", err)
+		//
+		// Any other failure aborts the detach: without an FD we can
+		// neither attempt the kernel-side Detach nor observe the
+		// link's release, so proceeding would remove the pin and
+		// report success while the program may keep running --
+		// exactly the contract violation this function exists to
+		// rule out. The link record survives for a retry.
+		return fmt.Errorf("load pinned link %s: %w", pin, err)
 	}
 	var syncDetached bool
 	var kernelLinkID link.ID
 	if detachLnk != nil {
 		// Capture the kernel link ID while we still hold an FD;
-		// stage 4 needs it to observe the object's release.
+		// stage 4 needs it to observe the object's release. An
+		// Info failure aborts for the same reason a load failure
+		// does: without the ID, stage 4 cannot verify the release
+		// for the async-teardown link types.
 		if info, err := detachLnk.Info(); err == nil {
 			kernelLinkID = info.ID
 		} else {
-			k.logger.Warn("link Info failed before detach wait", "link_pin_path", pin, "err", err)
+			if cerr := detachLnk.Close(); cerr != nil {
+				k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
+			}
+			return fmt.Errorf("link info %s: %w", pin, err)
 		}
 		if err := detachLnk.Detach(); err == nil {
 			syncDetached = true
@@ -250,41 +259,49 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 			k.logger.Warn("link Detach failed", "link_pin_path", pin, "err", err)
 			// continue: cleanup must still happen
 		}
-		if detachLnkOpened {
-			// We opened this FD ourselves; close it. The
-			// tracked-link case (if any) is closed later
-			// via releaseLink.
-			_ = detachLnk.Close()
-		}
+		// The FD is deliberately NOT closed yet: it must be held
+		// across the stage-2 pin removal so the pin's put can
+		// never drop the last reference. Stage 3 closes it.
 	}
 
 	// Stage 2: remove the pin.
 	if err := os.Remove(pin); err != nil {
 		if os.IsNotExist(err) {
 			k.logger.Debug("link pin already gone", "link_pin_path", pin)
-			// Pin gone, but a tracked link may still be live
-			// (in-process attach by the same adapter). Drop it.
-			if cerr := k.releaseLink(pin); cerr != nil {
-				k.logger.Warn("close tracked link after missing pin", "link_pin_path", pin, "err", cerr)
+			if detachLnk != nil {
+				if cerr := detachLnk.Close(); cerr != nil {
+					k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
+				}
 			}
 			if !syncDetached && kernelLinkID != 0 {
 				k.waitKernelLinkGone(ctx, kernelLinkID, pin)
 			}
 			return nil
 		}
+		if detachLnk != nil {
+			if cerr := detachLnk.Close(); cerr != nil {
+				k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
+			}
+		}
 		return fmt.Errorf("remove link pin %s: %w", pin, err)
 	}
 
-	// Stage 3: close the FD via releaseLink (which also drops
-	// the tracking-map entry).
-	if err := k.releaseLink(pin); err != nil {
-		k.logger.Warn("close tracked link", "link_pin_path", pin, "err", err)
+	// Stage 3: close our link FD. This must stay after the
+	// stage-2 pin removal: with the FD held across the pin's put,
+	// only our own close can drop the last reference, and an FD
+	// close tears the link down synchronously inside close(2).
+	if detachLnk != nil {
+		if cerr := detachLnk.Close(); cerr != nil {
+			k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
+		}
 	}
 	k.logger.Debug("link pin removed", "link_pin_path", pin)
-	// Best-effort removal of the parent directory. This races
-	// with concurrent attach in non-daemon mode (no global lock),
-	// but attach calls MkdirAll before pinning, so it recovers
-	// if the directory disappears underneath it.
+	// Best-effort removal of the parent directory. bpfman's own
+	// attach cannot race this -- every mutation, CLI or daemon,
+	// holds the cross-process writer flock -- but the directory
+	// lives on a shared bpffs that out-of-band actors can touch;
+	// attach calls MkdirAll before pinning, so it recovers if the
+	// directory disappears underneath it.
 	os.Remove(filepath.Dir(pin))
 
 	// Stage 4: only the async-teardown types need the wait; a
@@ -332,10 +349,11 @@ func (k *kernelAdapter) waitKernelLinkGone(ctx context.Context, id link.ID, pin 
 }
 
 // pinWithRetry creates the parent directory and invokes pin. If the
-// pin fails because a concurrent detach removed the directory, it
-// retries once. This covers the race between detach (which removes
-// empty link directories) and attach (which creates them) when
-// running outside daemon mode with no global lock.
+// pin fails because the directory vanished underneath it, it retries
+// once. bpfman's own detach cannot race this -- every mutation, CLI
+// or daemon, holds the cross-process writer flock -- but the
+// directory lives on a shared bpffs where an out-of-band removal can
+// strike between MkdirAll and pin.
 //
 // Generic over any string-derived path type (bpfman.LinkPath, plain
 // string, future newtypes) so callers preserve their type discipline

--- a/platform/ebpf/pin.go
+++ b/platform/ebpf/pin.go
@@ -259,8 +259,9 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 			k.logger.Warn("link Detach failed", "link_pin_path", pin, "err", err)
 			// continue: cleanup must still happen
 		}
-		// The FD is deliberately NOT closed yet: it must be held
-		// across the stage-2 pin removal so the pin's put can
+		// The FD is deliberately NOT closed yet: stage 4's
+		// first-probe fast path is sound only if an FD is held
+		// across the stage-2 pin removal, so the pin's put can
 		// never drop the last reference. Stage 3 closes it.
 	}
 
@@ -273,8 +274,12 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 					k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
 				}
 			}
+			// The pin vanished out-of-band, so our Close is not
+			// provably the last reference drop: the external
+			// unlink's put may still be pending. Disable the
+			// first-probe fast path; every ENOENT settles.
 			if !syncDetached && kernelLinkID != 0 {
-				k.waitKernelLinkGone(ctx, kernelLinkID, pin)
+				k.waitKernelLinkGone(ctx, kernelLinkID, pin, false)
 			}
 			return nil
 		}
@@ -289,7 +294,8 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 	// Stage 3: close our link FD. This must stay after the
 	// stage-2 pin removal: with the FD held across the pin's put,
 	// only our own close can drop the last reference, and an FD
-	// close tears the link down synchronously inside close(2).
+	// close tears the link down synchronously inside close(2) --
+	// the invariant behind stage 4's first-probe fast path.
 	if detachLnk != nil {
 		if cerr := detachLnk.Close(); cerr != nil {
 			k.logger.Warn("close loaded link", "link_pin_path", pin, "err", cerr)
@@ -307,44 +313,107 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 	// Stage 4: only the async-teardown types need the wait; a
 	// successful Detach already disconnected the program.
 	if !syncDetached && kernelLinkID != 0 {
-		k.waitKernelLinkGone(ctx, kernelLinkID, pin)
+		k.waitKernelLinkGone(ctx, kernelLinkID, pin, true)
 	}
 	return nil
 }
 
 // waitKernelLinkGone polls until the kernel link object with the
 // given ID has been released, bounded so a wedged reference can
-// never hang teardown. The ID exposes three states: alive (an FD
-// comes back), dying (EAGAIN: the refcount already hit zero but
-// the deferred release has not run -- the program can still fire
-// on its hook), and gone (ENOENT: the ID has left the table).
-// Only the third terminates the wait; treating EAGAIN as gone
-// returns into the very window this wait exists to outlive.
-func (k *kernelAdapter) waitKernelLinkGone(ctx context.Context, id link.ID, pin string) {
-	const deadline = 3 * time.Second
+// never hang teardown.
+//
+// The caller holds the link's FD across the pin removal (DetachLink
+// stages 1-3), so the pin's put can never drop the last reference;
+// only our own Close can, and an FD close frees the link
+// synchronously inside close(2) -- ID removal and the hook detach
+// both complete before Close returns. ENOENT on the first probe
+// therefore means the teardown already happened, and the wait ends
+// at once. ENOENT on any later probe is ambiguous: an external
+// holder may have released the link via a deferred (non-FD) put
+// whose hook detach is still unwinding behind the ID removal, so
+// those paths observe a short settle period before returning.
+//
+// closeWasLastDrop states whether the caller's Close provably
+// performed the last reference drop, which is what makes the
+// first-probe fast path sound. When the pin vanished out-of-band
+// the external unlink's put may still be pending, so the caller
+// passes false and every ENOENT takes the settle path.
+func (k *kernelAdapter) waitKernelLinkGone(ctx context.Context, id link.ID, pin string, closeWasLastDrop bool) {
 	backoff := time.Millisecond
 	start := time.Now()
+	firstProbe := closeWasLastDrop
+	lookupErrLogged := false
+	var goneSince time.Time
 	for {
-		l, err := link.NewFromID(id)
-		if err != nil && !errors.Is(err, unix.EAGAIN) {
-			return
-		}
-		if err == nil {
+		l, err := k.linkWait.newLinkFromID(id)
+		switch {
+		case err == nil:
 			_ = l.Close()
+			goneSince = time.Time{}
+		case errors.Is(err, os.ErrNotExist):
+			if firstProbe {
+				return
+			}
+			if goneSince.IsZero() {
+				goneSince = time.Now()
+			}
+			if time.Since(goneSince) >= k.linkWait.settle {
+				return
+			}
+		case errors.Is(err, unix.EAGAIN):
+			// The ID slot holds a link mid-creation, which for
+			// our ID means it has been recycled by a concurrent
+			// attach -- so our link was already freed by an
+			// external deferred put whose hook detach may still
+			// be unwinding. Not proof of settled teardown; keep
+			// polling.
+			goneSince = time.Time{}
+		default:
+			// Log once per wait: a persistent failure (EMFILE,
+			// EPERM) would otherwise emit a warning every probe
+			// for the full deadline.
+			if !lookupErrLogged {
+				k.logger.Warn("kernel link lookup failed during detach wait", "link_pin_path", pin, "kernel_link_id", id, "err", err)
+				lookupErrLogged = true
+			}
 		}
+		firstProbe = false
 
-		if time.Since(start) >= deadline {
-			k.logger.Warn("kernel link still present after detach wait", "link_pin_path", pin, "kernel_link_id", id, "waited", deadline)
+		if time.Since(start) >= k.linkWait.deadline {
+			if goneSince.IsZero() {
+				k.logger.Warn("kernel link still present after detach wait", "link_pin_path", pin, "kernel_link_id", id, "waited", k.linkWait.deadline)
+			}
 			return
 		}
 		select {
 		case <-ctx.Done():
+			k.logger.Warn("kernel link detach wait cancelled", "link_pin_path", pin, "kernel_link_id", id, "err", ctx.Err())
 			return
 		case <-time.After(backoff):
 		}
-		if backoff < 50*time.Millisecond {
-			backoff *= 2
-		}
+		backoff = min(backoff*2, k.linkWait.maxBackoff)
+	}
+}
+
+type kernelLinkHandle interface {
+	Close() error
+}
+
+// linkWaitParams bounds waitKernelLinkGone. New fills in the
+// defaults; tests construct adapters with faster ones.
+type linkWaitParams struct {
+	newLinkFromID func(id link.ID) (kernelLinkHandle, error)
+	deadline      time.Duration
+	settle        time.Duration
+	maxBackoff    time.Duration
+}
+
+func defaultLinkWaitParams() linkWaitParams {
+	return linkWaitParams{
+		newLinkFromID: func(id link.ID) (kernelLinkHandle, error) { return link.NewFromID(id) },
+		deadline:      3 * time.Second,
+		settle:        100 * time.Millisecond,
+		maxBackoff:    50 * time.Millisecond,
 	}
 }
 

--- a/platform/ebpf/pin.go
+++ b/platform/ebpf/pin.go
@@ -241,6 +241,8 @@ func (k *kernelAdapter) DetachLink(ctx context.Context, linkPinPath bpfman.LinkP
 		// stage 4 needs it to observe the object's release.
 		if info, err := detachLnk.Info(); err == nil {
 			kernelLinkID = info.ID
+		} else {
+			k.logger.Warn("link Info failed before detach wait", "link_pin_path", pin, "err", err)
 		}
 		if err := detachLnk.Detach(); err == nil {
 			syncDetached = true

--- a/platform/ebpf/pin_test.go
+++ b/platform/ebpf/pin_test.go
@@ -1,0 +1,225 @@
+package ebpf
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type noopKernelLinkHandle struct{}
+
+func (noopKernelLinkHandle) Close() error { return nil }
+
+var errNotExist = fmt.Errorf("lookup: %w", os.ErrNotExist)
+
+// newWaitTestAdapter builds an adapter whose kernel-link wait uses the
+// given lookup and test-sized bounds, logging into logs.
+func newWaitTestAdapter(logs *bytes.Buffer, fn func(link.ID) (kernelLinkHandle, error)) *kernelAdapter {
+	return &kernelAdapter{
+		logger: slog.New(slog.NewTextHandler(logs, nil)),
+		linkWait: linkWaitParams{
+			newLinkFromID: fn,
+			deadline:      50 * time.Millisecond,
+			settle:        10 * time.Millisecond,
+			maxBackoff:    time.Millisecond,
+		},
+	}
+}
+
+// A first-probe ENOENT means our own Close dropped the last reference
+// and the kernel freed the link synchronously inside close(2), so the
+// wait must return at once: no settle, no second probe. Uses the
+// production parameters so the asserted latency is the shipped one.
+func TestWaitKernelLinkGoneReturnsOnFirstENOENT(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	k := &kernelAdapter{
+		logger:   slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		linkWait: defaultLinkWaitParams(),
+	}
+	k.linkWait.newLinkFromID = func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		return nil, errNotExist
+	}
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+	elapsed := time.Since(start)
+
+	require.Equal(t, 1, calls, "first-probe ENOENT must end the wait without further probes")
+	require.Less(t, elapsed, k.linkWait.settle, "first-probe ENOENT must not pay the settle period")
+}
+
+// ENOENT after the link has been seen alive is ambiguous: an external
+// holder may have released it via a deferred (non-FD) put whose free
+// is still unwinding behind the ID removal. The settle period must
+// apply on that path.
+func TestWaitKernelLinkGoneSettlesAfterExternalRelease(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	k := newWaitTestAdapter(&bytes.Buffer{}, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		if calls == 1 {
+			return noopKernelLinkHandle{}, nil
+		}
+		return nil, errNotExist
+	})
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.GreaterOrEqual(t, time.Since(start), k.linkWait.settle, "ENOENT after alive must observe the settle period")
+	require.Greater(t, calls, 2, "the settle must keep probing after the alive observation")
+}
+
+// When the pin vanished out-of-band before our removal, our Close is
+// not provably the last reference drop, so even a first-probe ENOENT
+// is ambiguous and must observe the settle period.
+func TestWaitKernelLinkGoneSettlesOnFirstENOENTWhenPinVanished(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	k := newWaitTestAdapter(&bytes.Buffer{}, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		return nil, errNotExist
+	})
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", false)
+
+	require.GreaterOrEqual(t, time.Since(start), k.linkWait.settle, "first-probe ENOENT without the close-was-last-drop proof must observe the settle period")
+	require.Greater(t, calls, 1, "the settle must keep probing")
+}
+
+// ENOENT is only proof of completed teardown on the very first probe,
+// where it means our own Close freed the link synchronously. EAGAIN on
+// the first probe means the ID slot was recycled, so our link was
+// freed by an external deferred put whose hook detach may still be
+// unwinding -- a follow-up ENOENT must observe the settle period, not
+// return instantly.
+func TestWaitKernelLinkGoneSettlesAfterEAGAIN(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	k := newWaitTestAdapter(&bytes.Buffer{}, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("lookup: %w", unix.EAGAIN)
+		}
+		return nil, errNotExist
+	})
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.GreaterOrEqual(t, time.Since(start), k.linkWait.settle, "ENOENT after EAGAIN must observe the settle period")
+	require.Greater(t, calls, 2, "the settle must keep probing after the EAGAIN observation")
+}
+
+// A transient lookup failure on the first probe leaves the link's
+// state unknown, so a follow-up ENOENT is ambiguous in the same way:
+// the settle period must apply.
+func TestWaitKernelLinkGoneSettlesAfterTransientError(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	var logs bytes.Buffer
+	k := newWaitTestAdapter(&logs, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("lookup: %w", unix.EMFILE)
+		}
+		return nil, errNotExist
+	})
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.GreaterOrEqual(t, time.Since(start), k.linkWait.settle, "ENOENT after a transient error must observe the settle period")
+	require.Greater(t, calls, 2, "the settle must keep probing after the transient error")
+}
+
+// Reaching the deadline while the link is already gone and merely
+// settling is success, not a wedged reference: the "still present"
+// warning must not fire.
+func TestWaitKernelLinkGoneNoWarnWhenGoneAtDeadline(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	var logs bytes.Buffer
+	k := newWaitTestAdapter(&logs, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		if calls == 1 {
+			return noopKernelLinkHandle{}, nil
+		}
+		return nil, errNotExist
+	})
+	k.linkWait.settle = 10 * k.linkWait.deadline
+
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.NotContains(t, logs.String(), "kernel link still present after detach wait", "a gone-but-settling link is not still present")
+}
+
+// A link that stays alive means an external reference is pinning it;
+// the wait must hold on until the deadline and then warn.
+func TestWaitKernelLinkGoneWarnsAtDeadlineWhileAlive(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	k := newWaitTestAdapter(&logs, func(link.ID) (kernelLinkHandle, error) {
+		return noopKernelLinkHandle{}, nil
+	})
+
+	start := time.Now()
+	k.waitKernelLinkGone(t.Context(), link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.GreaterOrEqual(t, time.Since(start), k.linkWait.deadline)
+	require.Contains(t, logs.String(), "kernel link still present after detach wait")
+}
+
+func TestWaitKernelLinkGoneKeepsWaitingOnTransientLookupError(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	ctx, cancel := context.WithCancel(t.Context())
+	var logs bytes.Buffer
+	k := newWaitTestAdapter(&logs, func(link.ID) (kernelLinkHandle, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("lookup: %w", unix.EMFILE)
+		}
+		cancel()
+		return noopKernelLinkHandle{}, nil
+	})
+
+	k.waitKernelLinkGone(ctx, link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.Greater(t, calls, 1, "transient lookup errors must not terminate the wait")
+	require.Contains(t, logs.String(), "kernel link lookup failed during detach wait")
+}
+
+func TestWaitKernelLinkGoneLogsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var logs bytes.Buffer
+	k := newWaitTestAdapter(&logs, func(link.ID) (kernelLinkHandle, error) {
+		cancel()
+		return noopKernelLinkHandle{}, nil
+	})
+
+	k.waitKernelLinkGone(ctx, link.ID(42), "/sys/fs/bpf/demo/link", true)
+
+	require.Contains(t, logs.String(), "kernel link detach wait cancelled")
+}

--- a/platform/ebpf/test_dispatcher.go
+++ b/platform/ebpf/test_dispatcher.go
@@ -2,95 +2,63 @@ package ebpf
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/cilium/ebpf"
 
+	"github.com/bpfman/bpfman"
 	"github.com/bpfman/bpfman/dispatcher"
 )
 
-// testDispatchers holds lazily-loaded test dispatchers used as
-// verification targets when loading XDP/TC programs as Extension
-// type. These are minimal dispatchers loaded from the standard
-// bytecode with one slot enabled; they exist purely so the verifier
-// can check the extension's signature at load time. They remain alive
-// for the lifetime of the kernel adapter.
-type testDispatchers struct {
-	mu   sync.Mutex
-	xdp  *ebpf.Program
-	tc   *ebpf.Program
-	xdpC *ebpf.Collection
-	tcC  *ebpf.Collection
-}
-
-// getXDP returns the test XDP dispatcher program, loading it lazily on
-// first call.
-func (td *testDispatchers) getXDP() (*ebpf.Program, error) {
-	td.mu.Lock()
-	defer td.mu.Unlock()
-
-	if td.xdp != nil {
-		return td.xdp, nil
+// loadTestDispatcher loads a minimal one-slot dispatcher of the given
+// kind for use as an extension load's verifier target: loading an
+// XDP/TC program as BPF_PROG_TYPE_EXT needs a target program whose
+// BTF the kernel checks the extension's signature against. It returns
+// the dispatcher program and a close function releasing the whole
+// collection.
+//
+// The caller closes the collection as soon as the extension has
+// loaded. The kernel takes its own reference on the target program
+// (prog->aux->dst_prog) for as long as the extension exists, so the
+// userspace FDs need not outlive the load call -- and must not: a
+// quiescent daemon holds no bpf object FDs, and the gRPC e2e suite
+// asserts exactly that against the daemon's fd table.
+func loadTestDispatcher(programType bpfman.ProgramType) (*ebpf.Program, func(), error) {
+	var (
+		spec     *ebpf.CollectionSpec
+		progName string
+		err      error
+	)
+	switch programType {
+	case bpfman.ProgramTypeXDP:
+		cfg, cfgErr := dispatcher.NewXDPConfig(1)
+		if cfgErr != nil {
+			return nil, nil, fmt.Errorf("create test XDP dispatcher config: %w", cfgErr)
+		}
+		spec, err = dispatcher.LoadXDPDispatcher(cfg)
+		progName = "xdp_dispatcher"
+	case bpfman.ProgramTypeTC:
+		cfg, cfgErr := dispatcher.NewTCConfig(1)
+		if cfgErr != nil {
+			return nil, nil, fmt.Errorf("create test TC dispatcher config: %w", cfgErr)
+		}
+		spec, err = dispatcher.LoadTCDispatcher(cfg)
+		progName = "tc_dispatcher"
+	default:
+		return nil, nil, fmt.Errorf("no test dispatcher for program type %s", programType)
 	}
-
-	cfg, err := dispatcher.NewXDPConfig(1)
 	if err != nil {
-		return nil, fmt.Errorf("create test XDP dispatcher config: %w", err)
-	}
-
-	spec, err := dispatcher.LoadXDPDispatcher(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("load test XDP dispatcher spec: %w", err)
+		return nil, nil, fmt.Errorf("load test dispatcher spec for %s: %w", programType, err)
 	}
 
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return nil, fmt.Errorf("create test XDP dispatcher collection: %w", err)
+		return nil, nil, fmt.Errorf("create test dispatcher collection for %s: %w", programType, err)
 	}
 
-	prog := coll.Programs["xdp_dispatcher"]
+	prog := coll.Programs[progName]
 	if prog == nil {
 		coll.Close()
-		return nil, fmt.Errorf("xdp_dispatcher program not found in test collection")
+		return nil, nil, fmt.Errorf("%s program not found in test dispatcher collection", progName)
 	}
-
-	td.xdpC = coll
-	td.xdp = prog
-	return prog, nil
-}
-
-// getTC returns the test TC dispatcher program, loading it lazily on
-// first call.
-func (td *testDispatchers) getTC() (*ebpf.Program, error) {
-	td.mu.Lock()
-	defer td.mu.Unlock()
-
-	if td.tc != nil {
-		return td.tc, nil
-	}
-
-	cfg, err := dispatcher.NewTCConfig(1)
-	if err != nil {
-		return nil, fmt.Errorf("create test TC dispatcher config: %w", err)
-	}
-
-	spec, err := dispatcher.LoadTCDispatcher(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("load test TC dispatcher spec: %w", err)
-	}
-
-	coll, err := ebpf.NewCollection(spec)
-	if err != nil {
-		return nil, fmt.Errorf("create test TC dispatcher collection: %w", err)
-	}
-
-	prog := coll.Programs["tc_dispatcher"]
-	if prog == nil {
-		coll.Close()
-		return nil, fmt.Errorf("tc_dispatcher program not found in test collection")
-	}
-
-	td.tcC = coll
-	td.tc = prog
-	return prog, nil
+	return prog, func() { coll.Close() }, nil
 }


### PR DESCRIPTION
The daemon kept every probe-style link FD it attached in an in-memory map so detach could close it later. That map was broken: state that could not survive the process holding it, in a daemon whose store and bpffs are supposed to be the truth. Nothing rebuilt it after a restart, so the same link took a different detach route depending on the daemon's uptime history, and the held FDs made the daemon a silent co-owner of every tracked link's liveness, recorded nowhere. This PR removes the map and makes detach's contract -- returned means the kernel link object is gone -- both enforced and observable.

With the map gone, the bpffs pin is a link's only reference in daemon and CLI mode alike: attach closes its FD once the pin exists, and detach always reopens an FD from the pin, holds it across the pin removal, and closes it last. That ordering is what makes teardown synchronous. In the kernel (`kernel/bpf/syscall.c`, verified at v6.6 and v6.18-rc7), an FD close frees the link synchronously inside `close(2)` via `bpf_link_put_direct` -- hook detach included -- while every other reference drop, a pin removal among them, defers the free to a workqueue. Holding our FD across the pin's put means only our own close can drop the last reference, so by the time detach returns the program is off its hook. The old split had two bugs this structure removes: the reopen-from-pin route closed its FD before the pin removal, handing the last drop to the deferred path so a detached program could keep firing briefly after detach returned, and the tracked route could keep a zombie alive -- after an out-of-band unpin, a daemon-held FD left the link attached and firing, invisible to bpfman's own state, until the daemon exited.

Detach now also fails when it cannot honour that contract: a pin that will not open for any reason other than ENOENT, or a failed Info read, aborts the detach with an error rather than warn-and-continue, and the link record survives for a retry. Attach-time link closes log their error rather than discarding it -- on cilium's tracefs fallback path a failed close leaks the kprobe_events/uprobe_events entry with no owner left to reap it.

The post-close wait (`waitKernelLinkGone`) is reworked around the same kernel facts. Its old three-state model was inverted: EAGAIN from `BPF_LINK_GET_FD_BY_ID` means a link mid-creation, not one dying; a dying link reports ENOENT while its free is still pending, and the free removes the link's ID before it detaches the hook, so the old loop could return during exactly the window it was supposed to wait out. The wait now keys on the first probe: ENOENT there means our own close already completed the teardown, and the wait returns at once; any later ENOENT is ambiguous -- an external holder may have released the link through the deferred put, and an earlier EAGAIN or transient error may have masked the state -- and observes a short settle. The caller states whether its close provably performed the last drop, so the branch where the pin vanished out-of-band disables the fast path outright. Transient lookup errors log once per wait, the deadline warning fires only when the link is genuinely still present, the poll backoff respects its cap, and the tuning lives in an injectable `linkWaitParams`.

On the e2e side, the net detach-quiescence probe no longer fails the whole script on a single lost ping: probe failure retries within the poll window, the 0.3s ping timeout fits several attempts where one second fitted at most two, and the retry message carries the ping's exit code and stderr so a broken data path names itself. A new `assert_kernel_link_gone` helper probes, via the `linkinfo` builtin, that the link's kernel ID is no longer openable the instant `bpfman link detach` returns, with preconditions that stop it passing vacuously when no kernel ID was recorded; it is applied once per distinct detach path (the per-kind round-trip scripts and netns variants, one multi-prog wave, one dispatcher lifecycle script -- 17 sites). Its reach is deliberately bounded: script bpfman commands run as short-lived subprocesses, so the probe catches references that outlive the command -- a surviving pin, or a daemon-held FD in a daemon-mode run -- while post-detach firing through the kernel's deferred-release window remains the quiescence polls' domain. The instruments divide the labour accordingly: the polls prove the counter stops moving under stimulus, the delta assertions keep exact attribution while attached, and `linkinfo` guards the reference accounting.

The gRPC e2e suite gains the assertions only a long-lived daemon can support. The script corpus's subprocess model means process exit releases any leaked reference before an assertion can observe it, so reference-lifetime bugs are structurally invisible there; the gRPC suite runs one persistent `bpfman serve` process, where they are not. Three detach-contract tests read the daemon directly: its fd table must hold no bpf link FDs while a link is attached (with a self-check that opens a pin in the test process and requires the matcher to count it, so the zero can never go vacuous); the kernel link ID must be unopenable the instant the Detach RPC returns; and an out-of-band pin removal must release the link rather than leave a zombie. A fourth, end-state check runs on the parallel stress phase's cleanup: once every lifecycle completes, the daemon must hold no bpf object FDs -- programs and maps included -- and manage no programs. Leaks accumulate, so a reference leaked by any of the ~1000 lifecycles, in any interleaving, is still visible when the suite goes quiet, and failures name the held objects via fdinfo.

That end-state check immediately found daemon-held state predating this PR: the adapter cached one test dispatcher per network type as the verifier target for extension loads, so a quiescent daemon carried two dispatcher program FDs and two map FDs for its lifetime. The cache is removed -- the target now loads per extension load and closes when the load returns, the kernel holding its own reference (`prog->aux->dst_prog`) for as long as the extension exists. A quiescent daemon now holds no bpf object FDs at all, which is the invariant the end-state check pins permanently.

One architectural observation worth recording. The reference-persistence bug family -- the liveLinks map, the dispatcher cache, any future leaked FD -- exists only because the daemon is a single long-lived process; the CLI topology is immune by construction, since process exit releases everything. With this PR the daemon holds no state beyond the store and bpffs, so an exec-per-request daemon (the gRPC surface forking the CLI per mutation) becomes a viable simplification that would eliminate the family outright, at the cost of a fork/exec per control-plane operation. It would not remove the need for the detach contract itself -- the synchronous teardown ordering matters identically in a short-lived process -- but it would make leak persistence impossible rather than merely tested-for. Not done here; noted as a direction the now-stateless daemon leaves open.

## Testing

Unit suite green (race detector on) and golangci-lint clean. The full `.bpfman` script corpus passes natively as root against this branch, and the full gRPC suite passes at default scale (1024 lifecycles across eight program types) including the end-state quiescence check. The wait behaviours -- the first-probe fast path with the production constants, the settle after an alive observation, after EAGAIN, after a transient error and on the pin-vanished branch, and the deadline, gone-at-deadline, transient-error and cancellation paths -- are pinned by unit tests driving the loop through injected fakes. The kernel-ordering claims are read directly from `kernel/bpf/syscall.c` at v6.6 and v6.18-rc7.

The new gRPC tests are red/green demonstrated rather than assumed: the while-attached fd scan and the zombie check fail against a daemon built from the pre-change implementation (one bpf_link FD held per attached link; the kernel link still alive three seconds after an out-of-band unpin), the detach-return check fails against a build that leaks the detach FD, and the end-state check fails on both implementations until the dispatcher cache is removed -- the pre-change daemon is otherwise tidy at rest, which is exactly why the while-attached probe exists. The nested-VM job has not been run against this branch and should gate merging.