### PR TITLE
Modernise the examples with go fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1251,8 +1251,7 @@ bpfman-vet: $(DISPATCHER_BPF_EMBEDS)
 # applications are excluded: they stay as their authors wrote them.
 .PHONY: bpfman-gofix
 bpfman-gofix: $(DISPATCHER_BPF_EMBEDS)
-	GOTOOLCHAIN=$(GOFIX_GO_VERSION) go fix -tags 'e2e,bpfman_ns' \
-		$$(go list ./... | grep -v '^github.com/bpfman/bpfman/examples')
+	GOTOOLCHAIN=$(GOFIX_GO_VERSION) go fix -tags 'e2e,bpfman_ns' ./...
 
 # Compile bpfman. Depends on the dispatcher BPF embeds because
 # the dispatcher Go package's go:embed directives need them at

--- a/examples/go-app-counter/kprobe_main.go
+++ b/examples/go-app-counter/kprobe_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-app-counter/main.go
+++ b/examples/go-app-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 
@@ -58,44 +57,30 @@ func main() {
 	// Create a wait group to wait for all goroutines to finish
 	var wg sync.WaitGroup
 
-	// Increment the wait group counter before starting each goroutine
-
 	// Start your goroutines, passing the cancellable context
-	wg.Add(1)
-	go func() {
-		defer wg.Done() // Decrement the wait group counter when the goroutine finishes
+	wg.Go(func() {
 		processKprobe(cancelCtx, &paramData)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		processTracepoint(cancelCtx, &paramData)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		processTc(cancelCtx, &paramData)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		processTcx(cancelCtx, &paramData)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		processUprobe(cancelCtx, &paramData)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		processXdp(cancelCtx, &paramData)
-	}()
+	})
 
 	// Listen for interrupt signal to gracefully shut down the goroutines
 	stop := make(chan os.Signal, 1)

--- a/examples/go-app-counter/tc_main.go
+++ b/examples/go-app-counter/tc_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-app-counter/tcx_main.go
+++ b/examples/go-app-counter/tcx_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-app-counter/tracepoint_main.go
+++ b/examples/go-app-counter/tracepoint_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-app-counter/uprobe_main.go
+++ b/examples/go-app-counter/uprobe_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-app-counter/xdp_main.go
+++ b/examples/go-app-counter/xdp_main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-kprobe-counter/main.go
+++ b/examples/go-kprobe-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-tc-counter/main.go
+++ b/examples/go-tc-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-tcx-counter/main.go
+++ b/examples/go-tcx-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-tracepoint-counter/main.go
+++ b/examples/go-tracepoint-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-uprobe-counter/main.go
+++ b/examples/go-uprobe-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-uretprobe-counter/main.go
+++ b/examples/go-uretprobe-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/examples/go-xdp-counter/main.go
+++ b/examples/go-xdp-counter/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 


### PR DESCRIPTION
The bpfman-gofix target has excluded the example applications since they were absorbed into the root module, with the stated intent of keeping them as their authors wrote them. This PR ends that grace period: the go1.26.4 fix modernisers run over `examples/...`, dropping the legacy `// +build` constraint lines that the `//go:build` form superseded and rewriting `go-app-counter`'s six-goroutine fan-out from the manual `Add`/`Done` pattern to `sync.WaitGroup.Go` (the comment describing the old counter bookkeeping goes with it). The second commit removes the package-list filter from the Makefile target, so the moderniser gate in CI keeps the examples current from here on.

## Testing

`go build ./examples/...` and `go vet ./examples/...` are clean, and re-running the now-inclusive `make bpfman-gofix` produces no further changes, so the CI moderniser gate passes by construction.