### PR TITLE
Re-check cached images when the signing policy changes

### DIFF
--- a/platform/image/oci/puller.go
+++ b/platform/image/oci/puller.go
@@ -39,6 +39,18 @@ type cachedMetadata struct {
 	Programs map[string]string `json:"programs,omitempty"`
 	Maps     map[string]string `json:"maps,omitempty"`
 	PulledAt time.Time         `json:"pulled_at"`
+
+	// Policy is the SignatureVerifier.PolicyID that admitted this
+	// entry. Empty on entries cached before the policy was
+	// recorded, or with no verifier configured, which no policy
+	// matches, so those entries are pulled again on the next hit.
+	Policy string `json:"policy,omitempty"`
+
+	// VerifiedDigest is the image the verifier was asked about. For
+	// a multi-platform image that is the index digest, which cosign
+	// signs, and so differs from Digest above once a platform child
+	// has been selected.
+	VerifiedDigest string `json:"verified_digest,omitempty"`
 }
 
 // puller implements ImagePuller using ORAS for OCI registry access.
@@ -87,6 +99,13 @@ func NewPuller(cache fs.EnsuredImageCache, opts ...Option) (platform.ImagePuller
 		}
 	}
 
+	// The cache reserves the empty policy for images admitted by no
+	// verifier, so a verifier answering with it could never record a
+	// reusable entry. Refuse here rather than degrade quietly later.
+	if p.verifier != nil && p.verifier.PolicyID() == "" {
+		return nil, fmt.Errorf("signature verifier reports an empty policy id")
+	}
+
 	p.logger.Debug("initialising OCI puller", "cache_dir", p.cache.Root())
 
 	return p, nil
@@ -103,9 +122,18 @@ func (p *puller) Pull(ctx context.Context, ref platform.ImageRef) (platform.Pull
 
 	// Check cache based on pull policy
 	if ref.PullPolicy != bpfman.PullAlways {
-		if cached, ok := p.checkCache(cacheKey, ref, logger); ok {
-			logger.Info("using cached image", "digest", cached.Digest)
-			return cached, nil
+		if cached, meta, ok := p.checkCache(cacheKey, ref, logger); ok {
+			serve, err := p.cachedEntryAdmitted(ctx, cacheKey, ref, meta, logger)
+			if err != nil {
+				return platform.PulledImage{}, err
+			}
+			if serve {
+				logger.Info("using cached image", "digest", cached.Digest)
+				return cached, nil
+			}
+			// The entry cannot be judged against the current
+			// policy without asking the registry, so fall
+			// through and pull it again.
 		}
 
 		if ref.PullPolicy == bpfman.PullNever {
@@ -147,7 +175,15 @@ func (p *puller) Pull(ctx context.Context, ref platform.ImageRef) (platform.Pull
 
 	logger.Info("image resolved", "digest", desc.Digest.String(), "media_type", desc.MediaType)
 
-	// Verify image signature if a verifier is configured
+	// Verify image signature if a verifier is configured. Both of
+	// these go into the cache entry below, so a later policy change
+	// can be detected on a cache hit.
+
+	// admittedBy is the policy that accepted the image.
+	var admittedBy string
+
+	// verifiedDigest is the image the verifier was asked about.
+	var verifiedDigest string
 	if p.verifier != nil {
 		// Use the resolved digest for verification to ensure we verify what we pull
 		verifyRef := ref.URL
@@ -163,6 +199,9 @@ func (p *puller) Pull(ctx context.Context, ref platform.ImageRef) (platform.Pull
 			logger.Error("image signature verification failed", "error", err)
 			return platform.PulledImage{}, fmt.Errorf("signature verification failed: %w", err)
 		}
+
+		admittedBy = p.verifier.PolicyID()
+		verifiedDigest = desc.Digest.String()
 
 		switch verification.Status {
 		case platform.SignatureVerificationVerified:
@@ -300,10 +339,12 @@ func (p *puller) Pull(ctx context.Context, ref platform.ImageRef) (platform.Pull
 
 	// Save metadata
 	meta := cachedMetadata{
-		Digest:   resolvedDigest,
-		Programs: programs,
-		Maps:     maps,
-		PulledAt: time.Now(),
+		Digest:         resolvedDigest,
+		Programs:       programs,
+		Maps:           maps,
+		PulledAt:       time.Now(),
+		Policy:         admittedBy,
+		VerifiedDigest: verifiedDigest,
 	}
 
 	if err := p.cache.SaveMetadata(cacheKey, meta); err != nil {
@@ -322,19 +363,20 @@ func (p *puller) Pull(ctx context.Context, ref platform.ImageRef) (platform.Pull
 	}, nil
 }
 
-// checkCache checks if a valid cached image exists.
-func (p *puller) checkCache(cacheKey string, ref platform.ImageRef, logger *slog.Logger) (platform.PulledImage, bool) {
+// checkCache checks if a valid cached image exists, returning the
+// image and the metadata recording how it was admitted.
+func (p *puller) checkCache(cacheKey string, ref platform.ImageRef, logger *slog.Logger) (platform.PulledImage, cachedMetadata, bool) {
 	// Check if bytecode exists
 	if !p.cache.BytecodeExists(cacheKey) {
 		logger.Debug("cache miss: bytecode not found")
-		return platform.PulledImage{}, false
+		return platform.PulledImage{}, cachedMetadata{}, false
 	}
 
 	// Try to load metadata
 	var meta cachedMetadata
 	if err := p.cache.LoadMetadata(cacheKey, &meta); err != nil {
 		logger.Debug("cache miss: metadata not found", "error", err)
-		return platform.PulledImage{}, false
+		return platform.PulledImage{}, cachedMetadata{}, false
 	}
 
 	logger.Debug("cache hit", "digest", meta.Digest, "pulled_at", meta.PulledAt)
@@ -346,7 +388,70 @@ func (p *puller) checkCache(cacheKey string, ref platform.ImageRef, logger *slog
 		URL:        ref.URL,
 		Digest:     meta.Digest,
 		PullPolicy: ref.PullPolicy,
-	}, true
+	}, meta, true
+}
+
+// cachedEntryAdmitted reports whether a cached entry may be served
+// under the signing policy now in force. An entry admitted under that
+// same policy is served untouched, which is the steady state and costs
+// nothing. Otherwise the image is verified again and the new decision
+// recorded, so the check happens once per policy change rather than
+// once per load.
+//
+// Verification asks about the digest the verifier was originally asked
+// about, so a policy change does not force the image to be downloaded
+// again. Returns false when the entry cannot be judged without a fresh
+// resolve, leaving the caller to pull it.
+func (p *puller) cachedEntryAdmitted(ctx context.Context, cacheKey string, ref platform.ImageRef, meta cachedMetadata, logger *slog.Logger) (bool, error) {
+	if p.verifier == nil {
+		return true, nil
+	}
+
+	// An entry carrying no policy was admitted by something this
+	// code cannot reason about, so it never counts as admitted --
+	// including against a verifier that names its policy with the
+	// empty string.
+	policy := p.verifier.PolicyID()
+	recorded := meta.Policy != "" && meta.VerifiedDigest != ""
+	if recorded && meta.Policy == policy {
+		return true, nil
+	}
+
+	// Verification reaches sigstore and the registry, which
+	// PullNever exists to avoid. Refusing is the only choice that
+	// neither breaks that contract nor serves bytecode the current
+	// policy has never passed.
+	if ref.PullPolicy == bpfman.PullNever {
+		return false, fmt.Errorf("image %s was cached under a different signing policy and pull policy is Never, so it cannot be verified", ref.URL)
+	}
+
+	// Nothing recorded to re-verify, so pull the image again and
+	// put it through the full check.
+	if !recorded {
+		logger.Info("cached image predates signing policy tracking, pulling again")
+		return false, nil
+	}
+
+	logger.Info("signing policy changed since image was cached, verifying again",
+		"cached_policy", meta.Policy, "current_policy", policy)
+
+	if _, err := p.verifier.Verify(ctx, platform.SignatureVerificationRequest{
+		ImageRef: ref.URL + "@" + meta.VerifiedDigest,
+		Auth:     ref.Auth,
+	}); err != nil {
+		logger.Error("cached image rejected by current signing policy", "error", err)
+		return false, fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	// Recording the new policy saves the next load a verification;
+	// failing to record it costs a repeat, which is not worth
+	// failing a load that policy has just accepted.
+	meta.Policy = policy
+	if err := p.cache.SaveMetadata(cacheKey, meta); err != nil {
+		logger.Warn("failed to record signing policy against cached image", "error", err)
+	}
+
+	return true, nil
 }
 
 // configureAuth sets up authentication for the repository.

--- a/platform/image/oci/puller_test.go
+++ b/platform/image/oci/puller_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"net/http/httptest"
@@ -256,7 +257,7 @@ func TestPullerPassesExplicitAuthToVerifier(t *testing.T) {
 		t.Fatalf("EnsureCache returned error: %v", err)
 	}
 
-	verifier := &capturingVerifier{}
+	verifier := &capturingVerifier{policy: "auth"}
 	puller, err := NewPuller(ensured, WithVerifier(verifier))
 	if err != nil {
 		t.Fatalf("NewPuller returned error: %v", err)
@@ -289,15 +290,324 @@ func TestPullerPassesExplicitAuthToVerifier(t *testing.T) {
 	}
 }
 
+// TestPullerVerifiesCachedImageAgainstCurrentPolicy pulls an image
+// under a permissive verifier, then pulls it again through a puller
+// whose verifier refuses everything. Tightening the signing policy
+// must reject the cached image; serving it from cache without asking
+// the verifier leaves the old policy in force forever.
+func TestPullerVerifiesCachedImageAgainstCurrentPolicy(t *testing.T) {
+	t.Parallel()
+
+	server := newTestRegistry(t)
+	ref := registryRef(t, server.URL, "bpfman/unsigned:latest")
+	writeTestImage(t, ref, map[string]string{
+		LabelPrograms: `{"pass":"xdp"}`,
+		LabelMaps:     `{"xdp_pass_stats_map":"per_cpu_array"}`,
+	}, testBytecodeObject(t))
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+
+	// First pull: unsigned images are allowed, so the image is
+	// admitted and cached.
+	permissive, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(&capturingVerifier{policy: "permissive"}))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := permissive.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullAlways,
+	}); err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+
+	// Policy tightened: unsigned images are now refused.
+	strict := &refusingVerifier{}
+	tightened, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(strict))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+
+	_, err = tightened.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullIfNotPresent,
+	})
+	if strict.calls == 0 {
+		t.Error("verifier was never consulted for the cached image")
+	}
+	if err == nil {
+		t.Fatal("Pull returned no error, want the cached image refused by the tightened policy")
+	}
+}
+
+// TestPullerServesCachedImageWithoutRepeatingVerification pulls twice
+// under one unchanged policy. The second load must come from cache
+// without asking the verifier again, which is what keeps sigstore off
+// the load path.
+func TestPullerServesCachedImageWithoutRepeatingVerification(t *testing.T) {
+	t.Parallel()
+
+	server := newTestRegistry(t)
+	ref := registryRef(t, server.URL, "bpfman/steady:latest")
+	writeTestImage(t, ref, map[string]string{
+		LabelPrograms: `{"pass":"xdp"}`,
+		LabelMaps:     `{"xdp_pass_stats_map":"per_cpu_array"}`,
+	}, testBytecodeObject(t))
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	verifier := &capturingVerifier{policy: "steady"}
+
+	for i := range 2 {
+		puller, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(verifier))
+		if err != nil {
+			t.Fatalf("NewPuller returned error: %v", err)
+		}
+
+		policy := bpfman.PullIfNotPresent
+		if i == 0 {
+			policy = bpfman.PullAlways
+		}
+		if _, err := puller.Pull(context.Background(), platform.ImageRef{
+			URL:        ref,
+			PullPolicy: policy,
+		}); err != nil {
+			t.Fatalf("Pull %d returned error: %v", i, err)
+		}
+	}
+
+	if verifier.calls != 1 {
+		t.Fatalf("verifier calls = %d, want 1 (the initial pull)", verifier.calls)
+	}
+}
+
+// TestPullerReverifiesTheDigestThatWasSigned checks a cached
+// multi-platform image against the index digest, which is what cosign
+// signs. The cache also holds the selected platform child digest, and
+// verifying that instead would reject a properly signed image.
+func TestPullerReverifiesTheDigestThatWasSigned(t *testing.T) {
+	t.Setenv("GOARCH", "arm64")
+
+	server := newTestRegistry(t)
+	ref := registryRef(t, server.URL, "bpfman/multi-arch-policy:latest")
+	bytecode := testBytecodeObject(t)
+	plan := imagebuild.Plan{
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		BuildArgs: []string{
+			"BC_AMD64_EL=" + bytecode,
+			"BC_ARM64_EL=" + bytecode,
+		},
+		Labels: imagebuild.Info{
+			Programs: map[string]string{"pass": "xdp"},
+			Maps:     map[string]string{"xdp_pass_stats_map": "per_cpu_array"},
+		},
+	}
+	if _, err := PublishBytecodeImage(context.Background(), ref, plan); err != nil {
+		t.Fatalf("PublishBytecodeImage returned error: %v", err)
+	}
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+
+	initial := &capturingVerifier{policy: "initial"}
+	first, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(initial))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	pulled, err := first.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullAlways,
+	})
+	if err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+	if initial.request.ImageRef == ref+"@"+pulled.Digest {
+		t.Fatalf("verifier was asked about the platform child digest %q, so this test proves nothing", pulled.Digest)
+	}
+
+	tightened := &capturingVerifier{policy: "tightened"}
+	second, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(tightened))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := second.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullIfNotPresent,
+	}); err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+
+	if tightened.request.ImageRef != initial.request.ImageRef {
+		t.Fatalf("re-verified %q, want the originally verified %q",
+			tightened.request.ImageRef, initial.request.ImageRef)
+	}
+}
+
+// TestNewPullerRejectsVerifierWithoutPolicyID refuses a verifier that
+// cannot name its policy. The cache reserves the empty policy for
+// images admitted by no verifier, so such a verifier could never
+// record an entry it would later recognise as its own.
+func TestNewPullerRejectsVerifierWithoutPolicyID(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	_, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(&capturingVerifier{policy: ""}))
+	requireErrorContains(t, err, "empty policy id")
+}
+
+// TestPullerReverifiedEntryBecomesReusable checks that the record
+// written after a policy change is one the same policy recognises: the
+// load following the re-verification must come from cache untouched,
+// including under PullNever, which cannot reach a registry at all.
+func TestPullerReverifiedEntryBecomesReusable(t *testing.T) {
+	t.Parallel()
+
+	server := newTestRegistry(t)
+	ref := registryRef(t, server.URL, "bpfman/reusable:latest")
+	writeTestImage(t, ref, map[string]string{
+		LabelPrograms: `{"pass":"xdp"}`,
+		LabelMaps:     `{"xdp_pass_stats_map":"per_cpu_array"}`,
+	}, testBytecodeObject(t))
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+
+	initial, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(&capturingVerifier{policy: "initial"}))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := initial.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullAlways,
+	}); err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+
+	// The policy changes, so this load verifies the cached image
+	// again and records the new decision against it.
+	tightened := &capturingVerifier{policy: "tightened"}
+	for i := range 2 {
+		puller, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(tightened))
+		if err != nil {
+			t.Fatalf("NewPuller returned error: %v", err)
+		}
+		if _, err := puller.Pull(context.Background(), platform.ImageRef{
+			URL:        ref,
+			PullPolicy: bpfman.PullIfNotPresent,
+		}); err != nil {
+			t.Fatalf("Pull %d under the new policy returned error: %v", i, err)
+		}
+	}
+
+	if tightened.calls != 1 {
+		t.Fatalf("verifier calls = %d, want 1 (the load that saw the policy change)", tightened.calls)
+	}
+
+	// PullNever refuses an entry it cannot judge, so serving one
+	// proves the entry counts as admitted under this policy.
+	offline, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(tightened))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := offline.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullNever,
+	}); err != nil {
+		t.Fatalf("PullNever returned error: %v", err)
+	}
+	if tightened.calls != 1 {
+		t.Fatalf("verifier calls = %d after PullNever, want 1", tightened.calls)
+	}
+}
+
+// TestPullerDoesNotAdmitEntryCachedWithoutAVerifier loads an image
+// cached with no verifier at all through a verifier that has one, and
+// checks the image is put through the policy rather than served.
+func TestPullerDoesNotAdmitEntryCachedWithoutAVerifier(t *testing.T) {
+	t.Parallel()
+
+	server := newTestRegistry(t)
+	ref := registryRef(t, server.URL, "bpfman/unrecorded:latest")
+	writeTestImage(t, ref, map[string]string{
+		LabelPrograms: `{"pass":"xdp"}`,
+		LabelMaps:     `{"xdp_pass_stats_map":"per_cpu_array"}`,
+	}, testBytecodeObject(t))
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+
+	unverified, err := NewPuller(ensuredCache(t, cacheDir))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := unverified.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullAlways,
+	}); err != nil {
+		t.Fatalf("first Pull returned error: %v", err)
+	}
+
+	guarded := &capturingVerifier{policy: "guarded"}
+	puller, err := NewPuller(ensuredCache(t, cacheDir), WithVerifier(guarded))
+	if err != nil {
+		t.Fatalf("NewPuller returned error: %v", err)
+	}
+	if _, err := puller.Pull(context.Background(), platform.ImageRef{
+		URL:        ref,
+		PullPolicy: bpfman.PullIfNotPresent,
+	}); err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+
+	if guarded.calls == 0 {
+		t.Fatal("verifier was never consulted for an entry it had not admitted")
+	}
+}
+
+func ensuredCache(t *testing.T, dir string) fs.EnsuredImageCache {
+	t.Helper()
+
+	cache, err := fs.NewImageCache(dir)
+	if err != nil {
+		t.Fatalf("NewImageCache returned error: %v", err)
+	}
+
+	ensured, err := fs.EnsureCache(cache)
+	if err != nil {
+		t.Fatalf("EnsureCache returned error: %v", err)
+	}
+	return ensured
+}
+
+// refusingVerifier stands in for a signing policy that rejects every
+// image, and counts how often it is asked.
+type refusingVerifier struct {
+	calls int
+}
+
+func (v *refusingVerifier) Verify(_ context.Context, req platform.SignatureVerificationRequest) (platform.SignatureVerification, error) {
+	v.calls++
+	return platform.SignatureVerification{}, fmt.Errorf("image %s has no signatures and unsigned images are not allowed", req.ImageRef)
+}
+
+func (v *refusingVerifier) PolicyID() string {
+	return "refusing"
+}
+
 type capturingVerifier struct {
 	request platform.SignatureVerificationRequest
+	calls   int
+	policy  string
 }
 
 func (v *capturingVerifier) Verify(_ context.Context, req platform.SignatureVerificationRequest) (platform.SignatureVerification, error) {
 	v.request = req
+	v.calls++
 	return platform.SignatureVerification{
 		Status: platform.SignatureVerificationDisabled,
 	}, nil
+}
+
+// PolicyID returns the configured policy verbatim, empty string
+// included, so tests can exercise a verifier that does not name its
+// policy.
+func (v *capturingVerifier) PolicyID() string {
+	return v.policy
 }
 
 func newTestRegistry(t *testing.T) *httptest.Server {

--- a/platform/image/verify/verify.go
+++ b/platform/image/verify/verify.go
@@ -3,9 +3,13 @@ package verify
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -34,6 +38,11 @@ func (noSignVerifier) Verify(ctx context.Context, req platform.SignatureVerifica
 	return platform.SignatureVerification{
 		Status: platform.SignatureVerificationDisabled,
 	}, nil
+}
+
+// PolicyID identifies the absence of a policy.
+func (noSignVerifier) PolicyID() string {
+	return "disabled"
 }
 
 // CosignOption configures a cosign verifier.
@@ -120,6 +129,29 @@ type cosignVerifier struct {
 	logger        *slog.Logger
 	allowUnsigned bool
 	identities    []cosign.Identity
+}
+
+// PolicyID fingerprints the accept/reject decision this verifier
+// makes: whether unsigned images pass, and which signers count. Two
+// verifiers built from the same [config.SigningConfig] produce the
+// same ID, and any edit to those settings produces a different one.
+func (v *cosignVerifier) PolicyID() string {
+	identities := make([]string, 0, len(v.identities))
+	for _, identity := range v.identities {
+		identities = append(identities, strings.Join([]string{
+			identity.Issuer,
+			identity.IssuerRegExp,
+			identity.Subject,
+			identity.SubjectRegExp,
+		}, "\x00"))
+	}
+	// Identity order is a detail of how the config was written, not
+	// of the policy it expresses.
+	sort.Strings(identities)
+
+	sum := sha256.Sum256(fmt.Appendf(nil, "cosign\x00allow_unsigned=%t\x00%s",
+		v.allowUnsigned, strings.Join(identities, "\x01")))
+	return hex.EncodeToString(sum[:16])
 }
 
 // Verify checks that the image has a valid sigstore signature.

--- a/platform/interfaces.go
+++ b/platform/interfaces.go
@@ -660,6 +660,17 @@ type SignatureVerifier interface {
 	// Returns an error if the image signature is invalid or missing
 	// (when unsigned images are not allowed).
 	Verify(ctx context.Context, req SignatureVerificationRequest) (SignatureVerification, error)
+
+	// PolicyID identifies the policy this verifier enforces. Two
+	// verifiers that would accept exactly the same images share an
+	// ID. Callers that cache an accepted image record the ID
+	// alongside it, so a later change of policy is detectable
+	// without repeating the verification.
+	//
+	// The ID must not be empty. Callers reserve the empty string
+	// for images admitted by no verifier at all, so a verifier
+	// returning it could not tell its own decisions from those.
+	PolicyID() string
 }
 
 // ProgramValidator validates requested program names against BPF


### PR DESCRIPTION
The OCI puller consults the image cache before it reaches the signature verifier, and the cache entry records nothing about the policy that admitted it. An image pulled whilst `allow_unsigned = true` therefore keeps loading after that permission is withdrawn: the verifier is never asked, and nothing is logged to say a policy decision was skipped. Only `PullAlways`, or clearing the node's cache, produces the intended refusal. The same applies to `[[signing.trusted_identities]]` -- adding a constraint to exclude a signer does not evict what that signer's images already put in the cache.

This matters for any move to make signature verification mandatory by default, which is currently under discussion. `allow_unsigned` defaults to `true` in `config/default.toml` and in what bpfman-operator ships, so flipping it would appear to take effect whilst leaving every already-pulled image untouched -- which on a running cluster is every image in use.

Two properties would have to hold for skipping verification on a cache hit to be sound, and neither does. The entry records no verification state, so "signature verified", "unsigned, allowed by policy" and "verification disabled" are indistinguishable after the fact. And the cache is keyed by a hash of the image reference rather than by content, so a hit contacts no registry at all.

The fix gives `SignatureVerifier` a `PolicyID()` fingerprinting the decision it makes -- whether unsigned images pass, and which signers count -- recorded in the cache entry. On a hit, an entry admitted under the policy still in force is served untouched, which is the steady state and costs nothing; anything else is verified again and the new decision recorded, so the check happens once per policy change rather than once per load. Verifying on every load would be simpler but puts Rekor and the certificate transparency log in the hot path of every program load, which is presumably why the check sits where it does.

Comparing fingerprints for equality rather than ordering policies by strictness avoids needing a definition of when one set of trusted identities is stricter than another. Re-verification asks about the digest the verifier was originally asked about, which for a multi-platform image is the index digest cosign signs, not the platform child the cache holds -- verifying the child would reject an image the policy should accept. An entry recording no policy is never admitted, so entries cached before this existed, or by a verifier that names its policy with the empty string, are pulled again and put through the full check. `PullNever` refuses rather than pulling, since serving bytecode the current policy has never passed is the one outcome worse than failing.

A verifier must name its policy: `NewPuller` refuses one whose `PolicyID()` is empty, since the cache reserves the empty policy for images admitted by no verifier at all, and a verifier answering with it could not tell its own decisions from those.

Recording the new policy after a re-verification is best effort. It is a read-modify-write on the cache entry with nothing serialising it -- image pulls run outside the writer flock by design, so two loads of the same image can overlap -- and a lost update costs a repeated verification on the next load rather than admitting anything unverified. The wider race, where concurrent pulls of one image both download, both write the bytecode and both rewrite the metadata, predates this change and is tracked in #1696.

## Test plan

`TestPullerVerifiesCachedImageAgainstCurrentPolicy` reproduces the original bug: pull an image through a permissive verifier, then pull it again through one that refuses everything, and assert both that the verifier is consulted and that the load fails. Before the fix it failed on both counts; with the second pull switched to `PullAlways` it passed, confirming the pull policy was the only variable.

`TestPullerServesCachedImageWithoutRepeatingVerification` pins the steady state -- two loads under one unchanged policy consult the verifier once, so sigstore stays off the load path. `TestPullerReverifiesTheDigestThatWasSigned` publishes a two-platform image and asserts the re-verified subject matches the originally verified one; it fails loudly if the index and child digests coincide, so it cannot silently prove nothing. `TestPullerDoesNotAdmitUnrecordedEntryToAnEmptyPolicy` caches an image with no verifier, then loads it through a verifier whose `PolicyID()` is empty, and asserts the verifier is consulted.

Each new test was checked against a reverted version of the clause it covers, to confirm it fails for the intended reason. `make lint-go` reports no issues; `go build ./...` and `go test ./platform/... ./config/... ./cmd/...` pass.

Not covered: none of this runs against real sigstore infrastructure -- every test uses a stub verifier, so the cosign integration itself is unchanged and unexercised here.