### PR TITLE
Expose the image subcommand in root help

### DIFF
--- a/cmd/bpfman/cli.go
+++ b/cmd/bpfman/cli.go
@@ -46,9 +46,9 @@ type CLI struct {
 	// subcommands.
 	Dispatcher DispatcherCmd `cmd:"" hidden:"" group:"resources" help:"Manage dispatchers."`
 
-	// Image groups the OCI image subcommands (build, inspect, verify
-	// signatures).
-	Image ImageCmd `cmd:"" hidden:"" group:"infra" help:"Image operations (verify signatures)."`
+	// Image groups the OCI image subcommands (build,
+	// generate-build-args, inspect, verify).
+	Image ImageCmd `cmd:"" group:"infra" help:"Manage OCI images containing BPF bytecode."`
 
 	// Serve starts the gRPC daemon.
 	Serve ServeCmd `cmd:"" hidden:"" group:"infra" help:"Start the gRPC daemon."`

--- a/cmd/bpfman/cli_test.go
+++ b/cmd/bpfman/cli_test.go
@@ -157,6 +157,10 @@ func TestRootHelpShowsOnlyPublicLifecycleCommands(t *testing.T) {
 		"link detach",
 		"link get",
 		"link list",
+		"image build",
+		"image generate-build-args",
+		"image inspect",
+		"image verify",
 		"version",
 	} {
 		if !strings.Contains(help, want) {
@@ -169,10 +173,6 @@ func TestRootHelpShowsOnlyPublicLifecycleCommands(t *testing.T) {
 		"link delete",
 		"dispatcher list",
 		"dispatcher get",
-		"image build",
-		"image generate-build-args",
-		"image inspect",
-		"image verify",
 		"serve",
 	} {
 		if strings.Contains(help, hidden) {


### PR DESCRIPTION
The image group (build, generate-build-args, inspect, verify) was hidden from root help, but these are user-facing commands, not internal plumbing. This drops the hidden tag so they appear alongside the other public verbs.

The old help text, "Image operations (verify signatures)", described only one of the four subcommands; it now reads "Manage OCI images containing BPF bytecode" to match the style of the other groups. The root help test now expects the image commands in the public list rather than the hidden one.