### PR TITLE
Fix xtask protobuf build for tonic-build 0.13

### DIFF
--- a/xtask/src/protobuf.rs
+++ b/xtask/src/protobuf.rs
@@ -22,7 +22,7 @@ fn build_bpfman(_opts: &Options) -> anyhow::Result<()> {
     let includes = &[proto_dir.to_str().unwrap()];
     tonic_build::configure()
         .out_dir(out_dir)
-        .compile(protos, includes)?;
+        .compile_protos(protos, includes)?;
 
     // protoc -I=./bpfman/proto --go_out=paths=source_relative:./clients/gobpfman ./bpfman/proto/bpfman.proto
     let status = Command::new("protoc")
@@ -59,6 +59,6 @@ fn build_csi(_opts: &Options) -> anyhow::Result<()> {
 
     tonic_build::configure()
         .out_dir(out_dir)
-        .compile(protos, includes)?;
+        .compile_protos(protos, includes)?;
     Ok(())
 }


### PR DESCRIPTION
The bpfman-image-build workflow has failed on every push to main since the dependabot production-dependencies bump merged in #1692. That bump took tonic-build from 0.11 to 0.13, which renamed `Builder::compile` to `Builder::compile_protos`, so the eBPF bytecode image jobs (`Build eBPF Image (xdp_pass)` and `(xdp_pass_private)`) fail to compile the xtask before they get anywhere:

```
error[E0599]: no method named `compile` found for struct `tonic_build::Builder`
  --> xtask/src/protobuf.rs:25:10
```

This updates both call sites in `xtask/src/protobuf.rs` to `compile_protos`. Nothing else changes; the generated output is the same.

The bump slipped through because the workflow's `pull_request` paths filter does not include `xtask/**` or the Cargo manifests, so the dependabot PR never exercised the xtask build -- it only surfaced on the push to main. Widening that filter is worth a separate change.

## Test plan

`cargo check -p xtask` compiles cleanly against the locked tonic-build 0.13.1, which is exactly where CI fails today. The workflow also has a `workflow_dispatch` trigger, so it can be run against this branch to watch the `Build rust wrapped eBPF` step pass; that step runs before any registry login, so it needs no credentials.