### PR TITLE
Fix image signature verification for cosign v3

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -156,20 +156,17 @@ jobs:
         # provider, that the signing identity is this workflow on
         # this repository, and that the signature was made by the
         # current commit rather than a prior run's stale signature
-        # on the floating :latest tag.
+        # on the floating :latest tag. The commit assertion uses
+        # cosign's own certificate flag because cosign v3 no
+        # longer emits the optional claims in its verify output.
         run: |
           set -euo pipefail
           cosign verify "$BPFMAN_IMG" \
             --certificate-identity-regexp 'https://github\.com/${{ github.repository }}/\.github/workflows/image-build\.yml@.*' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            > "${RUNNER_TEMP}/cosign-verify.json"
-          actual_sha=$(jq -r '.[0].optional.githubWorkflowSha' "${RUNNER_TEMP}/cosign-verify.json")
-          if [ "${actual_sha}" != "${{ github.sha }}" ]; then
-            echo "FAIL: signature is from sha=${actual_sha}, expected ${{ github.sha }}" >&2
-            jq '.[0].optional' "${RUNNER_TEMP}/cosign-verify.json" >&2
-            exit 1
-          fi
-          echo "Signature verified: githubWorkflowSha=${actual_sha}"
+            --certificate-github-workflow-sha "${{ github.sha }}" \
+            > /dev/null
+          echo "Signature verified: githubWorkflowSha=${{ github.sha }}"
 
       - name: Verify cosign signature via binary's embedded attestation
         # Self-consistency check between the attestation the binary
@@ -179,18 +176,9 @@ jobs:
         # above would pass.
         run: |
           set -euo pipefail
-          docker run --rm -e BPFMAN_MODE= "$BPFMAN_IMG" version \
-            | grep ^Attestation: \
-            | sed 's/^Attestation: *//' \
-            | sh \
-            > "${RUNNER_TEMP}/embedded-verify.json"
-          actual_sha=$(jq -r '.[0].optional.githubWorkflowSha' "${RUNNER_TEMP}/embedded-verify.json")
-          if [ "${actual_sha}" != "${{ github.sha }}" ]; then
-            echo "FAIL: embedded-attestation verify returned sha=${actual_sha}, expected ${{ github.sha }}" >&2
-            jq '.[0].optional' "${RUNNER_TEMP}/embedded-verify.json" >&2
-            exit 1
-          fi
-          echo "Embedded attestation verified: githubWorkflowSha=${actual_sha}"
+          attest_cmd=$(docker run --rm -e BPFMAN_MODE= "$BPFMAN_IMG" version | grep ^Attestation: | sed 's/^Attestation: *//')
+          sh -c "${attest_cmd} --certificate-github-workflow-sha ${{ github.sha }}" > /dev/null
+          echo "Embedded attestation verified: githubWorkflowSha=${{ github.sha }}"
 
   # Build all the userspace example images and push them to the registry.
   build-and-push-userspace-images:


### PR DESCRIPTION
The `Verify bpfman image (amd64/arm64)` jobs in bpfman-image-build have failed on every push to main since 2026-07-13, when the dependabot actions group bump (`70be2ab5f`) moved `sigstore/cosign-installer` from v3.8.2 to v4.1.2, switching the installed cosign from v2.x to v3.0.6. Cosign v3 no longer emits the optional claims in its verify JSON output, so the jobs' jq extraction of `.[0].optional.githubWorkflowSha` returns `null` and the sha comparison fails with `FAIL: signature is from sha=null`. The signature verification itself still passes; only the output inspection broke.

This replaces the jq post-processing with cosign's own `--certificate-github-workflow-sha` flag, so the current-commit assertion happens inside signature verification rather than by parsing output. The embedded-attestation step gets the same treatment: the `cosign verify` command line the binary prints is captured and the flag appended before execution. Net effect is the same guarantee as before (fresh signature from this run's commit, not a stale one on the floating `:latest` tag) with less machinery.

## Test plan

Verified locally with cosign v3.0.6, the exact version cosign-installer v4.1.2 installs, against the live `quay.io/bpfman/bpfman:latest`: the direct-verify shape passes with the current signing commit (`5e8d3a892`) and fails with a bogus sha; the embedded-attestation shape, using the genuine `Attestation:` command extracted from the published binary's `version` output, likewise passes with the correct sha and fails with a wrong one. yamllint passes on the edited workflow. The verify jobs only run against an image freshly pushed with real registry credentials, so a fork dispatch cannot exercise them end to end; the first push to main after merge is the final confirmation.